### PR TITLE
Add E2E Sanity Test For Net

### DIFF
--- a/test/metric/metric_value_query.go
+++ b/test/metric/metric_value_query.go
@@ -23,6 +23,7 @@ var metricValueFetchers = []MetricValueFetcher{
 	&MemMetricValueFetcher{},
 	&ProcStatMetricValueFetcher{},
 	&DiskIOMetricValueFetcher{},
+	&NetMetricValueFetcher{},
 }
 
 func GetMetricFetcher(metricName string) (MetricValueFetcher, error) {

--- a/test/metric/net.go
+++ b/test/metric/net.go
@@ -53,7 +53,7 @@ func (f *NetMetricValueFetcher) getMetricSpecificDimensions() []types.Dimension 
 	return []types.Dimension{
 		{
 			Name:  aws.String("interface"),
-			Value: aws.String("eth0"),
+			Value: aws.String("docker0"),
 		},
 	}
 }

--- a/test/metric/net.go
+++ b/test/metric/net.go
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build linux && integration
+// +build linux,integration
+
+package metric
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+)
+
+type NetMetricValueFetcher struct {
+	baseMetricValueFetcher
+}
+
+var _ MetricValueFetcher = (*NetMetricValueFetcher)(nil)
+
+func (f *NetMetricValueFetcher) Fetch(namespace, metricName string, stat Statistics) (MetricValues, error) {
+	dims := f.getMetricSpecificDimensions()
+	values, err := f.fetch(namespace, metricName, dims, stat)
+	if err != nil {
+		log.Printf("Error while fetching metric value for %s: %v", metricName, err)
+	}
+	return values, err
+}
+
+func (f *NetMetricValueFetcher) isApplicable(metricName string) bool {
+	diskIOSupportedMetric := f.getPluginSupportedMetric()
+	_, exists := diskIOSupportedMetric[metricName]
+	return exists
+}
+
+func (f *NetMetricValueFetcher) getPluginSupportedMetric() map[string]struct{} {
+	// Net Supported Metrics
+	// https://github.com/aws/amazon-cloudwatch-agent/blob/6451e8b913bcf9892f2cead08e335c913c690e6d/translator/translate/metrics/config/registered_metrics.go#L15
+	return map[string]struct{}{
+		"net_bytes_sent":   {},
+		"net_bytes_recv":   {},
+		"net_drop_in":      {},
+		"net_drop_out":     {},
+		"net_err_in":       {},
+		"net_err_out":      {},
+		"net_packets_sent": {},
+		"net_packets_recv": {},
+	}
+}
+
+func (f *NetMetricValueFetcher) getMetricSpecificDimensions() []types.Dimension {
+	return []types.Dimension{
+		{
+			Name:  aws.String("name"),
+			Value: aws.String("nvme0n1"),
+		},
+	}
+}

--- a/test/metric/net.go
+++ b/test/metric/net.go
@@ -52,8 +52,8 @@ func (f *NetMetricValueFetcher) getPluginSupportedMetric() map[string]struct{} {
 func (f *NetMetricValueFetcher) getMetricSpecificDimensions() []types.Dimension {
 	return []types.Dimension{
 		{
-			Name:  aws.String("name"),
-			Value: aws.String("nvme0n1"),
+			Name:  aws.String("interface"),
+			Value: aws.String("eth0"),
 		},
 	}
 }

--- a/test/metric/query-json.json
+++ b/test/metric/query-json.json
@@ -10,7 +10,7 @@
             {
               "Name": "InstanceId",
               "Value": "i-X"
-            },
+            }
           ]
         },
         "Period": 60,

--- a/test/metric_value_benchmark/agent_configs/net_config.json
+++ b/test/metric_value_benchmark/agent_configs/net_config.json
@@ -1,0 +1,25 @@
+{
+    "agent": {
+      "metrics_collection_interval": 60,
+      "run_as_user": "root",
+      "debug": true,
+      "logfile": ""
+    },
+    "metrics": {
+      "namespace": "MetricValueBenchmarkTest",
+      "append_dimensions": {
+        "InstanceId": "${aws:InstanceId}"
+      },
+      "metrics_collected": {
+        "net": {
+            "measurement": [
+             "bytes_sent", "bytes_recv", "drop_in", "drop_out", "err_in", "err_out", "packets_sent", "packets_recv"
+            ],
+            "resources": [
+              "*"
+            ],
+            "metrics_collection_interval": 60
+          }
+      }
+    }
+  }

--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -37,6 +37,7 @@ var testRunners = []*TestRunner{
 	{testRunner: &MemTestRunner{}},
 	{testRunner: &ProcStatTestRunner{}},
 	{testRunner: &DiskIOTestRunner{}},
+	{testRunner: &NetTestRunner{}},
 }
 
 func (suite *MetricBenchmarkTestSuite) TestAllInSuite() {

--- a/test/metric_value_benchmark/net_test.go
+++ b/test/metric_value_benchmark/net_test.go
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build linux && integration
+// +build linux,integration
+
+package metric_value_benchmark
+
+import (
+	"time"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
+)
+
+type NetTestRunner struct {
+}
+
+var _ ITestRunner = (*NetTestRunner)(nil)
+
+func (m *NetTestRunner) validate() status.TestGroupResult {
+	metricsToFetch := m.getMeasuredMetrics()
+	testResults := make([]status.TestResult, len(metricsToFetch))
+	for i, name := range metricsToFetch {
+		testResults[i] = m.validateDiskMetric(name)
+	}
+
+	return status.TestGroupResult{
+		Name:        m.getTestName(),
+		TestResults: testResults,
+	}
+}
+
+func (m *NetTestRunner) getTestName() string {
+	return "Net"
+}
+
+func (m *NetTestRunner) getAgentConfigFileName() string {
+	return "net_config.json"
+}
+
+func (m *NetTestRunner) getAgentRunDuration() time.Duration {
+	return minimumAgentRuntime
+}
+
+func (m *NetTestRunner) getMeasuredMetrics() []string {
+	return []string{
+		"net_bytes_sent", "net_bytes_recv", "net_drop_in", "net_drop_out", "net_err_in",
+		"net_err_out", "net_packets_sent", "net_packets_recv"}
+}
+
+func (m *NetTestRunner) validateDiskMetric(metricName string) status.TestResult {
+	testResult := status.TestResult{
+		Name:   metricName,
+		Status: status.FAILED,
+	}
+
+	fetcher, err := metric.GetMetricFetcher(metricName)
+	if err != nil {
+		return testResult
+	}
+
+	values, err := fetcher.Fetch(namespace, metricName, metric.AVERAGE)
+	if err != nil {
+		return testResult
+	}
+
+	if !isAllValuesGreaterThanOrEqualToZero(metricName, values) {
+		return testResult
+	}
+
+	testResult.Status = status.SUCCESSFUL
+	return testResult
+}

--- a/test/metric_value_benchmark/net_test.go
+++ b/test/metric_value_benchmark/net_test.go
@@ -22,7 +22,7 @@ func (m *NetTestRunner) validate() status.TestGroupResult {
 	metricsToFetch := m.getMeasuredMetrics()
 	testResults := make([]status.TestResult, len(metricsToFetch))
 	for i, name := range metricsToFetch {
-		testResults[i] = m.validateDiskMetric(name)
+		testResults[i] = m.validateNetMetric(name)
 	}
 
 	return status.TestGroupResult{
@@ -49,7 +49,7 @@ func (m *NetTestRunner) getMeasuredMetrics() []string {
 		"net_err_out", "net_packets_sent", "net_packets_recv"}
 }
 
-func (m *NetTestRunner) validateDiskMetric(metricName string) status.TestResult {
+func (m *NetTestRunner) validateNetMetric(metricName string) status.TestResult {
 	testResult := status.TestResult{
 		Name:   metricName,
 		Status: status.FAILED,


### PR DESCRIPTION
# Description of the issue
Add E2E Sanity Test for Net 

# Description of changes
* Added integration test to validate that the agent publishes metrics for the Net input plugin

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran on my fork: https://github.com/khanhntd/amazon-cloudwatch-agent/actions/runs/3437608790/jobs/5732904202
```
null_resource.integration_test (remote-exec): 2022/11/10 14:59:57 ==============Net==============
null_resource.integration_test (remote-exec): 2022/11/10 14:59:57 ==============Successful==============
null_resource.integration_test (remote-exec): net_bytes_sent     Successful
null_resource.integration_test (remote-exec): net_bytes_recv     Successful
null_resource.integration_test (remote-exec): net_drop_in        Successful
null_resource.integration_test (remote-exec): net_drop_out       Successful
null_resource.integration_test (remote-exec): net_err_in         Successful
null_resource.integration_test (remote-exec): net_err_out        Successful
null_resource.integration_test (remote-exec): net_packets_sent   Successful
null_resource.integration_test (remote-exec): net_packets_recv   Successful
```



