### PR TITLE
Add Collection Interval Test And Let It Work On Darwin

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -26,6 +26,7 @@ var osToTestDirMap = map[string][]string{
 		"./test/metrics_number_dimension",
 		"./test/metric_value_benchmark",
 		"./test/run_as_user",
+		"./test/collection_interval",
 	},
 	"ec2_performance": {
 		"./test/performancetest",

--- a/test/agent_util.go
+++ b/test/agent_util.go
@@ -1,9 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build linux && integration
-// +build linux,integration
-
 package test
 
 import (
@@ -15,8 +12,11 @@ import (
 )
 
 const (
-	CatCommand      = "cat "
-	AppOwnerCommand = "ps -u -p "
+	CatCommand       = "cat "
+	AppOwnerCommand  = "ps -u -p "
+	ConfigOutputPath = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
+	Namespace        = "CWAgent"
+	Host             = "host"
 )
 
 func CopyFile(pathIn string, pathOut string) {

--- a/test/collection_interval/collection_interval_test.go
+++ b/test/collection_interval/collection_interval_test.go
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package collection_interval
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/test"
+)
+
+const (
+	// Let the agent run for 2 minute intervals.
+	agentRuntime    = 2 * time.Minute
+	metricName      = "disk_used_percent"
+	periodInSeconds = 60
+	retryCount      = 3
+)
+
+type input struct {
+	lowerBoundInclusive int
+	upperBoundInclusive int
+	dataInput           string
+	testDescription     string
+}
+
+// Sets the collection interval and makes sure we get the numbers of expected metrics
+// With the chance of jitter the sample count of metrics could be lower or higher than expected number of metrics
+// The bounds are to account for jitter
+// Add a shorter force flush interval than collection interval to make sure sample count are closer to correct
+func TestCollectionInterval(t *testing.T) {
+
+	parameters := []input{
+		{
+			testDescription:     "No collection interval given default to 60s",
+			dataInput:           "resources/default.json",
+			lowerBoundInclusive: 1,
+			upperBoundInclusive: 3,
+		},
+		{
+			testDescription:     "Agent has 10s second collection interval",
+			dataInput:           "resources/agent_interval_10s.json",
+			lowerBoundInclusive: 11,
+			upperBoundInclusive: 13,
+		},
+		{
+			testDescription:     "Metric disk has 10s collection interval",
+			dataInput:           "resources/metric_interval_10s.json",
+			lowerBoundInclusive: 11,
+			upperBoundInclusive: 13,
+		},
+		{
+			testDescription:     "Agent has 60s collection interval, disk has 10s collection interval use disk collection interval",
+			dataInput:           "resources/metric_override_interval_10s.json",
+			lowerBoundInclusive: 11,
+			upperBoundInclusive: 13,
+		},
+	}
+
+	for _, parameter := range parameters {
+		t.Run(fmt.Sprintf("test description %s resource file location %s number of metrics lower bound %d and upper bound %d",
+			parameter.testDescription, parameter.dataInput, parameter.lowerBoundInclusive, parameter.upperBoundInclusive), func(t *testing.T) {
+			test.CopyFile(parameter.dataInput, test.ConfigOutputPath)
+			hostName, err := os.Hostname()
+			if err != nil {
+				t.Fatalf("Can't get hostname")
+			}
+			dimensions := []types.Dimension{
+				{
+					Name:  aws.String(test.Host),
+					Value: aws.String(hostName),
+				},
+			}
+			pass := false
+			for i := 0; i < retryCount; i++ {
+				// Start at the beginning of next minute so cw metrics sample count will only be in the next minute for minute aggregation
+				currentTime := time.Now()
+				startTime := currentTime.Truncate(time.Minute).Add(time.Minute)
+				duration := startTime.Sub(currentTime)
+				time.Sleep(duration)
+				test.StartAgent(test.ConfigOutputPath, true)
+				time.Sleep(agentRuntime)
+				test.StopAgent()
+				endTime := time.Now()
+				if test.ValidateSampleCount(t, metricName, test.Namespace, dimensions,
+					startTime, endTime,
+					parameter.lowerBoundInclusive, parameter.upperBoundInclusive, periodInSeconds) {
+					pass = true
+					break
+				}
+			}
+			if !pass {
+				t.Fail()
+			}
+		})
+	}
+}

--- a/test/collection_interval/resources/agent_interval_10s.json
+++ b/test/collection_interval/resources/agent_interval_10s.json
@@ -1,0 +1,24 @@
+{
+  "agent": {
+    "logfile": "",
+    "metrics_collection_interval": 10
+  },
+  "metrics": {
+    "metrics_collected": {
+      "disk": {
+        "measurement": [
+          "used_percent"
+        ],
+        "resources": [
+          "/"
+        ]
+      }
+    },
+    "aggregation_dimensions": [
+      [
+        "host"
+      ]
+    ],
+    "force_flush_interval": 5
+  }
+}

--- a/test/collection_interval/resources/default.json
+++ b/test/collection_interval/resources/default.json
@@ -1,0 +1,23 @@
+{
+  "agent": {
+    "logfile": ""
+  },
+  "metrics": {
+    "metrics_collected": {
+      "disk": {
+        "measurement": [
+          "used_percent"
+        ],
+        "resources": [
+          "/"
+        ]
+      }
+    },
+    "aggregation_dimensions": [
+      [
+        "host"
+      ]
+    ],
+    "force_flush_interval": 30
+  }
+}

--- a/test/collection_interval/resources/metric_interval_10s.json
+++ b/test/collection_interval/resources/metric_interval_10s.json
@@ -1,0 +1,24 @@
+{
+  "agent": {
+    "logfile": ""
+  },
+  "metrics": {
+    "metrics_collected": {
+      "disk": {
+        "measurement": [
+          "used_percent"
+        ],
+        "resources": [
+          "/"
+        ],
+        "metrics_collection_interval": 10
+      }
+    },
+    "aggregation_dimensions": [
+      [
+        "host"
+      ]
+    ],
+    "force_flush_interval": 5
+  }
+}

--- a/test/collection_interval/resources/metric_override_interval_10s.json
+++ b/test/collection_interval/resources/metric_override_interval_10s.json
@@ -1,0 +1,25 @@
+{
+  "agent": {
+    "logfile": "",
+    "metrics_collection_interval": 60
+  },
+  "metrics": {
+    "metrics_collected": {
+      "disk": {
+        "measurement": [
+          "used_percent"
+        ],
+        "resources": [
+          "/"
+        ],
+        "metrics_collection_interval": 10
+      }
+    },
+    "aggregation_dimensions": [
+      [
+        "host"
+      ]
+    ],
+    "force_flush_interval": 5
+  }
+}

--- a/test/run_as_user/run_as_user_test.go
+++ b/test/run_as_user/run_as_user_test.go
@@ -30,7 +30,7 @@ type input struct {
 	dataInput string
 }
 
-func TestBundle(t *testing.T) {
+func TestRunAsUser(t *testing.T) {
 
 	parameters := []input{
 		{dataInput: "resources/default.json", user: root},

--- a/test/util.go
+++ b/test/util.go
@@ -1,16 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build integration
-// +build integration
-
 package test
 
 import (
 	"context"
-	"log"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"log"
 )
 
 func GetInstanceId() string {


### PR DESCRIPTION
# Description of the issue
No collection interval test

# Description of changes
Add collection interval test

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
go test ./test/collection_interval -p 1 -timeout 30m -v

These tests can run on mac. We now split out the integration tests out of the main repo. We do not need tags to prevent the test running as a unit test.
