### PR TITLE
Test OL9 Instead Of OL8-6

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -50,10 +50,10 @@
     "binaryName": "amazon-cloudwatch-agent.rpm"
   },
   {
-    "os": "ol8-6",
+    "os": "ol9",
     "username": "ec2-user",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
-    "ami": "cloudwatch-agent-integration-test-ol8-6*",
+    "ami": "cloudwatch-agent-integration-test-ol9*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm"


### PR DESCRIPTION
# Description of the issue
Oracle 8-6 base image does not allow ssh. Causing integration test issues. 

# Description of changes
Use newer version ol base image

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
[_Describe what tests you have done._](https://github.com/sethAmazon/amazon-cloudwatch-agent/actions/runs/3570702957)
