### PR TITLE
Add cloudwatch:GetMetricStatistics To IAM Role

### DIFF
--- a/terraform/ec2/linux/iam.tf
+++ b/terraform/ec2/linux/iam.tf
@@ -30,6 +30,7 @@ data "aws_iam_policy_document" "user-managed-policy-document" {
       "cloudwatch:GetMetricData",
       "cloudwatch:PutMetricData",
       "cloudwatch:ListMetrics",
+      "cloudwatch:GetMetricStatistics",
       "ec2:DescribeVolumes",
       "ec2:DescribeTags",
       "logs:PutLogEvents",


### PR DESCRIPTION
# Description of the issue
cloudwatch:GetMetricStatistics is missing from iam assume role

# Description of changes
Add cloudwatch:GetMetricStatistics to iam assume role

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A
