### PR TITLE
Add E2E sanity test for NetStat

### DIFF
--- a/test/metric/metric_value_query.go
+++ b/test/metric/metric_value_query.go
@@ -19,6 +19,7 @@ import (
 )
 
 var metricValueFetchers = []MetricValueFetcher{
+	&SwapMetricValueFetcher{},
 	&CPUMetricValueFetcher{},
 	&MemMetricValueFetcher{},
 	&ProcStatMetricValueFetcher{},

--- a/test/metric/swap.go
+++ b/test/metric/swap.go
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+//go:build linux && integration
+// +build linux,integration
+
+package metric
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+)
+
+type SwapMetricValueFetcher struct {
+	baseMetricValueFetcher
+}
+
+var _ MetricValueFetcher = (*SwapMetricValueFetcher)(nil)
+
+func (f *SwapMetricValueFetcher) Fetch(namespace, metricName string, stat Statistics) (MetricValues, error) {
+	dimensions := f.getMetricSpecificDimensions()
+	dimensions = append(dimensions, f.getInstanceIdDimension())
+	values, err := f.fetch(namespace, metricName, dimensions, stat)
+	if err != nil {
+		log.Printf("Error while fetching metric value for $s: $v", metricName, err)
+	}
+	return values, err
+}
+
+func (f *SwapMetricValueFetcher) isApplicable(metricName string) bool {
+	swapSupportedMetric := f.getPluginSupportedMetric()
+	_, exists := swapSupportedMetric[metricName]
+	return exists
+}
+
+// https://github.com/aws/amazon-cloudwatch-agent/blob/6451e8b913bcf9892f2cead08e335c913c690e6d/translator/translate/metrics/config/registered_metrics.go#L35
+func (f *SwapMetricValueFetcher) getPluginSupportedMetric() map[string]struct{} {
+	return map[string]struct{}{
+		"swap_free":         {},
+		"swap_used":         {},
+		"swap_used_percent": {},
+	}
+}
+
+func (f *SwapMetricValueFetcher) getMetricSpecificDimensions() []types.Dimension {
+	return []types.Dimension{}
+}

--- a/test/metric_value_benchmark/agent_configs/netstat_config.json
+++ b/test/metric_value_benchmark/agent_configs/netstat_config.json
@@ -1,0 +1,34 @@
+{
+    "agent": {
+        "metrics_collection_interval": 60,
+        "run_as_user": "root",
+        "debug": true,
+        "logfile": ""
+    },
+    "metrics": {
+        "namespace": "MetricValueBenchmarkTest",
+        "append_dimensions": {
+            "InstanceId": "${aws:InstanceId}"
+        },
+        "metrics_collected": {
+            "netstat": {
+                "measurement": [
+                    "tcp_close",
+                    "tcp_close_wait",
+                    "tcp_closing",
+                    "tcp_established",
+                    "tcp_fin_wait1",
+                    "tcp_fin_wait2",
+                    "tcp_last_ack",
+                    "tcp_listen",
+                    "tcp_none",
+                    "tcp_syn_sent",
+                    "tcp_syn_recv",
+                    "tcp_time_wait",
+                    "udp_socket"
+                ],
+                "metrics_collection_interval": 60
+            }
+        }
+    }
+}

--- a/test/metric_value_benchmark/agent_configs/swap_config.json
+++ b/test/metric_value_benchmark/agent_configs/swap_config.json
@@ -1,0 +1,23 @@
+{
+    "agent": {
+        "metrics_collection_interval": 60,
+        "run_as_user": "root",
+        "debug": true,
+        "logfile": ""
+    },
+    "metrics": {
+        "namespace": "MetricValueBenchmarkTest",
+        "append_dimensions": {
+            "InstanceId": "${aws:InstanceId}"
+        },
+        "metrics_collected": {
+            "swap": {
+                "measurement": [
+                    "free",
+                    "used",
+                    "used_percent"
+                ]
+            }
+        }
+    }
+}

--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -62,6 +62,7 @@ func getEc2TestRunners(env *environment.MetaData) []*TestRunner {
 	if ec2TestRunners == nil {
 		factory := &metric.MetricFetcherFactory{Env: env}
 		ec2TestRunners = []*TestRunner{
+			{testRunner: &SwapTestRunner{BaseTestRunner{MetricFetcherFactory: factory}}},
 			{testRunner: &CPUTestRunner{BaseTestRunner{MetricFetcherFactory: factory}}},
 			{testRunner: &MemTestRunner{BaseTestRunner{MetricFetcherFactory: factory}}},
 			{testRunner: &ProcStatTestRunner{BaseTestRunner{MetricFetcherFactory: factory}}},

--- a/test/metric_value_benchmark/swap_test.go
+++ b/test/metric_value_benchmark/swap_test.go
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build linux && integration
+// +build linux,integration
+
+package metric_value_benchmark
+
+import (
+	"log"
+	"time"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
+)
+
+type SwapTestRunner struct {
+	BaseTestRunner
+}
+
+var _ ITestRunner = (*SwapTestRunner)(nil)
+
+func (t *SwapTestRunner) validate() status.TestGroupResult {
+	metricsToFetch := t.getMeasuredMetrics()
+	testResults := make([]status.TestResult, len(metricsToFetch))
+	for i, metricName := range metricsToFetch {
+		testResults[i] = t.validateSwapMetric(metricName)
+	}
+
+	return status.TestGroupResult{
+		Name:        t.getTestName(),
+		TestResults: testResults,
+	}
+}
+
+func (t *SwapTestRunner) getTestName() string {
+	return "Swap"
+}
+
+func (t *SwapTestRunner) getAgentConfigFileName() string {
+	return "swap_config.json"
+}
+func (t *SwapTestRunner) getAgentRunDuration() time.Duration {
+	return minimumAgentRuntime
+}
+
+func (t *SwapTestRunner) getMeasuredMetrics() []string {
+	return []string{
+		"swap_free",
+		"swap_used",
+		"swap_used_percent",
+	}
+}
+
+func (t *SwapTestRunner) validateSwapMetric(metricName string) status.TestResult {
+	testResult := status.TestResult{
+		Name:   metricName,
+		Status: status.FAILED,
+	}
+
+	fetcher, err := t.MetricFetcherFactory.GetMetricFetcher(metricName)
+	if err != nil {
+		return testResult
+	}
+
+	values, err := fetcher.Fetch(namespace, metricName, metric.AVERAGE)
+	log.Printf("metric values are %v", values)
+	if err != nil {
+		return testResult
+	}
+
+	if !isAllValuesGreaterThanOrEqualToZero(metricName, values) {
+		return testResult
+	}
+
+	testResult.Status = status.SUCCESSFUL
+	return testResult
+}


### PR DESCRIPTION
# Description of the issue

E2E sanity test for NetStat

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
[Ran on hacked_ec2 branch of fork](https://github.com/williazz/amazon-cloudwatch-agent/actions/runs/3759997774/jobs/6390558972)
```
null_resource.integration_test (remote-exec): 2022/12/20 19:45:32 >>>>>>>>>>>>>>Successful<<<<<<<<<<<<<<
null_resource.integration_test (remote-exec): 2022/12/20 19:45:32 ==============NetStat==============
null_resource.integration_test (remote-exec): 2022/12/20 19:45:32 ==============Successful==============
null_resource.integration_test (remote-exec): netstat_tcp_close         Successful
null_resource.integration_test (remote-exec): netstat_tcp_close_wait    Successful
null_resource.integration_test (remote-exec): netstat_tcp_closing       Successful
null_resource.integration_test (remote-exec): netstat_tcp_established   Successful
null_resource.integration_test (remote-exec): netstat_tcp_fin_wait1     Successful
null_resource.integration_test (remote-exec): netstat_tcp_fin_wait2     Successful
null_resource.integration_test (remote-exec): netstat_tcp_last_ack      Successful
null_resource.integration_test (remote-exec): netstat_tcp_listen        Successful
null_resource.integration_test (remote-exec): netstat_tcp_none          Successful
null_resource.integration_test (remote-exec): netstat_tcp_syn_sent      Successful
null_resource.integration_test (remote-exec): netstat_tcp_syn_recv      Successful
null_resource.integration_test (remote-exec): netstat_tcp_time_wait     Successful
null_resource.integration_test (remote-exec): netstat_udp_socket        Successful
```