### PR TITLE
Remove github.com/aws/amazon-cloudwatch-agent-test/test inside metric value query

### DIFF
--- a/test/metric/metric_value_query.go
+++ b/test/metric/metric_value_query.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/internal/awsservice"
-	"github.com/aws/amazon-cloudwatch-agent-test/test"
 )
 
 var metricValueFetchers = []MetricValueFetcher{


### PR DESCRIPTION
# Description of the issue
Remove unused `github.com/aws/amazon-cloudwatch-agent-test/test` inside metric value query

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Running on my fork https://github.com/khanhntd/amazon-cloudwatch-agent/actions/runs/3705582505


