### PR TITLE
Use User Var For EFS SSH Connect

### DIFF
--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -50,7 +50,7 @@ resource "null_resource" "mount_efs" {
 
   connection {
     type = "ssh"
-    user = "ec2-user"
+    user = var.user
     private_key = local.private_key_content
     host = aws_instance.cwagent.public_ip
   }


### PR DESCRIPTION
# Description of the issue
Tryign to connect using ec2-user on ubuntu instances. 

# Description of changes
Use user var for ssh connection.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Failed tests https://github.com/aws/private-amazon-cloudwatch-agent-staging/actions/runs/3857573617/jobs/6609866529
