### PR TITLE
Fix EFS Utils Install On Rhel8 And OL9

### DIFF
--- a/terraform/ec2/linux/install-efs-utils.sh
+++ b/terraform/ec2/linux/install-efs-utils.sh
@@ -9,8 +9,11 @@ if command -v apt-get >/dev/null; then
   ./build-deb.sh
   sudo apt-get -y install ./build/amazon-efs-utils*deb
 elif command -v yum >/dev/null; then
-  sudo yum update -y
-  sudo yum install sudo yum install -y amazon-efs-utils
+  sudo yum -y install git rpm-build make
+  git clone https://github.com/aws/efs-utils
+  cd efs-utils
+  make rpm
+  sudo yum -y install build/amazon-efs-utils*rpm
 elif command -v zypper >/dev/null; then
   sudo zypper refresh
   sudo zypper install -y git rpm-build make


### PR DESCRIPTION
# Description of the issue
Failed test for efs on rhel8 and ol9

# Description of changes
Follow https://github.com/aws/efs-utils guide for yum

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Failed test https://github.com/aws/private-amazon-cloudwatch-agent-staging/actions/runs/3877393955/jobs/6612416155
