### PR TITLE
Fix build failures in DiskTestRunner due to merge conflicts

### DIFF
--- a/test/metric_append_dimension/metrics_append_dimension_test.go
+++ b/test/metric_append_dimension/metrics_append_dimension_test.go
@@ -9,8 +9,8 @@ package metric_append_dimension
 import (
 	"fmt"
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
-	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"github.com/stretchr/testify/suite"
@@ -46,7 +46,7 @@ func getTestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 	if testRunners == nil {
 		factory := dimension.GetDimensionFactory(*env)
 		testRunners = []*test_runner.TestRunner{
-			{TestRunner: &NoAppendDimensionTestRunner{Base: test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &NoAppendDimensionTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 		}
 	}
 	return testRunners

--- a/test/metric_value_benchmark/disk_test.go
+++ b/test/metric_value_benchmark/disk_test.go
@@ -10,9 +10,9 @@ import (
 	"log"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
-	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
@@ -43,7 +43,6 @@ func (t *DiskTestRunner) GetAgentConfigFileName() string {
 	return "disk_config.json"
 }
 
-
 func (t *DiskTestRunner) GetMeasuredMetrics() []string {
 	return []string{
 		"disk_free",
@@ -62,17 +61,17 @@ func (t *DiskTestRunner) validateDiskMetric(metricName string) status.TestResult
 		Status: status.FAILED,
 	}
 
-	dims, failed := t.DimensionFactory.GetDimensions([] dimension.Instruction{
-		{
-			Key: "InstanceId",
+	dims, failed := t.DimensionFactory.GetDimensions([]dimension.Instruction{
+		Instruction{
+			Key:   "InstanceId",
 			Value: dimension.UnknownDimensionValue(),
 		},
-		{
-			Key: "path",
+		Instruction{
+			Key:   "path",
 			Value: dimension.ExpectedDimensionValue{aws.String("/home/ec2-user/efs-mount-point")},
 		},
-		{
-			Key: "fstype",
+		Instruction{
+			Key:   "fstype",
 			Value: dimension.ExpectedDimensionValue{aws.String("nfs4")},
 		},
 	})


### PR DESCRIPTION
# Description of the issue
#67 had build failures because it had unresolved merge conflicts with #68 

# Description of changes
`DiskTestRunner` implements `test_runner.ITestRunner`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
builds on dev desktop
```
dev-dsk-billyzh-1e-8753df49 % go test ./test/metric_value_benchmark -p 1 -timeout 30m -computeType=EC2 -v --tags=integration
=== RUN   TestMetricValueBenchmarkSuite
>>>> Starting MetricBenchmarkTestSuite
=== RUN   TestMetricValueBenchmarkSuite/TestAllInSuite
2023/01/11 19:37:40 Running Disk
2023/01/11 19:37:40 Starting agent using agent config file agent_configs/disk_config.json
2023/01/11 19:37:40 Copy File agent_configs/disk_config.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/11 19:37:40 File agent_configs/disk_config.json abs path /home/billyzh/cwa-test-fork/test/metric_value_benchmark/agent_configs/disk_config.json
2023/01/11 19:37:40 File : agent_configs/disk_config.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/11 19:37:41 Agent has started
```

previously
```
dev-dsk-billyzh-1e-8753df49 % go test ./test/metric_value_benchmark -p 1 -timeout 30m -computeType=EC2 -v --tags=integration
# github.com/aws/amazon-cloudwatch-agent-test/test/metric_value_benchmark [github.com/aws/amazon-cloudwatch-agent-test/test/metric_value_benchmark.test]
test/metric_value_benchmark/disk_test.go:42:9: undefined: minimumAgentRuntime
test/metric_value_benchmark/disk_test.go:63:20: t.MetricFetcherFactory undefined (type *DiskTestRunner has no field or method MetricFetcherFactory)
test/metric_value_benchmark/metrics_value_benchmark_test.go:69:17: cannot use &DiskTestRunner{…} (value of type *DiskTestRunner) as type test_runner.ITestRunner in struct literal:
        *DiskTestRunner does not implement test_runner.ITestRunner (missing GetAgentConfigFileName method)
test/metric_value_benchmark/metrics_value_benchmark_test.go:69:33: cannot use test_runner.BaseTestRunner{…} (value of type test_runner.BaseTestRunner) as type BaseTestRunner in struct literal
FAIL    github.com/aws/amazon-cloudwatch-agent-test/test/metric_value_benchmark [build failed]
FAIL
```
