### PR TITLE
Fix imports github.com/aws/amazon-cloudwatch-agent-test/internal/comm…

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -13,7 +13,7 @@ import (
 )
 
 type matrixRow struct {
-	TestDir             string `json:"testDir"`
+	TestDir             string `json:"test_dir"`
 	Os                  string `json:"os"`
 	TestType            string `json:"testType"`
 	Arc                 string `json:"arc"`

--- a/internal/common/agent_util_unix.go
+++ b/internal/common/agent_util_unix.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package common
 

--- a/msi/tools/msiversion/msiversionconverter.go
+++ b/msi/tools/msiversion/msiversionconverter.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package main
 

--- a/test/ca_bundle/ca_bundle_test.go
+++ b/test/ca_bundle/ca_bundle_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/amazon-cloudwatch-agent-test/internal/common"
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/internal/common"
 )
 
 const configOutputPath = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"

--- a/test/cloudwatchlogs/publish_logs_test.go
+++ b/test/cloudwatchlogs/publish_logs_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package cloudwatchlogs
 

--- a/test/collection_interval/collection_interval_test.go
+++ b/test/collection_interval/collection_interval_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/internal/awsservice"
 	"github.com/aws/amazon-cloudwatch-agent-test/internal/common"
-	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 )
 
 const (

--- a/test/metric/dimension/container_insights_provider.go
+++ b/test/metric/dimension/container_insights_provider.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package dimension
 

--- a/test/metric/dimension/custom_provider.go
+++ b/test/metric/dimension/custom_provider.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package dimension
 
@@ -28,6 +27,6 @@ func (p *CustomDimensionProvider) GetDimension(instruction Instruction) types.Di
 
 	return types.Dimension{
 		Name:  aws.String(instruction.Key),
-		Value: aws.String(*instruction.Value.Value),
+		Value: instruction.Value.Value,
 	}
 }

--- a/test/metric/dimension/host_provider.go
+++ b/test/metric/dimension/host_provider.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package dimension
 

--- a/test/metric/dimension/instanceid_provider.go
+++ b/test/metric/dimension/instanceid_provider.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package dimension
 

--- a/test/metric/dimension/provider.go
+++ b/test/metric/dimension/provider.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package dimension
 

--- a/test/metric/metric_value_query.go
+++ b/test/metric/metric_value_query.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric
 

--- a/test/metric_append_dimension/metrics_append_dimension_test.go
+++ b/test/metric_append_dimension/metrics_append_dimension_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_append_dimension
 

--- a/test/metric_append_dimension/no_append_dimensions_test.go
+++ b/test/metric_append_dimension/no_append_dimensions_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_append_dimension
 

--- a/test/metric_value_benchmark/agent_configs/disk_config.json
+++ b/test/metric_value_benchmark/agent_configs/disk_config.json
@@ -10,6 +10,11 @@
     "append_dimensions": {
       "InstanceId": "${aws:InstanceId}"
     },
+    "aggregation_dimensions": [
+      [
+        "InstanceId"
+      ]
+    ],
     "metrics_collected": {
       "disk": {
         "resources": [

--- a/test/metric_value_benchmark/collectd_test.go
+++ b/test/metric_value_benchmark/collectd_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/container_insights_test.go
+++ b/test/metric_value_benchmark/container_insights_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/cpu_test.go
+++ b/test/metric_value_benchmark/cpu_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/disk_test.go
+++ b/test/metric_value_benchmark/disk_test.go
@@ -1,12 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 
 import (
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"log"
 	"time"
 
@@ -15,34 +16,36 @@ import (
 )
 
 type DiskTestRunner struct {
-	BaseTestRunner
+	test_runner.BaseTestRunner
 }
 
-func (t *DiskTestRunner) validate() status.TestGroupResult {
-	metricsToFetch := t.getMeasuredMetrics()
+var _ test_runner.ITestRunner = (*DiskTestRunner)(nil)
+
+func (t *DiskTestRunner) Validate() status.TestGroupResult {
+	metricsToFetch := t.GetMeasuredMetrics()
 	testResults := make([]status.TestResult, len(metricsToFetch))
 	for i, metricName := range metricsToFetch {
-		testResults[i] = t.validateDiskMetric(metricName)
+		testResults[i] = t.ValidateDiskMetric(metricName)
 	}
 
 	return status.TestGroupResult{
-		Name:        t.getTestName(),
+		Name:        t.GetTestName(),
 		TestResults: testResults,
 	}
 }
 
-func (t *DiskTestRunner) getTestName() string {
+func (t *DiskTestRunner) GetTestName() string {
 	return "Disk"
 }
 
-func (t *DiskTestRunner) getAgentConfigFileName() string {
+func (t *DiskTestRunner) GetAgentConfigFileName() string {
 	return "disk_config.json"
 }
-func (t *DiskTestRunner) getAgentRunDuration() time.Duration {
-	return minimumAgentRuntime
+func (t *DiskTestRunner) GetAgentRunDuration() time.Duration {
+	return test_runner.MinimumAgentRuntime
 }
 
-func (t *DiskTestRunner) getMeasuredMetrics() []string {
+func (t *DiskTestRunner) GetMeasuredMetrics() []string {
 	return []string{
 		"disk_free",
 		"disk_inodes_free",
@@ -54,18 +57,26 @@ func (t *DiskTestRunner) getMeasuredMetrics() []string {
 	}
 }
 
-func (t *DiskTestRunner) validateDiskMetric(metricName string) status.TestResult {
+func (t *DiskTestRunner) ValidateDiskMetric(metricName string) status.TestResult {
 	testResult := status.TestResult{
 		Name:   metricName,
 		Status: status.FAILED,
 	}
 
-	fetcher, err := t.MetricFetcherFactory.GetMetricFetcher(metricName)
-	if err != nil {
+	dims, failed := t.DimensionFactory.GetDimensions([]dimension.Instruction{
+		{
+			Key:   "InstanceId",
+			Value: dimension.UnknownDimensionValue(),
+		},
+	})
+
+	if len(failed) > 0 {
 		return testResult
 	}
 
-	values, err := fetcher.Fetch(namespace, metricName, metric.AVERAGE)
+	fetcher := metric.MetricValueFetcher{}
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+
 	log.Printf("metric values are %v", values)
 	if err != nil {
 		return testResult

--- a/test/metric_value_benchmark/diskio_test.go
+++ b/test/metric_value_benchmark/diskio_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/ecs_daemon_base_test_runner.go
+++ b/test/metric_value_benchmark/ecs_daemon_base_test_runner.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/emf_test.go
+++ b/test/metric_value_benchmark/emf_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/mem_test.go
+++ b/test/metric_value_benchmark/mem_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/net_test.go
+++ b/test/metric_value_benchmark/net_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/netstat_test.go
+++ b/test/metric_value_benchmark/netstat_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/processes_test.go
+++ b/test/metric_value_benchmark/processes_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/procstat_test.go
+++ b/test/metric_value_benchmark/procstat_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/prometheus_test.go
+++ b/test/metric_value_benchmark/prometheus_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metric_value_benchmark/swap_test.go
+++ b/test/metric_value_benchmark/swap_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metric_value_benchmark
 

--- a/test/metrics_number_dimension/metrics_number_dimension_test.go
+++ b/test/metrics_number_dimension/metrics_number_dimension_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metrics_number_dimension
 

--- a/test/nvidia_gpu/metrics_nvidia_gpu_linux_test.go
+++ b/test/nvidia_gpu/metrics_nvidia_gpu_linux_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package metrics_nvidia_gpu
 

--- a/test/performancetest/performance_test.go
+++ b/test/performancetest/performance_test.go
@@ -1,5 +1,4 @@
-//go:build unix
-// +build unix
+//go:build !windows
 
 package performancetest
 

--- a/test/run_as_user/run_as_user_test.go
+++ b/test/run_as_user/run_as_user_test.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package run_as_user
 

--- a/test/sanity/sanity_unix.go
+++ b/test/sanity/sanity_unix.go
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
+//go:build !windows
+
 package sanity
 
 import (

--- a/test/status/test_result.go
+++ b/test/status/test_result.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unixtegration
+//go:build !windows
 
 package status
 

--- a/test/status/test_status.go
+++ b/test/status/test_status.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package status
 

--- a/test/test_runner/base_test_runner.go
+++ b/test/test_runner/base_test_runner.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package test_runner
 

--- a/test/test_runner/test_suite.go
+++ b/test/test_runner/test_suite.go
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-//go:build unix
-// +build unix
+//go:build !windows
 
 package test_runner
 


### PR DESCRIPTION
…on: build constraints exclude all Go files in /home/ec2-user/amazon-cloudwatch-agent-test/internal/common

# Description of the issue
Weird edge case where if there is a //go:build unix not allowing a call from linux env when the original file sanity_test.go does not contain a unix build tag but call a *_unix.go file. 
```
null_resource.integration_test (remote-exec): 	imports github.com/aws/amazon-cloudwatch-agent-test/internal/common: build constraints exclude all Go files in /home/ec2-user/amazon-cloudwatch-agent-test/internal/common
null_resource.integration_test (remote-exec): no Go files in /home/ec2-user/amazon-cloudwatch-agent-test
╷
│ Error: remote-exec provisioner error
│ 
│   with null_resource.integration_test,
│   on main.tf line 120, in resource "null_resource" "integration_test":
│  120:   provisioner "remote-exec" {
│ 
│ error executing "/tmp/terraform_684748912.sh": Process exited with status 1
```

# Description of changes
Remove internal package so it can be imported in other packages. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
```
[ec2-user@ip-172-31-45-254 amazon-cloudwatch-agent-test]$ go test ./test/sanity -p 1 -v
=== RUN   TestAgentStatus
--- PASS: TestAgentStatus (2.37s)
PASS
ok  	github.com/aws/amazon-cloudwatch-agent-test/test/sanity	2.370s
```

```
[ec2-user@ip-172-31-45-254 amazon-cloudwatch-agent-test]$ go test ./test/collection_interval -p 1 -timeout 1h -computeType=EC2 -v
...
--- PASS: TestCollectionInterval (717.14s)
    --- PASS: TestCollectionInterval/test_description_No_collection_interval_given_default_to_60s_resource_file_location_resources/default.json_number_of_metrics_lower_bound_1_and_upper_bound_3 (177.14s)
    --- PASS: TestCollectionInterval/test_description_Agent_has_10s_second_collection_interval_resource_file_location_resources/agent_interval_10s.json_number_of_metrics_lower_bound_11_and_upper_bound_13 (179.90s)
    --- PASS: TestCollectionInterval/test_description_Metric_disk_has_10s_collection_interval_resource_file_location_resources/metric_interval_10s.json_number_of_metrics_lower_bound_11_and_upper_bound_13 (180.03s)
    --- PASS: TestCollectionInterval/test_description_Agent_has_60s_collection_interval,_disk_has_10s_collection_interval_use_disk_collection_interval_resource_file_location_resources/metric_override_interval_10s.json_number_of_metrics_lower_bound_11_and_upper_bound_13 (180.06s)
PASS
ok  	github.com/aws/amazon-cloudwatch-agent-test/test/collection_interval	717.142s
```
