### PR TITLE
Fix Append Dimension Test

### DIFF
--- a/test/metric/dimension/container_insights_provider.go
+++ b/test/metric/dimension/container_insights_provider.go
@@ -47,3 +47,7 @@ func (p *ContainerInsightsDimensionProvider) GetDimension(instruction Instructio
 
 	return types.Dimension{}
 }
+
+func (p *ContainerInsightsDimensionProvider) Name() string {
+	return "ContainerInsightsDimensionProvider"
+}

--- a/test/metric/dimension/custom_provider.go
+++ b/test/metric/dimension/custom_provider.go
@@ -30,3 +30,7 @@ func (p *CustomDimensionProvider) GetDimension(instruction Instruction) types.Di
 		Value: instruction.Value.Value,
 	}
 }
+
+func (p *CustomDimensionProvider) Name() string {
+	return "CustomDimensionProvider"
+}

--- a/test/metric/dimension/host_provider.go
+++ b/test/metric/dimension/host_provider.go
@@ -35,3 +35,7 @@ func (p *HostDimensionProvider) GetDimension(instruction Instruction) types.Dime
 		Value: aws.String(name),
 	}
 }
+
+func (p *HostDimensionProvider) Name() string {
+	return "HostDimensionProvider"
+}

--- a/test/metric/dimension/instanceid_provider.go
+++ b/test/metric/dimension/instanceid_provider.go
@@ -41,6 +41,10 @@ func (p *ECSInstanceIdDimensionProvider) GetDimension(instruction Instruction) t
 	}
 }
 
+func (p *ECSInstanceIdDimensionProvider) Name() string {
+	return "ECSInstanceIdDimensionProvider"
+}
+
 type LocalInstanceIdDimensionProvider struct {
 	Provider
 }
@@ -60,4 +64,8 @@ func (p *LocalInstanceIdDimensionProvider) GetDimension(instruction Instruction)
 		Name:  aws.String("InstanceId"),
 		Value: aws.String(ec2InstanceId),
 	}
+}
+
+func (p *LocalInstanceIdDimensionProvider) Name() string {
+	return "LocalInstanceIdDimensionProvider"
 }

--- a/test/metric/dimension/provider.go
+++ b/test/metric/dimension/provider.go
@@ -16,11 +16,11 @@ type ExpectedDimensionValue struct {
 }
 
 func (d *ExpectedDimensionValue) IsKnown() bool {
-	return d.Value == nil
+	return d.Value != nil
 }
 
 func UnknownDimensionValue() ExpectedDimensionValue {
-	return ExpectedDimensionValue{}
+	return ExpectedDimensionValue{Value: nil}
 }
 
 func GetDimensionFactory(env environment.MetaData) Factory {
@@ -72,6 +72,7 @@ func (f *Factory) GetDimensions(instructions []Instruction) ([]types.Dimension, 
 func (f *Factory) executeInstruction(instruction Instruction) types.Dimension {
 	for _, provider := range f.providers {
 		dim := provider.GetDimension(instruction)
+		log.Printf("instruction %v provider %s returned dimension %v", instruction, provider.Name(), dim)
 		if (dim != types.Dimension{}) {
 			return dim
 		}
@@ -82,6 +83,7 @@ func (f *Factory) executeInstruction(instruction Instruction) types.Dimension {
 type IProvider interface {
 	IsApplicable() bool
 	GetDimension(Instruction) types.Dimension
+	Name() string
 }
 
 type Provider struct {

--- a/test/metric_append_dimension/no_append_dimensions_test.go
+++ b/test/metric_append_dimension/no_append_dimensions_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"github.com/aws/aws-sdk-go-v2/aws"
-
 	"log"
 )
 

--- a/test/metric_value_benchmark/disk_test.go
+++ b/test/metric_value_benchmark/disk_test.go
@@ -6,13 +6,11 @@
 package metric_value_benchmark
 
 import (
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"log"
-	"time"
-
-	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
-	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 )
 
 type DiskTestRunner struct {
@@ -40,9 +38,6 @@ func (t *DiskTestRunner) GetTestName() string {
 
 func (t *DiskTestRunner) GetAgentConfigFileName() string {
 	return "disk_config.json"
-}
-func (t *DiskTestRunner) GetAgentRunDuration() time.Duration {
-	return test_runner.MinimumAgentRuntime
 }
 
 func (t *DiskTestRunner) GetMeasuredMetrics() []string {


### PR DESCRIPTION
# Description of the issue
```
[ec2-user@ip-172-31-45-254 amazon-cloudwatch-agent-test-fix-tests]$ go test ./test/metric_append_dimension/ -p 1 -timeout 1h -computeType=EC2 -v
=== RUN   TestMetricsAppendDimensionTestSuite
>>>> Starting MetricAppendDimensionTestSuite
=== RUN   TestMetricsAppendDimensionTestSuite/TestAllInSuite
2023/01/18 22:37:10 Running NoAppendDimension
2023/01/18 22:37:10 Starting agent using agent config file agent_configs/no_append_dimension.json
2023/01/18 22:37:10 Copy File agent_configs/no_append_dimension.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/18 22:37:10 File agent_configs/no_append_dimension.json abs path /home/ec2-user/amazon-cloudwatch-agent-test-fix-tests/test/metric_append_dimension/agent_configs/no_append_dimension.json
2023/01/18 22:37:10 File : agent_configs/no_append_dimension.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/18 22:37:11 Agent has started
2023/01/18 22:40:11 Agent has been running for : 3m0s
2023/01/18 22:40:11 Agent is stopped
2023/01/18 22:40:11 Delete file /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/18 22:40:11 Removed file: /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/18 22:40:11 host dim instruction {host {<nil>}}
2023/01/18 22:40:11 provider HostDimensionProvider returned dimension array {<nil> <nil> {}} dim name <nil> dim value <nil> key host <nil> value
2023/01/18 22:40:11 provider LocalInstanceIdDimensionProvider returned dimension array {<nil> <nil> {}} dim name <nil> dim value <nil> key host <nil> value
2023/01/18 22:40:11 provider CustomDimensionProvider returned dimension array {0xc000096140 <nil> {}} dim name 0xc000096140 dim value <nil> key host <nil> value
    suite.go:77: test panicked: runtime error: invalid memory address or nil pointer dereference
        goroutine 7 [running]:
        runtime/debug.Stack()
        	/usr/lib/golang/src/runtime/debug/stack.go:24 +0x65
        github.com/stretchr/testify/suite.failOnPanic(0xc0001dc680, {0x93ab60, 0xd81ee0})
        	/home/ec2-user/go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:77 +0x3b
        github.com/stretchr/testify/suite.Run.func1.1()
        	/home/ec2-user/go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:161 +0x252
        panic({0x93ab60, 0xd81ee0})
        	/usr/lib/golang/src/runtime/panic.go:838 +0x207
        github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension.(*Factory).GetDimensions(0x0?, {0xc000141410?, 0x2, 0x40f305?})
        	/home/ec2-user/amazon-cloudwatch-agent-test-fix-tests/test/metric/dimension/provider.go:62 +0x204
        github.com/aws/amazon-cloudwatch-agent-test/test/metric_append_dimension.(*NoAppendDimensionTestRunner).validateNoAppendDimensionMetric(0xc00000eb40, {0x9c13c8, 0xf})
        	/home/ec2-user/amazon-cloudwatch-agent-test-fix-tests/test/metric_append_dimension/no_append_dimensions_test.go:54 +0xd4
        github.com/aws/amazon-cloudwatch-agent-test/test/metric_append_dimension.(*NoAppendDimensionTestRunner).Validate(0xc00021d360?)
        	/home/ec2-user/amazon-cloudwatch-agent-test-fix-tests/test/metric_append_dimension/no_append_dimensions_test.go:27 +0x93
        github.com/aws/amazon-cloudwatch-agent-test/test/test_runner.(*TestRunner).Run(0xc00021d360, {0xa841e0, 0xc000108300})
        	/home/ec2-user/amazon-cloudwatch-agent-test-fix-tests/test/test_runner/base_test_runner.go:61 +0x10e
        github.com/aws/amazon-cloudwatch-agent-test/test/metric_append_dimension.(*MetricsAppendDimensionTestSuite).TestAllInSuite(0xc000108300)
        	/home/ec2-user/amazon-cloudwatch-agent-test-fix-tests/test/metric_append_dimension/metrics_append_dimension_test.go:57 +0x73
        reflect.Value.call({0xc0001091a0?, 0xc000010e50?, 0x13?}, {0x9bc348, 0x4}, {0xc00005de70, 0x1, 0x1?})
        	/usr/lib/golang/src/reflect/value.go:556 +0x845
        reflect.Value.Call({0xc0001091a0?, 0xc000010e50?, 0xc000108300?}, {0xc00004ce70, 0x1, 0x1})
        	/usr/lib/golang/src/reflect/value.go:339 +0xbf
        github.com/stretchr/testify/suite.Run.func1(0xc0001dc680)
        	/home/ec2-user/go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:175 +0x4b6
        testing.tRunner(0xc0001dc680, 0xc000160240)
        	/usr/lib/golang/src/testing/testing.go:1439 +0x102
        created by testing.(*T).Run
        	/usr/lib/golang/src/testing/testing.go:1486 +0x35f
2023/01/18 22:40:11 >>>>>>>>>>>>>><<<<<<<<<<<<<<
2023/01/18 22:40:11 >>>>>>>>>>>>>>Successful<<<<<<<<<<<<<<
2023/01/18 22:40:11 >>>>>>>>>>>>>>><<<<<<<<<<<<<<<
>>>> Finished MetricAppendDimensionTestSuite
--- FAIL: TestMetricsAppendDimensionTestSuite (180.49s)
    --- FAIL: TestMetricsAppendDimensionTestSuite/TestAllInSuite (180.49s)
FAIL
FAIL	github.com/aws/amazon-cloudwatch-agent-test/test/metric_append_dimension	180.497s
FAIL
```

# Description of changes
Fix isknown dimension.  

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
```
[ec2-user@ip-172-31-45-254 amazon-cloudwatch-agent-test-fix-tests]$ go test ./test/metric_append_dimension/ -p 1 -timeout 1h -computeType=EC2 -v
=== RUN   TestMetricsAppendDimensionTestSuite
>>>> Starting MetricAppendDimensionTestSuite
=== RUN   TestMetricsAppendDimensionTestSuite/TestAllInSuite
2023/01/18 22:42:24 Running NoAppendDimension
2023/01/18 22:42:24 Starting agent using agent config file agent_configs/no_append_dimension.json
2023/01/18 22:42:24 Copy File agent_configs/no_append_dimension.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/18 22:42:24 File agent_configs/no_append_dimension.json abs path /home/ec2-user/amazon-cloudwatch-agent-test-fix-tests/test/metric_append_dimension/agent_configs/no_append_dimension.json
2023/01/18 22:42:24 File : agent_configs/no_append_dimension.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/18 22:42:24 Agent has started
2023/01/18 22:45:24 Agent has been running for : 3m0s
2023/01/18 22:45:25 Agent is stopped
2023/01/18 22:45:25 Delete file /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/18 22:45:25 Removed file: /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/18 22:45:25 host dim instruction {host {<nil>}}
2023/01/18 22:45:25 provider HostDimensionProvider returned dimension array {0xc0001c7500 0xc0001c7510 {}} dim name 0xc0001c7500 dim value 0xc0001c7510 key host <nil> value
2023/01/18 22:45:25 Result dim is : host, ip-172-31-45-254.us-west-2.compute.internal
2023/01/18 22:45:25 host dim instruction {cpu {0xc0001c74f0}}
2023/01/18 22:45:25 provider HostDimensionProvider returned dimension array {<nil> <nil> {}} dim name <nil> dim value <nil> key cpu 0xc0001c74f0 value
2023/01/18 22:45:25 provider LocalInstanceIdDimensionProvider returned dimension array {<nil> <nil> {}} dim name <nil> dim value <nil> key cpu 0xc0001c74f0 value
2023/01/18 22:45:25 provider CustomDimensionProvider returned dimension array {0xc0001c75a0 0xc0001c74f0 {}} dim name 0xc0001c75a0 dim value 0xc0001c74f0 key cpu 0xc0001c74f0 value
2023/01/18 22:45:25 Result dim is : cpu, cpu-total
2023/01/18 22:45:25 Metric query input dimensions : [{0xc0001c7500 0xc0001c7510 {}} {0xc0001c75a0 0xc0001c74f0 {}}]
2023/01/18 22:45:25 Metric data input is : {2023-01-18 22:45:25.039168963 +0000 UTC m=+180.442947327 [{0xc0001c7630 <nil> <nil> <nil> 0xc0001f8090 <nil> <nil> {}}] 2023-01-18 22:35:25.039168963 +0000 UTC m=-419.557052673 <nil> <nil> <nil>  {}}
2023/01/18 22:45:25 Metric values are : [8302.959999999963 8302.199999999953 8297.300000000047 8296.679999999935]
2023/01/18 22:45:25 metric values are [8302.959999999963 8302.199999999953 8297.300000000047 8296.679999999935]
2023/01/18 22:45:25 Values are all greater than or equal to zero for cpu_time_active
2023/01/18 22:45:25 >>>>>>>>>>>>>><<<<<<<<<<<<<<
2023/01/18 22:45:25 >>>>>>>>>>>>>>Successful<<<<<<<<<<<<<<
2023/01/18 22:45:25 ==============NoAppendDimension==============
2023/01/18 22:45:25 ==============Successful==============
cpu_time_active   Successful  
2023/01/18 22:45:25 ==============================
2023/01/18 22:45:25 >>>>>>>>>>>>>>><<<<<<<<<<<<<<<
>>>> Finished MetricAppendDimensionTestSuite
--- PASS: TestMetricsAppendDimensionTestSuite (180.48s)
    --- PASS: TestMetricsAppendDimensionTestSuite/TestAllInSuite (180.48s)
PASS
ok  	github.com/aws/amazon-cloudwatch-agent-test/test/metric_append_dimension	180.489s
```
