### PR TITLE
Fix Cloud Watch Logs Test

### DIFF
--- a/internal/common/agent_util_unix.go
+++ b/internal/common/agent_util_unix.go
@@ -19,6 +19,7 @@ const (
 	ConfigOutputPath = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
 	Namespace        = "CWAgent"
 	Host             = "host"
+	AgentLogFile     = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
 )
 
 func CopyFile(pathIn string, pathOut string) {
@@ -49,6 +50,19 @@ func DeleteFile(filePathAbsolute string) error {
 	}
 
 	log.Printf("Removed file: %s", filePathAbsolute)
+	return nil
+}
+
+func TouchFile(filePathAbsolute string) error {
+	log.Printf("Touch file %s", filePathAbsolute)
+	out, err := exec.Command("bash", "-c", "sudo touch "+filePathAbsolute).Output()
+
+	if err != nil {
+		log.Printf(fmt.Sprint(err) + string(out))
+		return err
+	}
+
+	log.Printf("Touched file: %s", filePathAbsolute)
 	return nil
 }
 

--- a/internal/common/agent_util_unix.go
+++ b/internal/common/agent_util_unix.go
@@ -19,7 +19,7 @@ const (
 	ConfigOutputPath = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
 	Namespace        = "CWAgent"
 	Host             = "host"
-	AgentLogFile     = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
+	AgentLogFile     = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
 )
 
 func CopyFile(pathIn string, pathOut string) {

--- a/test/cloudwatchlogs/publish_logs_test.go
+++ b/test/cloudwatchlogs/publish_logs_test.go
@@ -76,6 +76,8 @@ func TestWriteLogsToCloudWatch(t *testing.T) {
 
 	for _, param := range testParameters {
 		t.Run(param.testName, func(t *testing.T) {
+			common.DeleteFile(common.AgentLogFile)
+			common.TouchFile(common.AgentLogFile)
 			start := time.Now()
 
 			common.CopyFile(param.configPath, configOutputPath)
@@ -88,6 +90,12 @@ func TestWriteLogsToCloudWatch(t *testing.T) {
 			writeLogs(t, f, param.iterations)
 			time.Sleep(agentRuntime)
 			common.StopAgent()
+
+			agentLog, err := common.RunCommand(common.CatCommand + common.AgentLogFile)
+			if err != nil {
+				return
+			}
+			t.Logf("Agent logs %s", agentLog)
 
 			// check CWL to ensure we got the expected number of logs in the log stream
 			awsservice.ValidateLogs(t, instanceId, instanceId, param.numExpectedLogs, start)

--- a/test/cloudwatchlogs/resources/config_log.json
+++ b/test/cloudwatchlogs/resources/config_log.json
@@ -1,6 +1,7 @@
 {
   "agent": {
-    "run_as_user": "root"
+    "run_as_user": "root",
+    "debug": true
   },
   "logs": {
     "logs_collected": {

--- a/test/cloudwatchlogs/resources/config_log_filter.json
+++ b/test/cloudwatchlogs/resources/config_log_filter.json
@@ -1,6 +1,7 @@
 {
   "agent": {
-    "run_as_user": "root"
+    "run_as_user": "root",
+    "debug": true
   },
   "logs": {
     "logs_collected": {

--- a/test/cloudwatchlogs/resources/config_log_rotated.json
+++ b/test/cloudwatchlogs/resources/config_log_rotated.json
@@ -1,6 +1,7 @@
 {
   "agent": {
-    "run_as_user": "root"
+    "run_as_user": "root",
+    "debug": true
   },
   "logs": {
     "logs_collected": {

--- a/test/metric_value_benchmark/ecs_daemon_base_test_runner.go
+++ b/test/metric_value_benchmark/ecs_daemon_base_test_runner.go
@@ -7,6 +7,7 @@ package metric_value_benchmark
 
 import (
 	"fmt"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"os"
 	"time"
 
@@ -66,7 +67,7 @@ type BaseTestRunner struct {
 	DimensionFactory dimension.Factory
 }
 
-func (t *ECSTestRunner) Run(s *MetricBenchmarkTestSuite, e *environment.MetaData) {
+func (t *ECSTestRunner) Run(s test_runner.ITestSuite, e *environment.MetaData) {
 	testName := t.testRunner.getTestName()
 	fmt.Printf("Running %s", testName)
 	testGroupResult, err := t.runAgent(e)


### PR DESCRIPTION
# Description of the issue
Agent cannot read and publish the log file before it is being deleted. 
```
null_resource.integration_test (remote-exec):     cloudwatchlogs.go:72: Error occurred while getting log events: operation error CloudWatch Logs: GetLogEvents, https response error StatusCode: 400, RequestID: def1a3b4-b01c-414d-9199-b73c64261009, ResourceNotFoundException: The specified log group does not exist.
null_resource.integration_test (remote-exec): === RUN   TestWriteLogsToCloudWatch/Client-side_log_filtering
null_resource.integration_test (remote-exec): 2023/01/19 23:36:58 Copy File resources/config_log_filter.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
null_resource.integration_test (remote-exec): 2023/01/19 23:36:58 File resources/config_log_filter.json abs path /home/ubuntu/amazon-cloudwatch-agent-test/test/cloudwatchlogs/resources/config_log_filter.json
null_resource.integration_test (remote-exec): 2023/01/19 23:36:58 File : resources/config_log_filter.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
null_resource.integration_test (remote-exec): 2023/01/19 23:36:59 Agent has started
null_resource.integration_test: Still creating... [8m10s elapsed]
null_resource.integration_test: Still creating... [8m20s elapsed]
null_resource.integration_test (remote-exec): 2023/01/19 23:37:19 Writing 200 lines to /tmp/test.log
null_resource.integration_test: Still creating... [8m30s elapsed]
null_resource.integration_test: Still creating... [8m40s elapsed]
null_resource.integration_test (remote-exec): 2023/01/19 23:37:39 Agent is stopped
null_resource.integration_test (remote-exec): 2023/01/19 23:37:39 Checking i-0bb557e6a24e91311/i-0bb557e6a24e91311 since 2023-01-19T23:36:58Z for 100 expected logs
null_resource.integration_test: Still creating... [8m50s elapsed]
...
null_resource.integration_test: Still creating... [13m40s elapsed]
null_resource.integration_test (remote-exec):     cloudwatchlogs.go:72: Error occurred while getting log events: operation error CloudWatch Logs: GetLogEvents, https response error StatusCode: 400, RequestID: 96319239-9c0f-4a3d-8a00-06e324945433, ResourceNotFoundException: The specified log group does not exist.
null_resource.integration_test (remote-exec): --- FAIL: TestWriteLogsToCloudWatch (682.70s)
null_resource.integration_test (remote-exec):     --- FAIL: TestWriteLogsToCloudWatch/Happy_path (341.34s)
null_resource.integration_test (remote-exec):     --- FAIL: TestWriteLogsToCloudWatch/Client-side_log_filtering (341.31s)
```

# Description of changes
Do no delete log file until end of test run. This is fine since the agent has an offset on stop and start. 
```
[ec2-user@ip-172-31-45-254 amazon-cloudwatch-agent-test]$ go test ./test/cloudwatchlogs/ -p 1 -timeout 1h -computeType=EC2 -v
=== RUN   TestWriteLogsToCloudWatch
2023/01/19 23:28:37 Found instance id i-036192959ccf2fb39
=== RUN   TestWriteLogsToCloudWatch/Happy_path
2023/01/19 23:28:37 Copy File resources/config_log.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/19 23:28:37 File resources/config_log.json abs path /home/ec2-user/amazon-cloudwatch-agent-test/test/cloudwatchlogs/resources/config_log.json
2023/01/19 23:28:37 File : resources/config_log.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/19 23:28:37 Agent has started
2023/01/19 23:28:57 Writing 200 lines to /tmp/test.log
2023/01/19 23:29:17 Agent is stopped
2023/01/19 23:29:17 Checking i-036192959ccf2fb39/i-036192959ccf2fb39 since 2023-01-19T23:28:37Z for 200 expected logs
2023/01/19 23:29:18 Done paginating log events for i-036192959ccf2fb39/i-036192959ccf2fb39 and found 200 logs
=== RUN   TestWriteLogsToCloudWatch/Client-side_log_filtering
2023/01/19 23:29:18 Copy File resources/config_log_filter.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/19 23:29:18 File resources/config_log_filter.json abs path /home/ec2-user/amazon-cloudwatch-agent-test/test/cloudwatchlogs/resources/config_log_filter.json
2023/01/19 23:29:18 File : resources/config_log_filter.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/19 23:29:19 Agent has started
2023/01/19 23:29:39 Writing 200 lines to /tmp/test.log
2023/01/19 23:29:59 Agent is stopped
2023/01/19 23:29:59 Checking i-036192959ccf2fb39/i-036192959ccf2fb39 since 2023-01-19T23:29:18Z for 100 expected logs
2023/01/19 23:29:59 Done paginating log events for i-036192959ccf2fb39/i-036192959ccf2fb39 and found 100 logs
--- PASS: TestWriteLogsToCloudWatch (82.47s)
    --- PASS: TestWriteLogsToCloudWatch/Happy_path (41.43s)
    --- PASS: TestWriteLogsToCloudWatch/Client-side_log_filtering (40.98s)
=== RUN   TestRotatingLogsDoesNotSkipLines
2023/01/19 23:29:59 Found instance id i-036192959ccf2fb39
2023/01/19 23:29:59 Copy File resources/config_log_rotated.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/19 23:29:59 File resources/config_log_rotated.json abs path /home/ec2-user/amazon-cloudwatch-agent-test/test/cloudwatchlogs/resources/config_log_rotated.json
2023/01/19 23:29:59 File : resources/config_log_rotated.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/01/19 23:30:00 Agent has started
    publish_logs_test.go:122: Writing logs and rotating
2023/01/19 23:31:10 Agent is stopped
2023/01/19 23:31:10 Checking i-036192959ccf2fb39/i-036192959ccf2fb39Rotated since 2023-01-19T23:29:59Z for 3 expected logs
2023/01/19 23:31:10 Done paginating log events for i-036192959ccf2fb39/i-036192959ccf2fb39Rotated and found 3 logs
--- PASS: TestRotatingLogsDoesNotSkipLines (70.68s)
PASS
ok  	github.com/aws/amazon-cloudwatch-agent-test/test/cloudwatchlogs	153.146s
```

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._
