### PR TITLE
Fix Compile Error For ecs_daemon_base_test_runner

### DIFF
--- a/test/metric_value_benchmark/ecs_daemon_base_test_runner.go
+++ b/test/metric_value_benchmark/ecs_daemon_base_test_runner.go
@@ -7,6 +7,7 @@ package metric_value_benchmark
 
 import (
 	"fmt"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"os"
 	"time"
 
@@ -66,7 +67,7 @@ type BaseTestRunner struct {
 	DimensionFactory dimension.Factory
 }
 
-func (t *ECSTestRunner) Run(s *MetricBenchmarkTestSuite, e *environment.MetaData) {
+func (t *ECSTestRunner) Run(s test_runner.ITestSuite, e *environment.MetaData) {
 	testName := t.testRunner.getTestName()
 	fmt.Printf("Running %s", testName)
 	testGroupResult, err := t.runAgent(e)


### PR DESCRIPTION
# Description of the issue
Compile error for ecs_daemon_base_test_runner.

# Description of changes
Use compilable test suite interface. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
See no compilation errors. 
