### PR TITLE
CA Bundle Localstack Config In Test Instead Of Terraform EC2

### DIFF
--- a/environment/MetaData.go
+++ b/environment/MetaData.go
@@ -22,6 +22,8 @@ type MetaData struct {
 	CwagentConfigSsmParamName string
 	EcsServiceName            string
 	Bucket                    string
+	CwaCommitSha              string
+	CaCertPath                string
 }
 
 type MetaDataStrings struct {
@@ -32,13 +34,21 @@ type MetaDataStrings struct {
 	CwagentConfigSsmParamName string
 	EcsServiceName            string
 	Bucket                    string
+	CwaCommitSha              string
+	CaCertPath                string
 }
 
 func registerComputeType(dataString *MetaDataStrings) {
 	flag.StringVar(&(dataString.ComputeType), "computeType", "", "EC2/ECS/EKS")
 }
 func registerBucket(dataString *MetaDataStrings) {
-	flag.StringVar(&(dataString.Bucket), "bucket", "", "cloudwatch-agent-integration-bucket")
+	flag.StringVar(&(dataString.Bucket), "bucket", "", "s3 bucket ex cloudwatch-agent-integration-bucket")
+}
+func registerCwaCommitSha(dataString *MetaDataStrings) {
+	flag.StringVar(&(dataString.CwaCommitSha), "cwaCommitSha", "", "agent commit hash ex 0b81ac79ee13f5248b860bbda3afc4ee57f5b8b6")
+}
+func registerCaCertPath(dataString *MetaDataStrings) {
+	flag.StringVar(&(dataString.CaCertPath), "caCertPath", "", "ec2 path to crts ex /etc/ssl/certs/ca-certificates.crt")
 }
 func registerECSData(dataString *MetaDataStrings) {
 	flag.StringVar(&(dataString.EcsLaunchType), "ecsLaunchType", "", "EC2 or Fargate")
@@ -88,6 +98,8 @@ func RegisterEnvironmentMetaDataFlags(metaDataStrings *MetaDataStrings) *MetaDat
 	registerComputeType(metaDataStrings)
 	registerECSData(metaDataStrings)
 	registerBucket(metaDataStrings)
+	registerCwaCommitSha(metaDataStrings)
+	registerCaCertPath(metaDataStrings)
 	return metaDataStrings
 }
 
@@ -96,6 +108,8 @@ func GetEnvironmentMetaData(data *MetaDataStrings) *MetaData {
 	metaData = fillComputeType(metaData, data)
 	metaData = fillECSData(metaData, data)
 	metaData.Bucket = data.Bucket
+	metaData.CwaCommitSha = data.CwaCommitSha
+	metaData.CaCertPath = data.CaCertPath
 
 	return metaData
 }

--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -101,13 +101,6 @@ resource "null_resource" "integration_test" {
       "aws s3 cp s3://${local.binary_uri} .",
       "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
       var.install_agent,
-      "echo get ssl pem for localstack and export local stack host name",
-      "cd ~/amazon-cloudwatch-agent-test/localstack/ls_tmp",
-      "aws s3 cp s3://${var.s3_bucket}/integration-test/ls_tmp/${var.cwa_github_sha} . --recursive",
-      "cat ${var.ca_cert_path} > original.pem",
-      "cat original.pem snakeoil.pem > combine.pem",
-      "sudo cp original.pem /opt/aws/amazon-cloudwatch-agent/original.pem",
-      "sudo cp combine.pem /opt/aws/amazon-cloudwatch-agent/combine.pem",
     ]
 
     connection {
@@ -128,7 +121,7 @@ resource "null_resource" "integration_test" {
       "echo run integration test",
       "cd ~/amazon-cloudwatch-agent-test",
       "echo run sanity test && go test ./test/sanity -p 1 -v",
-      "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -v"
+      "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -v"
     ]
     connection {
       type        = "ssh"

--- a/test/ca_bundle/ca_bundle_test.go
+++ b/test/ca_bundle/ca_bundle_test.go
@@ -4,8 +4,14 @@
 package ca_bundle
 
 import (
+	"context"
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"log"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -14,14 +20,23 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-test/internal/common"
 )
 
-const configOutputPath = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
-const commonConfigOutputPath = "/opt/aws/amazon-cloudwatch-agent/etc/common-config.toml"
-const configJSON = "/config.json"
-const commonConfigTOML = "/common-config.toml"
-const targetString = "x509: certificate signed by unknown authority"
+const (
+	configOutputPath       = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
+	commonConfigOutputPath = "/opt/aws/amazon-cloudwatch-agent/etc/common-config.toml"
+	configJSON             = "/config.json"
+	commonConfigTOML       = "/common-config.toml"
+	targetString           = "x509: certificate signed by unknown authority"
 
-// Let the agent run for 30 seconds. This will give agent enough time to call server
-const agentRuntime = 30 * time.Second
+	// Let the agent run for 30 seconds. This will give agent enough time to call server
+	agentRuntime         = 30 * time.Second
+	localstackS3Key      = "integration-test/ls_tmp/%s"
+	keyDelimiter         = "/"
+	localstackConfigPath = "../../localstack/ls_tmp/"
+	originalPem          = "original.pem"
+	combinePem           = "combine.pem"
+	snakeOilPem          = "snakeoil.pem"
+	tmpDirectory         = "/tmp/"
+)
 
 type input struct {
 	findTarget bool
@@ -37,6 +52,8 @@ func init() {
 // Must run this test with parallel 1 since this will fail if more than one test is running at the same time
 // This test uses a pem file created for the local stack endpoint to be able to connect via ssl
 func TestBundle(t *testing.T) {
+	metadata := environment.GetEnvironmentMetaData(envMetaDataStrings)
+	setUpLocalstackConfig(metadata)
 
 	parameters := []input{
 		//Use the system pem ca bundle  + local stack pem file ssl should connect thus target string not found
@@ -74,4 +91,67 @@ func outputLogContainsTarget(output string) bool {
 	contains := strings.Contains(output, targetString)
 	log.Printf("Log file contains target string %t", contains)
 	return contains
+}
+
+// Get localstack pem files
+func setUpLocalstackConfig(metadata *environment.MetaData) {
+	// Download localstack config files
+	prefix := fmt.Sprintf(localstackS3Key, metadata.CwaCommitSha)
+	cxt := context.Background()
+	cfg, err := config.LoadDefaultConfig(cxt)
+	if err != nil {
+		log.Fatalf("Can't get config error: %v", err)
+	}
+	client := s3.NewFromConfig(cfg)
+	listObjectsInput := &s3.ListObjectsV2Input{
+		Bucket: aws.String(metadata.Bucket),
+		Prefix: aws.String(prefix),
+	}
+	listObjectsOutput, err := client.ListObjectsV2(cxt, listObjectsInput)
+	if err != nil {
+		log.Fatalf("Got error retrieving list of objects %v", err)
+	}
+	downloader := manager.NewDownloader(client)
+	for _, object := range listObjectsOutput.Contents {
+		key := *object.Key
+		log.Printf("Download object %s", key)
+		keySplit := strings.Split(key, keyDelimiter)
+		fileName := keySplit[len(keySplit)-1]
+		file, err := os.Create(localstackConfigPath + fileName)
+		if err != nil {
+			log.Println(err)
+		}
+		defer file.Close()
+		_, err = downloader.Download(cxt, file, &s3.GetObjectInput{
+			Bucket: aws.String(metadata.Bucket),
+			Key:    aws.String(key),
+		})
+		if err != nil {
+			log.Printf("Error downing file %s error %v", key, err)
+		}
+	}
+
+	// generate localstack crt files
+	writeFile(localstackConfigPath+originalPem, readFile(metadata.CaCertPath))
+	writeFile(localstackConfigPath+combinePem, readFile(metadata.CaCertPath))
+	writeFile(localstackConfigPath+combinePem, readFile(localstackConfigPath+snakeOilPem))
+
+	// copy crt files to agent directory
+	writeFile(tmpDirectory+originalPem, readFile(localstackConfigPath+originalPem))
+	writeFile(tmpDirectory+combinePem, readFile(localstackConfigPath+combinePem))
+}
+
+func readFile(path string) []byte {
+	file, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("Failed to read file %s error %v", path, err)
+	}
+	return file
+}
+
+func writeFile(path string, output []byte) {
+	err := os.WriteFile(path, output, 0644)
+	if err != nil {
+		log.Fatalf("Error writting file %s, error %v,", path, err)
+	}
 }

--- a/test/ca_bundle/resources/integration/ssl/with/combine/bundle/common-config.toml
+++ b/test/ca_bundle/resources/integration/ssl/with/combine/bundle/common-config.toml
@@ -1,3 +1,3 @@
 
  [ssl]
-    ca_bundle_path = "/opt/aws/amazon-cloudwatch-agent/combine.pem"
+    ca_bundle_path = "/tmp/combine.pem"

--- a/test/ca_bundle/resources/integration/ssl/with/original/bundle/common-config.toml
+++ b/test/ca_bundle/resources/integration/ssl/with/original/bundle/common-config.toml
@@ -1,3 +1,3 @@
 
  [ssl]
-    ca_bundle_path = "/opt/aws/amazon-cloudwatch-agent/original.pem"
+    ca_bundle_path = "/tmp/original.pem"

--- a/test/ca_bundle/resources/integration/ssl/without/bundle/common-config.toml
+++ b/test/ca_bundle/resources/integration/ssl/without/bundle/common-config.toml
@@ -1,3 +1,3 @@
 
 # [ssl]
-#    ca_bundle_path = "/opt/aws/amazon-cloudwatch-agent/combine.pem"
+#    ca_bundle_path = "/tmp/combine.pem"

--- a/test/ca_bundle/resources/integration/ssl/without/bundle/http/common-config.toml
+++ b/test/ca_bundle/resources/integration/ssl/without/bundle/http/common-config.toml
@@ -1,3 +1,3 @@
 
 # [ssl]
-#    ca_bundle_path = "/opt/aws/amazon-cloudwatch-agent/combine.pem"
+#    ca_bundle_path = "/tmp/combine.pem"


### PR DESCRIPTION
# Description of the issue
Ca bundle config is only required for ca bundle test.

# Description of changes
Move CA Bundle Localstack Config Into Test Instead Of Terraform EC2

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
go test ./test/ca_bundle/ -p 1 -timeout 1h -computeType=EC2 -bucket=private-cloudwatch-agent-integration-test -cwaCommitSha=adbf82d787639641ddabf969e6c119072efc71a3 -caCertPath=/etc/ssl/certs/ca-bundle.crt -v
