### PR TITLE
Reduce metric_value_benchmark Runtime

### DIFF
--- a/test/metric/metric_value_query.go
+++ b/test/metric/metric_value_query.go
@@ -21,7 +21,7 @@ import (
 type MetricValueFetcher struct {
 }
 
-func (n *MetricValueFetcher) Fetch(namespace, metricName string, metricSpecificDimensions []types.Dimension, stat Statistics) (MetricValues, error) {
+func (n *MetricValueFetcher) Fetch(namespace, metricName string, metricSpecificDimensions []types.Dimension, stat Statistics, metricQueryPeriod int32) (MetricValues, error) {
 	dimensions := metricSpecificDimensions
 	log.Printf("Metric query input dimensions : %s", fmt.Sprint(dimensions))
 
@@ -31,7 +31,6 @@ func (n *MetricValueFetcher) Fetch(namespace, metricName string, metricSpecificD
 		Dimensions: dimensions,
 	}
 
-	metricQueryPeriod := int32(60)
 	metricDataQueries := []types.MetricDataQuery{
 		{
 			MetricStat: &types.MetricStat{

--- a/test/metric_dimension/agent_configs/global_append_dimension.json
+++ b/test/metric_dimension/agent_configs/global_append_dimension.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "metrics_collection_interval": 60,
+    "metrics_collection_interval": 15,
     "run_as_user": "root",
     "debug": true,
     "logfile": ""
@@ -18,6 +18,7 @@
       "cpu": {
         "measurement": ["time_active"]
       }
-    }
+    },
+    "force_flush_interval": 5
   }
 }

--- a/test/metric_dimension/agent_configs/no_append_dimension.json
+++ b/test/metric_dimension/agent_configs/no_append_dimension.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "metrics_collection_interval": 60,
+    "metrics_collection_interval": 15,
     "run_as_user": "root",
     "debug": true,
     "logfile": ""
@@ -54,6 +54,7 @@
           ]
         }
       ]
-    }
+    },
+    "force_flush_interval": 5
   }
 }

--- a/test/metric_dimension/agent_configs/one_aggregate_dimension.json
+++ b/test/metric_dimension/agent_configs/one_aggregate_dimension.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "metrics_collection_interval": 60,
+    "metrics_collection_interval": 15,
     "run_as_user": "root",
     "debug": true,
     "logfile": ""
@@ -18,6 +18,7 @@
           "time_active", "time_guest"
         ]
       }
-    }
+    },
+    "force_flush_interval": 5
   }
 }

--- a/test/metric_dimension/aggregate_dimension_test.go
+++ b/test/metric_dimension/aggregate_dimension_test.go
@@ -57,7 +57,7 @@ func (t *OneAggregateDimensionTestRunner) validateNoAppendDimensionMetric(metric
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch("MetricAggregateDimensionTest", metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch("MetricAggregateDimensionTest", metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	log.Printf("metric values are %v", values)
 	if err != nil {
 		return testResult

--- a/test/metric_dimension/global_append_dimensions_test.go
+++ b/test/metric_dimension/global_append_dimensions_test.go
@@ -75,7 +75,7 @@ func (t *GlobalAppendDimensionsTestRunner) validateGlobalAppendDimensionMetric(m
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch("MetricGlobalAppendDimensionTest", metricName, expDims, metric.AVERAGE)
+	values, err := fetcher.Fetch("MetricGlobalAppendDimensionTest", metricName, expDims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	log.Printf("metric values are %v", values)
 	if err != nil {
 		return testResult
@@ -85,7 +85,7 @@ func (t *GlobalAppendDimensionsTestRunner) validateGlobalAppendDimensionMetric(m
 		return testResult
 	}
 
-	// this is making sure once dimensions in "append_dimensions" are tagged, the agent does drop the 
+	// this is making sure once dimensions in "append_dimensions" are tagged, the agent does drop the
 	// host dimension. We should not see the same metrics with host dimension anymore
 	dropDims, failed := t.DimensionFactory.GetDimensions([]dimension.Instruction{
 		{
@@ -102,7 +102,7 @@ func (t *GlobalAppendDimensionsTestRunner) validateGlobalAppendDimensionMetric(m
 		return testResult
 	}
 
-	values, err = fetcher.Fetch("MetricGlobalAppendDimensionTest", metricName, dropDims, metric.AVERAGE)
+	values, err = fetcher.Fetch("MetricGlobalAppendDimensionTest", metricName, dropDims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	if err != nil || len(values) != 0 {
 		return testResult
 	}

--- a/test/metric_dimension/no_append_dimensions_test.go
+++ b/test/metric_dimension/no_append_dimensions_test.go
@@ -67,7 +67,7 @@ func (t *NoAppendDimensionTestRunner) validateNoAppendDimensionMetric(metricName
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch("MetricAppendDimensionTest", metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch("MetricAppendDimensionTest", metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	log.Printf("metric values are %v", values)
 	if err != nil {
 		return testResult

--- a/test/metric_value_benchmark/agent_configs/collectd_config.json
+++ b/test/metric_value_benchmark/agent_configs/collectd_config.json
@@ -1,6 +1,6 @@
 {
     "agent": {
-      "metrics_collection_interval": 60,
+      "metrics_collection_interval": 15,
       "run_as_user": "root",
       "debug": true,
       "logfile": ""
@@ -14,6 +14,7 @@
         "collectd": {
           "collectd_security_level": "none"
         }
-      }
+      },
+      "force_flush_interval": 5
     }
   }

--- a/test/metric_value_benchmark/agent_configs/container_insights.json
+++ b/test/metric_value_benchmark/agent_configs/container_insights.json
@@ -1,11 +1,12 @@
 {
   "agent": {
-    "region": "us-west-2"
+    "region": "us-west-2",
+    "metrics_collection_interval": 15
   },
   "logs": {
     "metrics_collected": {
       "ecs": {
-        "metrics_collection_interval": 30
+        "metrics_collection_interval": 15
       }
     },
     "force_flush_interval": 5

--- a/test/metric_value_benchmark/agent_configs/cpu_config.json
+++ b/test/metric_value_benchmark/agent_configs/cpu_config.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "metrics_collection_interval": 60,
+    "metrics_collection_interval": 15,
     "run_as_user": "root",
     "debug": true,
     "logfile": ""
@@ -18,8 +18,9 @@
           "usage_active", "usage_guest", "usage_guest_nice", "usage_idle", "usage_iowait", "usage_irq",
           "usage_nice", "usage_softirq", "usage_steal", "usage_system", "usage_user"
         ],
-        "metrics_collection_interval": 60
+        "metrics_collection_interval": 15
       }
-    }
+    },
+    "force_flush_interval": 5
   }
 }

--- a/test/metric_value_benchmark/agent_configs/disk_config.json
+++ b/test/metric_value_benchmark/agent_configs/disk_config.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "metrics_collection_interval": 60,
+    "metrics_collection_interval": 15,
     "run_as_user": "root",
     "debug": true,
     "logfile": ""
@@ -31,6 +31,7 @@
         ],
         "drop_device": true
       }
-    }
+    },
+    "force_flush_interval": 5
   }
 }

--- a/test/metric_value_benchmark/agent_configs/diskio_config.json
+++ b/test/metric_value_benchmark/agent_configs/diskio_config.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "metrics_collection_interval": 60,
+    "metrics_collection_interval": 15,
     "run_as_user": "root",
     "debug": true,
     "logfile": ""
@@ -18,8 +18,9 @@
         "measurement": [
           "iops_in_progress", "io_time", "reads", "read_bytes", "read_time", "writes", "write_bytes", "write_time"
         ],
-        "metrics_collection_interval": 60
+        "metrics_collection_interval": 15
       }
-    }
+    },
+    "force_flush_interval": 5
   }
 }

--- a/test/metric_value_benchmark/agent_configs/emf_config.json
+++ b/test/metric_value_benchmark/agent_configs/emf_config.json
@@ -1,6 +1,6 @@
 {
     "agent": {
-      "metrics_collection_interval": 60,
+      "metrics_collection_interval": 15,
       "run_as_user": "root",
       "debug": true,
       "logfile": ""
@@ -8,6 +8,7 @@
     "logs": {
         "metrics_collected": {
             "emf": { }
-        }
+        },
+      "force_flush_interval": 5
     }
   }

--- a/test/metric_value_benchmark/agent_configs/mem_config.json
+++ b/test/metric_value_benchmark/agent_configs/mem_config.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "metrics_collection_interval": 60,
+    "metrics_collection_interval": 15,
     "run_as_user": "root",
     "debug": true,
     "logfile": ""
@@ -16,8 +16,9 @@
           "active", "available", "available_percent", "buffered", "cached", "free", "inactive", "total",
           "used", "used_percent"
         ],
-        "metrics_collection_interval": 60
+        "metrics_collection_interval": 15
       }
-    }
+    },
+    "force_flush_interval": 5
   }
 }

--- a/test/metric_value_benchmark/agent_configs/net_config.json
+++ b/test/metric_value_benchmark/agent_configs/net_config.json
@@ -1,6 +1,6 @@
 {
     "agent": {
-      "metrics_collection_interval": 60,
+      "metrics_collection_interval": 15,
       "run_as_user": "root",
       "debug": true,
       "logfile": ""
@@ -18,8 +18,9 @@
             "resources": [
               "*"
             ],
-            "metrics_collection_interval": 60
+            "metrics_collection_interval": 15
           }
-      }
+      },
+      "force_flush_interval": 5
     }
   }

--- a/test/metric_value_benchmark/agent_configs/netstat_config.json
+++ b/test/metric_value_benchmark/agent_configs/netstat_config.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "metrics_collection_interval": 60,
+    "metrics_collection_interval": 15,
     "run_as_user": "root",
     "debug": true,
     "logfile": ""
@@ -27,8 +27,9 @@
           "tcp_time_wait",
           "udp_socket"
         ],
-        "metrics_collection_interval": 60
+        "metrics_collection_interval": 15
       }
-    }
+    },
+    "force_flush_interval": 5
   }
 }

--- a/test/metric_value_benchmark/agent_configs/processes_config.json
+++ b/test/metric_value_benchmark/agent_configs/processes_config.json
@@ -1,6 +1,6 @@
 {
     "agent": {
-      "metrics_collection_interval": 60,
+      "metrics_collection_interval": 15,
       "run_as_user": "root",
       "debug": true,
       "logfile": ""
@@ -15,8 +15,9 @@
             "measurement": [
               "blocked","running","sleeping","stopped","total","dead","idle","paging","total_threads","zombies"
             ],
-            "metrics_collection_interval": 60
+            "metrics_collection_interval": 15
           }
-      }
+      },
+      "force_flush_interval": 5
     }
   }

--- a/test/metric_value_benchmark/agent_configs/procstat_config.json
+++ b/test/metric_value_benchmark/agent_configs/procstat_config.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "metrics_collection_interval": 60,
+    "metrics_collection_interval": 15,
     "run_as_user": "root",
     "debug": true,
     "logfile": ""
@@ -25,9 +25,10 @@
             "memory_swap",
             "memory_vms"
           ],
-          "metrics_collection_interval": 60
+          "metrics_collection_interval": 15
         }
       ]
-    }
+    },
+    "force_flush_interval": 5
   }
 }

--- a/test/metric_value_benchmark/agent_configs/prometheus_config.json
+++ b/test/metric_value_benchmark/agent_configs/prometheus_config.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "metrics_collection_interval": 60,
+    "metrics_collection_interval": 15,
     "run_as_user": "root",
     "debug": true,
     "logfile": ""
@@ -34,6 +34,7 @@
           ]
         }
       }
-    }
+    },
+    "force_flush_interval": 5
   }
 }

--- a/test/metric_value_benchmark/agent_configs/statsd_config.json
+++ b/test/metric_value_benchmark/agent_configs/statsd_config.json
@@ -1,6 +1,6 @@
 {
     "agent": {
-      "metrics_collection_interval": 60,
+      "metrics_collection_interval": 15,
       "run_as_user": "root",
       "debug": true,
       "logfile": ""
@@ -12,10 +12,11 @@
       },
       "metrics_collected": {
         "statsd": {
-            "metrics_aggregation_interval": 60,
-            "metrics_collection_interval": 60,
+            "metrics_aggregation_interval": 15,
+            "metrics_collection_interval": 15,
             "service_address": ":8125"
         }
-      }
+      },
+      "force_flush_interval": 5
     }
   }

--- a/test/metric_value_benchmark/agent_configs/swap_config.json
+++ b/test/metric_value_benchmark/agent_configs/swap_config.json
@@ -1,6 +1,6 @@
 {
     "agent": {
-        "metrics_collection_interval": 60,
+        "metrics_collection_interval": 15,
         "run_as_user": "root",
         "debug": true,
         "logfile": ""
@@ -18,6 +18,7 @@
                     "used_percent"
                 ]
             }
-        }
+        },
+        "force_flush_interval": 5
     }
 }

--- a/test/metric_value_benchmark/collectd_test.go
+++ b/test/metric_value_benchmark/collectd_test.go
@@ -96,7 +96,7 @@ func (t *CollectDTestRunner) validateCollectDMetric(metricName string) status.Te
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	if err != nil {
 		return testResult
 	}

--- a/test/metric_value_benchmark/container_insights_test.go
+++ b/test/metric_value_benchmark/container_insights_test.go
@@ -77,7 +77,7 @@ func (t *ContainerInsightsTestRunner) validateContainerInsightsMetrics(metricNam
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch("ECS/ContainerInsights", metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch("ECS/ContainerInsights", metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	if err != nil {
 		return testResult
 	}

--- a/test/metric_value_benchmark/cpu_test.go
+++ b/test/metric_value_benchmark/cpu_test.go
@@ -71,7 +71,7 @@ func (t *CPUTestRunner) validateCpuMetric(metricName string) status.TestResult {
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	log.Printf("metric values are %v", values)
 	if err != nil {
 		return testResult

--- a/test/metric_value_benchmark/disk_test.go
+++ b/test/metric_value_benchmark/disk_test.go
@@ -70,7 +70,7 @@ func (t *DiskTestRunner) ValidateDiskMetric(metricName string) status.TestResult
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 
 	log.Printf("metric values are %v", values)
 	if err != nil {

--- a/test/metric_value_benchmark/diskio_test.go
+++ b/test/metric_value_benchmark/diskio_test.go
@@ -68,7 +68,7 @@ func (m *DiskIOTestRunner) validateDiskMetric(metricName string) status.TestResu
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	if err != nil {
 		return testResult
 	}

--- a/test/metric_value_benchmark/emf_test.go
+++ b/test/metric_value_benchmark/emf_test.go
@@ -85,7 +85,7 @@ func (t *EMFTestRunner) validateEMFMetric(metricName string) status.TestResult {
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	if err != nil {
 		return testResult
 	}

--- a/test/metric_value_benchmark/mem_test.go
+++ b/test/metric_value_benchmark/mem_test.go
@@ -64,7 +64,7 @@ func (m *MemTestRunner) validateMemMetric(metricName string) status.TestResult {
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	if err != nil {
 		return testResult
 	}

--- a/test/metric_value_benchmark/net_test.go
+++ b/test/metric_value_benchmark/net_test.go
@@ -69,7 +69,7 @@ func (m *NetTestRunner) validateNetMetric(metricName string) status.TestResult {
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 
 	if err != nil {
 		return testResult

--- a/test/metric_value_benchmark/netstat_test.go
+++ b/test/metric_value_benchmark/netstat_test.go
@@ -76,7 +76,7 @@ func (t *NetStatTestRunner) validateNetStatMetric(metricName string) status.Test
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 
 	log.Printf("metric values are %v", values)
 	if err != nil {

--- a/test/metric_value_benchmark/processes_test.go
+++ b/test/metric_value_benchmark/processes_test.go
@@ -63,7 +63,7 @@ func (m *ProcessesTestRunner) validateProcessesMetric(metricName string) status.
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	if err != nil {
 		return testResult
 	}

--- a/test/metric_value_benchmark/procstat_test.go
+++ b/test/metric_value_benchmark/procstat_test.go
@@ -77,7 +77,7 @@ func (m *ProcStatTestRunner) validateProcStatMetric(metricName string) status.Te
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	if err != nil {
 		return testResult
 	}

--- a/test/metric_value_benchmark/prometheus_test.go
+++ b/test/metric_value_benchmark/prometheus_test.go
@@ -148,7 +148,7 @@ func (t *PrometheusTestRunner) validatePrometheusMetric(metricName string) statu
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	if err != nil {
 		return testResult
 	}

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -88,7 +88,7 @@ func (t *StatsdTestRunner) validateStatsdMetric(metricName string) status.TestRe
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	if err != nil {
 		return testResult
 	}

--- a/test/metric_value_benchmark/swap_test.go
+++ b/test/metric_value_benchmark/swap_test.go
@@ -66,7 +66,7 @@ func (t *SwapTestRunner) validateSwapMetric(metricName string) status.TestResult
 	}
 
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	log.Printf("metric values are %v", values)
 	if err != nil {
 		return testResult

--- a/test/test_runner/base_test_runner.go
+++ b/test/test_runner/base_test_runner.go
@@ -17,10 +17,11 @@ import (
 )
 
 const (
-	configOutputPath     = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
-	agentConfigDirectory = "agent_configs"
-	extraConfigDirectory = "extra_configs"
-	MinimumAgentRuntime  = 3 * time.Minute
+	configOutputPath         = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
+	agentConfigDirectory     = "agent_configs"
+	extraConfigDirectory     = "extra_configs"
+	MinimumAgentRuntime      = 1 * time.Minute
+	HighResolutionStatPeriod = 30
 )
 
 type ITestRunner interface {


### PR DESCRIPTION
# Description of the issue
metric_value_benchmark test takes too long

# Description of changes
Reduce the collection interval so we publish more than once per minute, so we can reduce runtime per test to 1 minute. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
testing running gh actions in the private repo. Can't post link bc it is private. 
