### PR TITLE
Fix Localstack Config File

### DIFF
--- a/test/ca_bundle/ca_bundle_test.go
+++ b/test/ca_bundle/ca_bundle_test.go
@@ -55,6 +55,7 @@ func init() {
 // This test uses a pem file created for the local stack endpoint to be able to connect via ssl
 func TestBundle(t *testing.T) {
 	metadata := environment.GetEnvironmentMetaData(envMetaDataStrings)
+	t.Logf("metadata required for test cwa sha %s bucket %s ca cert path %s", metadata.CwaCommitSha, metadata.Bucket, metadata.CaCertPath)
 	setUpLocalstackConfig(metadata)
 
 	parameters := []input{
@@ -73,6 +74,7 @@ func TestBundle(t *testing.T) {
 		log.Printf("resource file location %s find target %t", parameter.dataInput, parameter.findTarget)
 		t.Run(fmt.Sprintf("resource file location %s find target %t", parameter.dataInput, parameter.findTarget), func(t *testing.T) {
 			common.ReplaceLocalStackHostName(parameter.dataInput + configJSON)
+			t.Logf("config file after localstack host replace %s", string(readFile(parameter.dataInput+configJSON)))
 			common.CopyFile(parameter.dataInput+configJSON, configOutputPath)
 			common.CopyFile(parameter.dataInput+commonConfigTOML, commonConfigOutputPath)
 			common.StartAgent(configOutputPath, true)

--- a/test/ca_bundle/resources/integration/ssl/with/combine/bundle/config.json
+++ b/test/ca_bundle/resources/integration/ssl/with/combine/bundle/config.json
@@ -6,7 +6,7 @@
     "logfile": ""
   },
   "metrics": {
-    "endpoint_override": "https://:4566",
+    "endpoint_override": "https://localhost.localstack.cloud:4566",
     "metrics_collected": {
       "disk": {
         "measurement": [


### PR DESCRIPTION
# Description of the issue
Ca bundle test is failing due to wrong configuration. 

# Description of changes
Fix config and add more logging

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/private-amazon-cloudwatch-agent-staging/actions/runs/4127740089/jobs/7131675206
