### PR TITLE
Improve "aggregation_dimensions" testing

### DIFF
--- a/test/metric/dimension/provider.go
+++ b/test/metric/dimension/provider.go
@@ -65,7 +65,9 @@ func (f *Factory) GetDimensions(instructions []Instruction) ([]types.Dimension, 
 			log.Printf("Result dim is : %s, %s", *dim.Name, *dim.Value)
 		} else {
 			unfulfilledInstructions = append(unfulfilledInstructions, instruction)
-			log.Printf("unfulfilled dim is : %s, %s", *dim.Name, *dim.Value)
+			if dim.Name != nil && dim.Value != nil {
+				log.Printf("unfulfilled dim is : %s, %s", *dim.Name, *dim.Value)
+			}
 		}
 	}
 

--- a/test/metric/dimension/provider.go
+++ b/test/metric/dimension/provider.go
@@ -6,9 +6,10 @@
 package dimension
 
 import (
+	"log"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
-	"log"
 )
 
 type ExpectedDimensionValue struct {
@@ -76,6 +77,7 @@ func (f *Factory) executeInstruction(instruction Instruction) types.Dimension {
 		dim := provider.GetDimension(instruction)
 		log.Printf("instruction %v provider %s returned dimension %v", instruction, provider.Name(), dim)
 		if (dim != types.Dimension{}) {
+			log.Printf("dim %v, %v", *dim.Name, *dim.Value)
 			return dim
 		}
 	}

--- a/test/metric/dimension/provider.go
+++ b/test/metric/dimension/provider.go
@@ -79,7 +79,6 @@ func (f *Factory) executeInstruction(instruction Instruction) types.Dimension {
 		dim := provider.GetDimension(instruction)
 		log.Printf("instruction %v provider %s returned dimension %v", instruction, provider.Name(), dim)
 		if (dim != types.Dimension{}) {
-			log.Printf("dim %v, %v", *dim.Name, *dim.Value)
 			return dim
 		}
 	}

--- a/test/metric/metric_value_query.go
+++ b/test/metric/metric_value_query.go
@@ -21,10 +21,19 @@ import (
 type MetricValueFetcher struct {
 }
 
+func logDimensions(dims []types.Dimension) {
+	log.Printf("\tDimensions:\n")
+	for _, d := range dims {
+		if d.Name != nil && d.Value != nil {
+			log.Printf("\t\tDim(name=%q, val=%q\n", *d.Name, *d.Value)
+		}
+	}
+}
+
 func (n *MetricValueFetcher) Fetch(namespace, metricName string, metricSpecificDimensions []types.Dimension, stat Statistics, metricQueryPeriod int32) (MetricValues, error) {
 	dimensions := metricSpecificDimensions
-	log.Printf("Metric query input dimensions : %s", fmt.Sprint(dimensions))
-
+	log.Println("Metric query input dimensions")
+	logDimensions(dimensions)
 	metricToFetch := types.Metric{
 		Namespace:  aws.String(namespace),
 		MetricName: aws.String(metricName),

--- a/test/metric_dimension/agent_configs/aggregation_dimensions.json
+++ b/test/metric_dimension/agent_configs/aggregation_dimensions.json
@@ -1,0 +1,31 @@
+{
+  "metrics": {
+    "namespace": "TestAggregationDimensions",
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}",
+      "InstanceType": "${aws:InstanceType}"
+    },
+    "aggregation_dimensions": [
+      [],
+      [
+        "InstanceId"
+      ],
+      [
+        "InstanceId",
+        "InstanceType"
+      ],
+      [
+        "foo",
+        "bar",
+        "InstanceId"
+      ]
+    ],
+    "metrics_collected": {
+      "mem": {
+        "measurement": [
+          "mem_used_percent"
+        ]
+      }
+    }
+  }
+}

--- a/test/metric_dimension/agent_configs/aggregation_dimensions.json
+++ b/test/metric_dimension/agent_configs/aggregation_dimensions.json
@@ -1,5 +1,9 @@
 {
+  "agent": {
+    "metrics_collection_interval": 10
+  },
   "metrics": {
+    "force_flush_interval": 10,
     "namespace": "TestAggregationDimensions",
     "append_dimensions": {
       "InstanceId": "${aws:InstanceId}",

--- a/test/metric_dimension/agent_configs/aggregation_dimensions.json
+++ b/test/metric_dimension/agent_configs/aggregation_dimensions.json
@@ -21,7 +21,7 @@
       [
         "foo",
         "bar",
-        "InstanceId"
+        "InstanceType"
       ]
     ],
     "metrics_collected": {

--- a/test/metric_dimension/agent_configs/aggregation_dimensions.json
+++ b/test/metric_dimension/agent_configs/aggregation_dimensions.json
@@ -1,35 +1,46 @@
 {
-  "agent": {
-    "metrics_collection_interval": 10
-  },
-  "metrics": {
-    "force_flush_interval": 10,
-    "namespace": "TestAggregationDimensions",
-    "append_dimensions": {
-      "InstanceId": "${aws:InstanceId}",
-      "InstanceType": "${aws:InstanceType}"
+    "agent": {
+        "metrics_collection_interval": 10
     },
-    "aggregation_dimensions": [
-      [],
-      [
-        "InstanceId"
-      ],
-      [
-        "InstanceId",
-        "InstanceType"
-      ],
-      [
-        "foo",
-        "bar",
-        "InstanceType"
-      ]
-    ],
-    "metrics_collected": {
-      "mem": {
-        "measurement": [
-          "mem_used_percent"
-        ]
-      }
+    "metrics": {
+        "force_flush_interval": 10,
+        "namespace": "TestAggregationDimensions",
+        "append_dimensions": {
+            "InstanceId": "${aws:InstanceId}",
+            "InstanceType": "${aws:InstanceType}"
+        },
+        "aggregation_dimensions": [
+            [],
+            [
+                "InstanceId"
+            ],
+            [
+                "InstanceId",
+                "InstanceType"
+            ],
+            [
+                "foo",
+                "bar",
+                "InstanceType"
+            ]
+        ],
+        "metrics_collected": {
+            "mem": {
+                "append_dimensions": {
+                    "foo": "fooval",
+                    "bar": "barval",
+                    "baz": "bazval"
+                },
+                "measurement": [
+                    "mem_used_percent"
+                ]
+            },
+            "cpu": {
+                "measurement": [
+                    "usage_user"
+                ],
+                "metrics_collection_interval": 15
+            }
+        }
     }
-  }
 }

--- a/test/metric_dimension/aggregate_dimension_test.go
+++ b/test/metric_dimension/aggregate_dimension_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
-	"log"
 )
 
 type OneAggregateDimensionTestRunner struct {
@@ -58,7 +57,6 @@ func (t *OneAggregateDimensionTestRunner) validateNoAppendDimensionMetric(metric
 
 	fetcher := metric.MetricValueFetcher{}
 	values, err := fetcher.Fetch("MetricAggregateDimensionTest", metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
-	log.Printf("metric values are %v", values)
 	if err != nil {
 		return testResult
 	}

--- a/test/metric_dimension/aggregation_dimensions_test.go
+++ b/test/metric_dimension/aggregation_dimensions_test.go
@@ -72,10 +72,13 @@ func (t *AggregationDimensionsTestRunner) validate(metricName string) status.Tes
 		values, err := f.Fetch("TestAggregationDimensions", metricName, dd,
 			metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 		// Do not expect the last aggregation of just "InstanceType".
-		if i == len(aggregations)-1 && len(values) > 0 {
-			log.Printf("Expected no metrics with these dimensions - %v", aggregation)
-			return r
+		if i == len(aggregations)-1 {
+			if len(values) > 0 {
+				log.Printf("Expected no metrics with these dimensions - %v", aggregation)
+				return r
+			}
 		} else {
+			// Expect values for the metric with the current dimension list.
 			if err != nil || !isAllValuesGreaterThanOrEqualToZero(metricName, values) {
 				return r
 			}

--- a/test/metric_dimension/aggregation_dimensions_test.go
+++ b/test/metric_dimension/aggregation_dimensions_test.go
@@ -105,6 +105,7 @@ func (t *AggregationDimensionsTestRunner) validate(metricName string) status.Tes
 		Name:   metricName,
 		Status: status.FAILED,
 	}
+	f := metric.MetricValueFetcher{}
 	// Validate the metric name with some expected dimension sets.
 	aggregations := getExpectedDimensions(metricName)
 	for _, aggregation := range aggregations {
@@ -115,7 +116,6 @@ func (t *AggregationDimensionsTestRunner) validate(metricName string) status.Tes
 			instructions = append(instructions, i)
 		}
 		dd, _ := t.DimensionFactory.GetDimensions(instructions)
-		f := metric.MetricValueFetcher{}
 		values, err := f.Fetch("TestAggregationDimensions", metricName, dd,
 			metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 		// Expect values for the metric with the current dimension list.
@@ -134,7 +134,6 @@ func (t *AggregationDimensionsTestRunner) validate(metricName string) status.Tes
 			instructions = append(instructions, i)
 		}
 		dd, _ := t.DimensionFactory.GetDimensions(instructions)
-		f := metric.MetricValueFetcher{}
 		values, _ := f.Fetch("TestAggregationDimensions", metricName, dd,
 			metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 		// Expect no values.

--- a/test/metric_dimension/aggregation_dimensions_test.go
+++ b/test/metric_dimension/aggregation_dimensions_test.go
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package metric_dimension
+
+import (
+	"log"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
+)
+
+type AggregationDimensionsTestRunner struct {
+	test_runner.BaseTestRunner
+}
+
+var _ test_runner.ITestRunner = (*AggregationDimensionsTestRunner)(nil)
+
+func (t *AggregationDimensionsTestRunner) Validate() status.TestGroupResult {
+	mm := t.GetMeasuredMetrics()
+	r := make([]status.TestResult, len(mm))
+	for i, m := range mm {
+		r[i] = t.validate(m)
+	}
+	return status.TestGroupResult{
+		Name:        t.GetTestName(),
+		TestResults: r,
+	}
+}
+
+func (t *AggregationDimensionsTestRunner) GetTestName() string {
+	return "AggregationDimensionsTestRunner"
+}
+
+func (t *AggregationDimensionsTestRunner) GetAgentConfigFileName() string {
+	return "aggregation_dimensions.json"
+}
+
+func (t *AggregationDimensionsTestRunner) GetMeasuredMetrics() []string {
+	return []string{"mem_used_percent"}
+}
+
+// validate checks that a metric exists with each of the expected dimension lists.
+func (t *AggregationDimensionsTestRunner) validate(metricName string) status.TestResult {
+	r := status.TestResult{
+		Name:   metricName,
+		Status: status.FAILED,
+	}
+	dd, errs := t.DimensionFactory.GetDimensions([]dimension.Instruction{
+		{
+			Key:   "InstanceType",
+			Value: dimension.UnknownDimensionValue(),
+		},
+		{
+			Key:   "InstanceId",
+			Value: dimension.UnknownDimensionValue(),
+		},
+	})
+	if len(errs) > 0 {
+		return r
+	}
+	f := metric.MetricValueFetcher{}
+	values, err := f.Fetch("TestAggregationDimensions", metricName, dd,
+		metric.AVERAGE, test_runner.HighResolutionStatPeriod)
+	log.Printf("metric values are %v", values)
+	if err != nil {
+		return r
+	}
+	if isAllValuesGreaterThanOrEqualToZero(metricName, values) {
+		r.Status = status.SUCCESSFUL
+	}
+	return r
+}

--- a/test/metric_dimension/metrics_dimension_test.go
+++ b/test/metric_dimension/metrics_dimension_test.go
@@ -7,14 +7,14 @@ package metric_dimension
 
 import (
 	"fmt"
+	"log"
+	"testing"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
-
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"github.com/stretchr/testify/suite"
-	"log"
-	"testing"
 )
 
 type MetricsAppendDimensionTestSuite struct {
@@ -48,6 +48,7 @@ func getTestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 			{TestRunner: &NoAppendDimensionTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &GlobalAppendDimensionsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &OneAggregateDimensionTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &AggregationDimensionsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 		}
 	}
 	return testRunners
@@ -58,7 +59,7 @@ func (suite *MetricsAppendDimensionTestSuite) TestAllInSuite() {
 	for _, testRunner := range getTestRunners(env) {
 		testRunner.Run(suite)
 	}
-	
+
 	suite.Assert().Equal(status.SUCCESSFUL, suite.result.GetStatus(), "Metric Append Dimension Test Suite Failed")
 }
 

--- a/test/metric_dimension/metrics_dimension_test.go
+++ b/test/metric_dimension/metrics_dimension_test.go
@@ -45,9 +45,9 @@ func getTestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 	if testRunners == nil {
 		factory := dimension.GetDimensionFactory(*env)
 		testRunners = []*test_runner.TestRunner{
-			{TestRunner: &NoAppendDimensionTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &GlobalAppendDimensionsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &OneAggregateDimensionTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &NoAppendDimensionTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &GlobalAppendDimensionsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &OneAggregateDimensionTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &AggregationDimensionsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 		}
 	}

--- a/test/metric_dimension/metrics_dimension_test.go
+++ b/test/metric_dimension/metrics_dimension_test.go
@@ -45,9 +45,9 @@ func getTestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 	if testRunners == nil {
 		factory := dimension.GetDimensionFactory(*env)
 		testRunners = []*test_runner.TestRunner{
-			// {TestRunner: &NoAppendDimensionTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &GlobalAppendDimensionsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &OneAggregateDimensionTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &NoAppendDimensionTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &GlobalAppendDimensionsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &OneAggregateDimensionTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &AggregationDimensionsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 		}
 	}

--- a/test/metric_value_benchmark/cpu_test.go
+++ b/test/metric_value_benchmark/cpu_test.go
@@ -6,12 +6,13 @@
 package metric_value_benchmark
 
 import (
+	"log"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"log"
 )
 
 type CPUTestRunner struct {
@@ -74,6 +75,7 @@ func (t *CPUTestRunner) validateCpuMetric(metricName string) status.TestResult {
 	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	log.Printf("metric values are %v", values)
 	if err != nil {
+		log.Printf("err: %v\n", err)
 		return testResult
 	}
 


### PR DESCRIPTION
# Description of the issue
Currently there is a test which just tests the `"aggregation_dimensions"` option with a single roll up like this:
```
{
  "agent": {
    "metrics_collection_interval": 15,
    "run_as_user": "root",
    "debug": true,
    "logfile": ""
  },
  "metrics": {
    "namespace": "MetricAggregateDimensionTest",
    "append_dimensions": {
      "InstanceId": "${aws:InstanceId}",
      "InstanceType": "${aws:InstanceType}"
    },
    "aggregation_dimensions": [[]],
    "metrics_collected": {
      "cpu": {
        "measurement": [
          "time_active", "time_guest"
        ]
      }
    },
    "force_flush_interval": 5
  }
}
```

This is not sufficient test coverage.
We should test multiple aggregations.
And we should verify negative cases such as aggregating on a dimension that does not exist does not cause any issue with other aggregations.
And that CWA doesn't do any extra aggregations which were not configured.

# Description of changes
Added a test with this config:
```
{
  "agent": {
    "metrics_collection_interval": 10
  },
  "metrics": {
    "force_flush_interval": 10,
    "namespace": "TestAggregationDimensions",
    "append_dimensions": {
      "InstanceId": "${aws:InstanceId}",
      "InstanceType": "${aws:InstanceType}"
    },
    "aggregation_dimensions": [
      [],
      [
        "InstanceId"
      ],
      [
        "InstanceId",
        "InstanceType"
      ],
      [
        "foo",
        "bar",
        "InstanceType"
      ]
    ],
    "metrics_collected": {
      "mem": {
        "measurement": [
          "mem_used_percent"
        ]
      }
    }
  }
}
```


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- Ran this against the current CWA release 1.247357.0 running on an AL2 EC2 instance:
```
[ec2-user@ip-172-31-17-153 amazon-cloudwatch-agent-test]$ go test -count=1 -p=1 -v ./test/metric_dimension/ -computeType=EC2
=== RUN   TestMetricsAppendDimensionTestSuite
>>>> Starting MetricAppendDimensionTestSuite
=== RUN   TestMetricsAppendDimensionTestSuite/TestAllInSuite
2023/02/14 18:57:32 Running NoAppendDimension
2023/02/14 18:57:32 Starting agent using agent config file agent_configs/no_append_dimension.json
2023/02/14 18:57:32 Copy File agent_configs/no_append_dimension.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 18:57:32 File agent_configs/no_append_dimension.json abs path /home/ec2-user/go/src/github.com/aws/amazon-cloudwatch-agent-test/test/metric_dimension/agent_configs/no_append_dimension.json
2023/02/14 18:57:32 File : agent_configs/no_append_dimension.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 18:57:32 Agent has started
2023/02/14 18:58:32 Agent has been running for : 1m0s
2023/02/14 18:58:32 Agent is stopped
2023/02/14 18:58:32 Delete file /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 18:58:32 Removed file: /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 18:58:32 instruction {host {<nil>}} provider HostDimensionProvider returned dimension {0xc00019b590 0xc00019b5a0 {}}
2023/02/14 18:58:32 Result dim is : host, ip-172-31-17-153.ec2.internal
2023/02/14 18:58:32 instruction {cpu {0xc00019b580}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:58:32 instruction {cpu {0xc00019b580}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:58:32 instruction {cpu {0xc00019b580}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:58:32 instruction {cpu {0xc00019b580}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:58:32 instruction {cpu {0xc00019b580}} provider CustomDimensionProvider returned dimension {0xc00019b620 0xc00019b580 {}}
2023/02/14 18:58:32 Result dim is : cpu, cpu-total
2023/02/14 18:58:32 Metric query input dimensions
2023/02/14 18:58:32 	Dimensions:
2023/02/14 18:58:32 		Dim(name="host", val="ip-172-31-17-153.ec2.internal"
2023/02/14 18:58:32 		Dim(name="cpu", val="cpu-total"
2023/02/14 18:58:32 Metric data input is : {2023-02-14 18:58:32.929780048 +0000 UTC m=+60.400920781 [{0xc00019b6d0 <nil> <nil> <nil> 0xc0001ce0f0 <nil> <nil> {}}] 2023-02-14 18:48:32.929780048 +0000 UTC m=-539.599079219 <nil> <nil> <nil>  {}}
2023/02/14 18:58:32 Metric values are : [999.0650000000605 998.9599999999627]
2023/02/14 18:58:32 metric values are [999.0650000000605 998.9599999999627]
2023/02/14 18:58:32 Values are all greater than or equal to zero for cpu_time_active
2023/02/14 18:58:32 Running GlobalAppendDimension
2023/02/14 18:58:32 Starting agent using agent config file agent_configs/global_append_dimension.json
2023/02/14 18:58:32 Copy File agent_configs/global_append_dimension.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 18:58:32 File agent_configs/global_append_dimension.json abs path /home/ec2-user/go/src/github.com/aws/amazon-cloudwatch-agent-test/test/metric_dimension/agent_configs/global_append_dimension.json
2023/02/14 18:58:32 File : agent_configs/global_append_dimension.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 18:58:33 Agent has started
2023/02/14 18:59:33 Agent has been running for : 1m0s
2023/02/14 18:59:33 Agent is stopped
2023/02/14 18:59:33 Delete file /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 18:59:33 Removed file: /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 18:59:33 instruction {ImageId {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {ImageId {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {ImageId {<nil>}} provider LocalImageIdDimensionProvider returned dimension {0xc0003142d0 0xc0003142e0 {}}
2023/02/14 18:59:33 Result dim is : ImageId, ami-02e136e904f3da870
2023/02/14 18:59:33 instruction {InstanceId {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {InstanceId {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {0xc000314330 0xc000314340 {}}
2023/02/14 18:59:33 Result dim is : InstanceId, i-0b4086af301a93a8d
2023/02/14 18:59:33 instruction {InstanceType {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {InstanceType {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {InstanceType {<nil>}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {InstanceType {<nil>}} provider LocalInstanceTypeDimensionProvider returned dimension {0xc0003143b0 0xc0003143c0 {}}
2023/02/14 18:59:33 Result dim is : InstanceType, t2.medium
2023/02/14 18:59:33 instruction {cpu {0xc000240d80}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {cpu {0xc000240d80}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {cpu {0xc000240d80}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {cpu {0xc000240d80}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {cpu {0xc000240d80}} provider CustomDimensionProvider returned dimension {0xc000314440 0xc000240d80 {}}
2023/02/14 18:59:33 Result dim is : cpu, cpu-total
2023/02/14 18:59:33 Metric query input dimensions
2023/02/14 18:59:33 	Dimensions:
2023/02/14 18:59:33 		Dim(name="ImageId", val="ami-02e136e904f3da870"
2023/02/14 18:59:33 		Dim(name="InstanceId", val="i-0b4086af301a93a8d"
2023/02/14 18:59:33 		Dim(name="InstanceType", val="t2.medium"
2023/02/14 18:59:33 		Dim(name="cpu", val="cpu-total"
2023/02/14 18:59:33 Metric data input is : {2023-02-14 18:59:33.372873193 +0000 UTC m=+120.844013998 [{0xc000314530 <nil> <nil> <nil> 0xc000312690 <nil> <nil> {}}] 2023-02-14 18:49:33.372873193 +0000 UTC m=-479.155986002 <nil> <nil> <nil>  {}}
2023/02/14 18:59:33 Metric values are : [999.7299999999814 999.6000000000931]
2023/02/14 18:59:33 metric values are [999.7299999999814 999.6000000000931]
2023/02/14 18:59:33 Values are all greater than or equal to zero for cpu_time_active
2023/02/14 18:59:33 instruction {host {<nil>}} provider HostDimensionProvider returned dimension {0xc000315200 0xc000315210 {}}
2023/02/14 18:59:33 Result dim is : host, ip-172-31-17-153.ec2.internal
2023/02/14 18:59:33 instruction {cpu {0xc0003151f0}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {cpu {0xc0003151f0}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {cpu {0xc0003151f0}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {cpu {0xc0003151f0}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 18:59:33 instruction {cpu {0xc0003151f0}} provider CustomDimensionProvider returned dimension {0xc000315290 0xc0003151f0 {}}
2023/02/14 18:59:33 Result dim is : cpu, cpu-total
2023/02/14 18:59:33 Metric query input dimensions
2023/02/14 18:59:33 	Dimensions:
2023/02/14 18:59:33 		Dim(name="host", val="ip-172-31-17-153.ec2.internal"
2023/02/14 18:59:33 		Dim(name="cpu", val="cpu-total"
2023/02/14 18:59:33 Metric data input is : {2023-02-14 18:59:33.407806891 +0000 UTC m=+120.878947588 [{0xc000315340 <nil> <nil> <nil> 0xc000313f80 <nil> <nil> {}}] 2023-02-14 18:49:33.407806891 +0000 UTC m=-479.121052412 <nil> <nil> <nil>  {}}
2023/02/14 18:59:33 Metric values are : []
2023/02/14 18:59:33 Running OneAggregatedDimension
2023/02/14 18:59:33 Starting agent using agent config file agent_configs/one_aggregate_dimension.json
2023/02/14 18:59:33 Copy File agent_configs/one_aggregate_dimension.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 18:59:33 File agent_configs/one_aggregate_dimension.json abs path /home/ec2-user/go/src/github.com/aws/amazon-cloudwatch-agent-test/test/metric_dimension/agent_configs/one_aggregate_dimension.json
2023/02/14 18:59:33 File : agent_configs/one_aggregate_dimension.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 18:59:33 Agent has started
2023/02/14 19:00:33 Agent has been running for : 1m0s
2023/02/14 19:00:33 Agent is stopped
2023/02/14 19:00:33 Delete file /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 19:00:33 Removed file: /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 19:00:33 Metric query input dimensions
2023/02/14 19:00:33 	Dimensions:
2023/02/14 19:00:33 Metric data input is : {2023-02-14 19:00:33.810586533 +0000 UTC m=+181.281727296 [{0xc000315a40 <nil> <nil> <nil> 0xc00021ec60 <nil> <nil> {}}] 2023-02-14 18:50:33.810586533 +0000 UTC m=-418.718272704 <nil> <nil> <nil>  {}}
2023/02/14 19:00:33 Metric values are : [1000.3300000000745 1000.2099999999627]
2023/02/14 19:00:33 Values are all greater than or equal to zero for cpu_time_active
2023/02/14 19:00:33 Metric query input dimensions
2023/02/14 19:00:33 	Dimensions:
2023/02/14 19:00:33 Metric data input is : {2023-02-14 19:00:33.843262311 +0000 UTC m=+181.314403104 [{0xc000214000 <nil> <nil> <nil> 0xc00021fa70 <nil> <nil> {}}] 2023-02-14 18:50:33.843262311 +0000 UTC m=-418.685596896 <nil> <nil> <nil>  {}}
2023/02/14 19:00:33 Metric values are : [0 0]
2023/02/14 19:00:33 Values are all greater than or equal to zero for cpu_time_guest
2023/02/14 19:00:33 Running AggregationDimensionsTestRunner
2023/02/14 19:00:33 Starting agent using agent config file agent_configs/aggregation_dimensions.json
2023/02/14 19:00:33 Copy File agent_configs/aggregation_dimensions.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 19:00:33 File agent_configs/aggregation_dimensions.json abs path /home/ec2-user/go/src/github.com/aws/amazon-cloudwatch-agent-test/test/metric_dimension/agent_configs/aggregation_dimensions.json
2023/02/14 19:00:33 File : agent_configs/aggregation_dimensions.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 19:00:34 Agent has started
2023/02/14 19:01:34 Agent has been running for : 1m0s
2023/02/14 19:01:34 Agent is stopped
2023/02/14 19:01:34 Delete file /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 19:01:34 Removed file: /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/02/14 19:01:34 instruction {foo {0xc000214080}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000214080}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000214080}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000214080}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000214080}} provider CustomDimensionProvider returned dimension {0xc0002140f0 0xc000214080 {}}
2023/02/14 19:01:34 Result dim is : foo, fooval
2023/02/14 19:01:34 instruction {bar {0xc000214090}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc000214090}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc000214090}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc000214090}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc000214090}} provider CustomDimensionProvider returned dimension {0xc000214170 0xc000214090 {}}
2023/02/14 19:01:34 Result dim is : bar, barval
2023/02/14 19:01:34 instruction {baz {0xc0002140a0}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {baz {0xc0002140a0}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {baz {0xc0002140a0}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {baz {0xc0002140a0}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {baz {0xc0002140a0}} provider CustomDimensionProvider returned dimension {0xc000214200 0xc0002140a0 {}}
2023/02/14 19:01:34 Result dim is : baz, bazval
2023/02/14 19:01:34 instruction {InstanceId {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceId {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {0xc000214250 0xc000214260 {}}
2023/02/14 19:01:34 Result dim is : InstanceId, i-0b4086af301a93a8d
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceTypeDimensionProvider returned dimension {0xc0002142d0 0xc0002142e0 {}}
2023/02/14 19:01:34 Result dim is : InstanceType, t2.medium
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 		Dim(name="foo", val="fooval"
2023/02/14 19:01:34 		Dim(name="bar", val="barval"
2023/02/14 19:01:34 		Dim(name="baz", val="bazval"
2023/02/14 19:01:34 		Dim(name="InstanceId", val="i-0b4086af301a93a8d"
2023/02/14 19:01:34 		Dim(name="InstanceType", val="t2.medium"
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.187114274 +0000 UTC m=+241.658254977 [{0xc0002143f0 <nil> <nil> <nil> 0xc0001149c0 <nil> <nil> {}}] 2023-02-14 18:51:34.187114274 +0000 UTC m=-358.341745023 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : [4.65164367633846 4.570516885999683 4.682594736007611 4.619668622165847]
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.220148777 +0000 UTC m=+241.691289523 [{0xc0002400f0 <nil> <nil> <nil> 0xc000312360 <nil> <nil> {}}] 2023-02-14 18:51:34.220148777 +0000 UTC m=-358.308710477 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : [4.65164367633846 4.570516885999683 4.682594736007611 4.619668622165847]
2023/02/14 19:01:34 instruction {InstanceId {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceId {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {0xc000215140 0xc000215150 {}}
2023/02/14 19:01:34 Result dim is : InstanceId, i-0b4086af301a93a8d
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceTypeDimensionProvider returned dimension {0xc0002151c0 0xc0002151d0 {}}
2023/02/14 19:01:34 Result dim is : InstanceType, t2.medium
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 		Dim(name="InstanceId", val="i-0b4086af301a93a8d"
2023/02/14 19:01:34 		Dim(name="InstanceType", val="t2.medium"
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.236617162 +0000 UTC m=+241.707757854 [{0xc000215280 <nil> <nil> <nil> 0xc0002bb0b0 <nil> <nil> {}}] 2023-02-14 18:51:34.236617162 +0000 UTC m=-358.292242146 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : [4.651775804661487 4.570516885999683 4.682594736007611 4.619668622165847]
2023/02/14 19:01:34 instruction {foo {0xc0002405e0}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc0002405e0}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc0002405e0}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc0002405e0}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc0002405e0}} provider CustomDimensionProvider returned dimension {0xc000240640 0xc0002405e0 {}}
2023/02/14 19:01:34 Result dim is : foo, fooval
2023/02/14 19:01:34 instruction {bar {0xc0002405f0}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc0002405f0}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc0002405f0}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc0002405f0}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc0002405f0}} provider CustomDimensionProvider returned dimension {0xc0002406c0 0xc0002405f0 {}}
2023/02/14 19:01:34 Result dim is : bar, barval
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceTypeDimensionProvider returned dimension {0xc000240730 0xc000240740 {}}
2023/02/14 19:01:34 Result dim is : InstanceType, t2.medium
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 		Dim(name="foo", val="fooval"
2023/02/14 19:01:34 		Dim(name="bar", val="barval"
2023/02/14 19:01:34 		Dim(name="InstanceType", val="t2.medium"
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.253902474 +0000 UTC m=+241.725043348 [{0xc000240b30 <nil> <nil> <nil> 0xc000313050 <nil> <nil> {}}] 2023-02-14 18:51:34.253902474 +0000 UTC m=-358.274956652 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : [4.65164367633846 4.570516885999683 4.682594736007611 4.619668622165847]
2023/02/14 19:01:34 instruction {foo {0xc000215890}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000215890}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000215890}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000215890}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000215890}} provider CustomDimensionProvider returned dimension {0xc0002158e0 0xc000215890 {}}
2023/02/14 19:01:34 Result dim is : foo, fooval
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 		Dim(name="foo", val="fooval"
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.273488626 +0000 UTC m=+241.744629309 [{0xc000215970 <nil> <nil> <nil> 0xc0002bbd40 <nil> <nil> {}}] 2023-02-14 18:51:34.273488626 +0000 UTC m=-358.255370691 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : []
2023/02/14 19:01:34 instruction {foo {0xc000215ef0}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000215ef0}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000215ef0}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000215ef0}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000215ef0}} provider CustomDimensionProvider returned dimension {0xc000215f50 0xc000215ef0 {}}
2023/02/14 19:01:34 Result dim is : foo, fooval
2023/02/14 19:01:34 instruction {bar {0xc000215f00}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc000215f00}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc000215f00}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc000215f00}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc000215f00}} provider CustomDimensionProvider returned dimension {0xc000215fd0 0xc000215f00 {}}
2023/02/14 19:01:34 Result dim is : bar, barval
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 		Dim(name="foo", val="fooval"
2023/02/14 19:01:34 		Dim(name="bar", val="barval"
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.30030412 +0000 UTC m=+241.771444868 [{0xc000314080 <nil> <nil> <nil> 0xc00021e8a0 <nil> <nil> {}}] 2023-02-14 18:51:34.30030412 +0000 UTC m=-358.228555132 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : []
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceTypeDimensionProvider returned dimension {0xc000241270 0xc000241280 {}}
2023/02/14 19:01:34 Result dim is : InstanceType, t2.medium
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 		Dim(name="InstanceType", val="t2.medium"
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.337099766 +0000 UTC m=+241.808240526 [{0xc000241310 <nil> <nil> <nil> 0xc000313ec0 <nil> <nil> {}}] 2023-02-14 18:51:34.337099766 +0000 UTC m=-358.191759474 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : []
2023/02/14 19:01:34 instruction {InstanceId {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceId {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {0xc000314c70 0xc000314c80 {}}
2023/02/14 19:01:34 Result dim is : InstanceId, i-0b4086af301a93a8d
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceTypeDimensionProvider returned dimension {0xc000314cf0 0xc000314d00 {}}
2023/02/14 19:01:34 Result dim is : InstanceType, t2.medium
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 		Dim(name="InstanceId", val="i-0b4086af301a93a8d"
2023/02/14 19:01:34 		Dim(name="InstanceType", val="t2.medium"
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.356434424 +0000 UTC m=+241.827575211 [{0xc000314db0 <nil> <nil> <nil> 0xc00019c120 <nil> <nil> {}}] 2023-02-14 18:51:34.356434424 +0000 UTC m=-358.172424789 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : [0.06691201070628036 0 0.03338898163582208 0.16700066800191282]
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.373700975 +0000 UTC m=+241.844841663 [{0xc0002418c0 <nil> <nil> <nil> 0xc00016e5d0 <nil> <nil> {}}] 2023-02-14 18:51:34.373700975 +0000 UTC m=-358.155158337 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : [0.06691201070628036 0 0.03338898163582208 0.16700066800191282]
2023/02/14 19:01:34 instruction {InstanceId {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceId {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {0xc0003153d0 0xc0003153e0 {}}
2023/02/14 19:01:34 Result dim is : InstanceId, i-0b4086af301a93a8d
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 		Dim(name="InstanceId", val="i-0b4086af301a93a8d"
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.392096938 +0000 UTC m=+241.863237773 [{0xc000315470 <nil> <nil> <nil> 0xc00019ccf0 <nil> <nil> {}}] 2023-02-14 18:51:34.392096938 +0000 UTC m=-358.136762227 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : [0.06691201070628036 0 0.03338898163582208 0.16700066800191282]
2023/02/14 19:01:34 instruction {foo {0xc000241db0}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000241db0}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000241db0}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000241db0}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000241db0}} provider CustomDimensionProvider returned dimension {0xc000241e00 0xc000241db0 {}}
2023/02/14 19:01:34 Result dim is : foo, fooval
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 		Dim(name="foo", val="fooval"
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.410778973 +0000 UTC m=+241.881919750 [{0xc000241e90 <nil> <nil> <nil> 0xc00016f170 <nil> <nil> {}}] 2023-02-14 18:51:34.410778973 +0000 UTC m=-358.118080250 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : []
2023/02/14 19:01:34 instruction {foo {0xc000315a50}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000315a50}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000315a50}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000315a50}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc000315a50}} provider CustomDimensionProvider returned dimension {0xc000315ab0 0xc000315a50 {}}
2023/02/14 19:01:34 Result dim is : foo, fooval
2023/02/14 19:01:34 instruction {bar {0xc000315a60}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc000315a60}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc000315a60}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc000315a60}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc000315a60}} provider CustomDimensionProvider returned dimension {0xc000315b30 0xc000315a60 {}}
2023/02/14 19:01:34 Result dim is : bar, barval
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 		Dim(name="foo", val="fooval"
2023/02/14 19:01:34 		Dim(name="bar", val="barval"
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.445119783 +0000 UTC m=+241.916260547 [{0xc000315be0 <nil> <nil> <nil> 0xc00019da70 <nil> <nil> {}}] 2023-02-14 18:51:34.445119783 +0000 UTC m=-358.083739453 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : []
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceTypeDimensionProvider returned dimension {0xc00013c940 0xc00013c950 {}}
2023/02/14 19:01:34 Result dim is : InstanceType, t2.medium
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 		Dim(name="InstanceType", val="t2.medium"
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.46562326 +0000 UTC m=+241.936764055 [{0xc00013ca00 <nil> <nil> <nil> 0xc0001ceff0 <nil> <nil> {}}] 2023-02-14 18:51:34.46562326 +0000 UTC m=-358.063235945 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : []
2023/02/14 19:01:34 instruction {foo {0xc00019a1f0}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc00019a1f0}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc00019a1f0}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc00019a1f0}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {foo {0xc00019a1f0}} provider CustomDimensionProvider returned dimension {0xc00019a260 0xc00019a1f0 {}}
2023/02/14 19:01:34 Result dim is : foo, fooval
2023/02/14 19:01:34 instruction {bar {0xc00019a200}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc00019a200}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc00019a200}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc00019a200}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {bar {0xc00019a200}} provider CustomDimensionProvider returned dimension {0xc00019a2e0 0xc00019a200 {}}
2023/02/14 19:01:34 Result dim is : bar, barval
2023/02/14 19:01:34 instruction {baz {0xc00019a210}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {baz {0xc00019a210}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {baz {0xc00019a210}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {baz {0xc00019a210}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {baz {0xc00019a210}} provider CustomDimensionProvider returned dimension {0xc00019a360 0xc00019a210 {}}
2023/02/14 19:01:34 Result dim is : baz, bazval
2023/02/14 19:01:34 instruction {InstanceId {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceId {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {0xc00019a3b0 0xc00019a3c0 {}}
2023/02/14 19:01:34 Result dim is : InstanceId, i-0b4086af301a93a8d
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/02/14 19:01:34 instruction {InstanceType {<nil>}} provider LocalInstanceTypeDimensionProvider returned dimension {0xc00019a430 0xc00019a440 {}}
2023/02/14 19:01:34 Result dim is : InstanceType, t2.medium
2023/02/14 19:01:34 Metric query input dimensions
2023/02/14 19:01:34 	Dimensions:
2023/02/14 19:01:34 		Dim(name="foo", val="fooval"
2023/02/14 19:01:34 		Dim(name="bar", val="barval"
2023/02/14 19:01:34 		Dim(name="baz", val="bazval"
2023/02/14 19:01:34 		Dim(name="InstanceId", val="i-0b4086af301a93a8d"
2023/02/14 19:01:34 		Dim(name="InstanceType", val="t2.medium"
2023/02/14 19:01:34 Metric data input is : {2023-02-14 19:01:34.483854125 +0000 UTC m=+241.954994951 [{0xc00019a550 <nil> <nil> <nil> 0xc000294a50 <nil> <nil> {}}] 2023-02-14 18:51:34.483854125 +0000 UTC m=-358.045005049 <nil> <nil> <nil>  {}}
2023/02/14 19:01:34 Metric values are : []
2023/02/14 19:01:34 >>>>>>>>>>>>>><<<<<<<<<<<<<<
2023/02/14 19:01:34 >>>>>>>>>>>>>>Successful<<<<<<<<<<<<<<
2023/02/14 19:01:34 ==============NoAppendDimension==============
2023/02/14 19:01:34 ==============Successful==============
cpu_time_active   Successful  
2023/02/14 19:01:34 ==============================
2023/02/14 19:01:34 ==============GlobalAppendDimension==============
2023/02/14 19:01:34 ==============Successful==============
cpu_time_active   Successful  
2023/02/14 19:01:34 ==============================
2023/02/14 19:01:34 ==============OneAggregatedDimension==============
2023/02/14 19:01:34 ==============Successful==============
cpu_time_active   Successful  
cpu_time_guest    Successful  
2023/02/14 19:01:34 ==============================
2023/02/14 19:01:34 ==============AggregationDimensionsTestRunner==============
2023/02/14 19:01:34 ==============Successful==============
mem_used_percent   Successful  
mem_used_percent   Successful  
mem_used_percent   Successful  
mem_used_percent   Successful  
mem_used_percent   Successful  
mem_used_percent   Successful  
mem_used_percent   Successful  
cpu_usage_user     Successful  
cpu_usage_user     Successful  
cpu_usage_user     Successful  
cpu_usage_user     Successful  
cpu_usage_user     Successful  
cpu_usage_user     Successful  
cpu_usage_user     Successful  
2023/02/14 19:01:34 ==============================
2023/02/14 19:01:34 >>>>>>>>>>>>>>><<<<<<<<<<<<<<<
>>>> Finished MetricAppendDimensionTestSuite
--- PASS: TestMetricsAppendDimensionTestSuite (241.98s)
    --- PASS: TestMetricsAppendDimensionTestSuite/TestAllInSuite (241.98s)
PASS
ok  	github.com/aws/amazon-cloudwatch-agent-test/test/metric_dimension	241.983s
```
