### PR TITLE
Add EMF Test Back Now It Is Supported In Staging Agent

### DIFF
--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -75,9 +75,9 @@ func getEc2TestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 			{TestRunner: &DiskIOTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &NetTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &EthtoolTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &EMFTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			// TODO: The following plugins are not fully supported by CCWA, hence disabled temporarily. Restore back once supported.
 			//{TestRunner: &StatsdTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			//{TestRunner: &EMFTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			//{TestRunner: &CollectDTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &SwapTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &ProcessesTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},


### PR DESCRIPTION
# Description of the issue
Staging agent added support for emf

# Description of changes
Add emf test back

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Integration test pipeline
https://github.com/aws/private-amazon-cloudwatch-agent-staging/actions/runs/4176934179/jobs/7234140972
