### PR TITLE
Allow TCP From 4566 So We Can Connect To Localstack

### DIFF
--- a/terraform/setup/vpc.tf
+++ b/terraform/setup/vpc.tf
@@ -48,4 +48,12 @@ resource "aws_security_group" "ec2_security_group" {
     protocol    = "TCP"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  // localstack http and https
+  ingress {
+    from_port   = 4566
+    to_port     = 4566
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }


### PR DESCRIPTION
# Description of the issue
Can't connect to localstack since port is not open. 

# Description of changes
Open port for localstack

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/private-amazon-cloudwatch-agent-staging/actions/runs/4197203954/jobs/7279213162
