### PR TITLE
Set IMDSv2 with hop limit 2 in Container Environment

### DIFF
--- a/terraform/ecs_ec2/daemon/main.tf
+++ b/terraform/ecs_ec2/daemon/main.tf
@@ -31,8 +31,9 @@ resource "aws_launch_configuration" "cluster" {
 
   user_data = "#!/bin/bash\necho ECS_CLUSTER=${aws_ecs_cluster.cluster.name} >> /etc/ecs/ecs.config"
   metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = "required"
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
   }
 }
 


### PR DESCRIPTION
# Description of the issue
Set IMDSv2 with hop limit 2 in Container Environment since the [hop limit required for container is 2](https://docs.amazonaws.cn/en_us/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#imds-considerations); however, the default hop limit being set for cluster is 1. Therefore, changing it to 2 to fix our ECS EC2
```
To avoid the process of falling back to IMDSv1 and the resultant delay, in a container environment we recommend that you set the hop limit to 2
```

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
I [have run with my forked](https://docs.amazonaws.cn/en_us/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html)
