### PR TITLE
Add Debian ARM11 Tests

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -33,6 +33,17 @@
     "family": "linux"
   },
   {
+    "os": "debian-11",
+    "username": "admin",
+    "instanceType": "c6g.large",
+    "installAgentCommand": "/snap/bin/go run ./install/install_agent.go deb",
+    "ami": "cloudwatch-agent-integration-test-debian-11-arm64*",
+    "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
+    "arc": "arm64",
+    "binaryName": "amazon-cloudwatch-agent.deb",
+    "family": "linux"
+  },
+  {
     "os": "al2",
     "username": "ec2-user",
     "instanceType":"t3a.medium",


### PR DESCRIPTION
# Description of the issue
Need to test debian 11 platform.  

# Description of changes
Add debian 11 arm as test. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/4246127488
Failures are due to too many mount targets in account. Working on a fix now. 