### PR TITLE
Enable statsd test and improve it.

### DIFF
--- a/internal/common/metrics.go
+++ b/internal/common/metrics.go
@@ -5,25 +5,41 @@ package common
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/cactus/go-statsd-client/v5/statsd"
+	"go.uber.org/multierr"
 )
 
 // StartLogWrite starts go routines to write logs to each of the logs that are monitored by CW Agent according to
 // the config provided
-func StartSendingMetrics(receiver string, agentRunDuration time.Duration, metricPerMinute int) error {
-	var err error
-	switch receiver {
-	case "statsd":
-		err = sendStatsdMetrics(metricPerMinute, agentRunDuration)
+func StartSendingMetrics(receiver string, agentRunDuration time.Duration, dataRate int) error {
+	//create wait group so main test thread waits for log writing to finish before stopping agent and collecting data
+	var (
+		err      error
+		multiErr error
+		wg       sync.WaitGroup
+	)
 
-	default:
-	}
-	return err
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		switch receiver {
+		case "statsd":
+			err = sendStatsdMetrics(dataRate, agentRunDuration)
+
+		default:
+		}
+
+		multiErr = multierr.Append(multiErr, err)
+	}()
+
+	wg.Wait()
+	return multiErr
 }
 
-func sendStatsdMetrics(metricPerMinute int, duration time.Duration) error {
+func sendStatsdMetrics(dataRate int, duration time.Duration) error {
 	// https://github.com/cactus/go-statsd-client#example
 	statsdClientConfig := &statsd.ClientConfig{
 		Address:     ":8125",
@@ -34,6 +50,7 @@ func sendStatsdMetrics(metricPerMinute int, duration time.Duration) error {
 		FlushInterval: 300 * time.Millisecond,
 	}
 	client, err := statsd.NewClientWithConfig(statsdClientConfig)
+
 	if err != nil {
 		return err
 	}
@@ -47,14 +64,13 @@ func sendStatsdMetrics(metricPerMinute int, duration time.Duration) error {
 	for {
 		select {
 		case <-ticker.C:
-			for time := 0; time < metricPerMinute; time++ {
+			for time := 0; time < dataRate; time++ {
 				go func(time int) {
-					client.Inc(fmt.Sprintf("statsd_metric_%v", time), int64(time), 1.0)
+					client.Inc(fmt.Sprintf("%v", time), int64(time), 1.0)
 				}(time)
 			}
 		case <-endTimeout:
 			return nil
 		}
 	}
-
 }

--- a/internal/common/metrics.go
+++ b/internal/common/metrics.go
@@ -5,40 +5,10 @@ package common
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/cactus/go-statsd-client/v5/statsd"
 )
-
-// SendStatsd will run until signaled to stop.
-// It will write the given list of metrics at the specified interval.
-func SendStatsd(stop <-chan struct{}, metricNames []string, interval time.Duration) error {
-	config := statsd.ClientConfig{
-		Address:     ":8125",
-		Prefix:      "statsd_prefix",
-		UseBuffered: true,
-		FlushInterval: 300 * time.Millisecond,
-	}
-	client, err := statsd.NewClientWithConfig(&config)
-	if err != nil {
-		log.Println("error creating statsd client", err)
-		return err
-	}
-	defer client.Close()
-
-	ticker := time.NewTicker(interval)
-	for {
-		select {
-		case <-stop:
-			return nil
-		case <-ticker.C:
-			for _, metricName := range metricNames {
-				client.Inc(metricName, 1, 1)
-			}
-		}
-	}
-}
 
 // StartLogWrite starts go routines to write logs to each of the logs that are monitored by CW Agent according to
 // the config provided

--- a/test/metric/metric_value_query.go
+++ b/test/metric/metric_value_query.go
@@ -59,7 +59,8 @@ func (n *MetricValueFetcher) Fetch(namespace, metricName string, metricSpecificD
 		MetricDataQueries: metricDataQueries,
 	}
 
-	log.Printf("Metric data input is : %s", fmt.Sprint(getMetricDataInput))
+	log.Printf("Metric data input: namespace %v, name %v, stat %v, period %v",
+		namespace, metricName, stat, metricQueryPeriod)
 
 	cwmClient, clientContext, err := awsservice.GetCloudWatchMetricsClient()
 	if err != nil {

--- a/test/metric_value_benchmark/agent_configs/statsd_config.json
+++ b/test/metric_value_benchmark/agent_configs/statsd_config.json
@@ -7,7 +7,7 @@
         "metrics_collected": {
             "statsd": {
                 "metrics_aggregation_interval": 30,
-                "metrics_collection_interval": 15,
+                "metrics_collection_interval": 5,
                 "service_address": ":8125"
             }
         },

--- a/test/metric_value_benchmark/agent_configs/statsd_config.json
+++ b/test/metric_value_benchmark/agent_configs/statsd_config.json
@@ -1,22 +1,16 @@
 {
-    "agent": {
-      "metrics_collection_interval": 15,
-      "run_as_user": "root",
-      "debug": true,
-      "logfile": ""
-    },
     "metrics": {
-      "namespace": "MetricValueBenchmarkTest",
-      "append_dimensions": {
-        "InstanceId": "${aws:InstanceId}"
-      },
-      "metrics_collected": {
-        "statsd": {
-            "metrics_aggregation_interval": 15,
-            "metrics_collection_interval": 15,
-            "service_address": ":8125"
-        }
-      },
-      "force_flush_interval": 5
+        "namespace": "statsd_test",
+        "append_dimensions": {
+            "InstanceId": "${aws:InstanceId}"
+        },
+        "metrics_collected": {
+            "statsd": {
+                "metrics_aggregation_interval": 30,
+                "metrics_collection_interval": 15,
+                "service_address": ":8125"
+            }
+        },
+        "force_flush_interval": 5
     }
-  }
+}

--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -66,21 +66,7 @@ func getEc2TestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 	if ec2TestRunners == nil {
 		factory := dimension.GetDimensionFactory(*env)
 		ec2TestRunners = []*test_runner.TestRunner{
-			{TestRunner: &DiskTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &NetStatTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &PrometheusTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &CPUTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &MemTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &ProcStatTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &DiskIOTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &NetTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &EthtoolTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &EMFTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// TODO: The following plugins are not fully supported by CCWA, hence disabled temporarily. Restore back once supported.
-			//{TestRunner: &StatsdTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			//{TestRunner: &CollectDTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &SwapTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &ProcessesTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &StatsdTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 		}
 	}
 	return ec2TestRunners

--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -67,6 +67,21 @@ func getEc2TestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 		factory := dimension.GetDimensionFactory(*env)
 		ec2TestRunners = []*test_runner.TestRunner{
 			{TestRunner: &StatsdTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &DiskTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &NetStatTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &PrometheusTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &CPUTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &MemTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &ProcStatTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &DiskIOTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &NetTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &EthtoolTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &EMFTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// TODO: The following plugins are not fully supported by CCWA, hence disabled temporarily. Restore back once supported.
+			//{TestRunner: &CollectDTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &SwapTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &ProcessesTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &StatsdTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 		}
 	}
 	return ec2TestRunners

--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -81,7 +81,6 @@ func getEc2TestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 			//{TestRunner: &CollectDTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &SwapTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &ProcessesTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &StatsdTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 		}
 	}
 	return ec2TestRunners

--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -108,7 +108,7 @@ func shouldRunEC2Test(env *environment.MetaData, t *test_runner.TestRunner) bool
 
 func isAllValuesGreaterThanOrEqualToZero(metricName string, values []float64) bool {
 	if len(values) == 0 {
-		log.Printf("No values found %v", metricName)
+		log.Printf("No values found for: %v", metricName)
 		return false
 	}
 	for _, value := range values {

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -76,8 +76,8 @@ func (t *StatsdTestRunner) GetAgentRunDuration() time.Duration {
 
 func (t *StatsdTestRunner) SetupAfterAgentRun() error {
 	// For each test run we want a unique metric name.
-	// Just in case 2 different people run this test in parallel, using the
-	// same AWS account...
+	// That way the test can be run back to back on the same EC2 instance.
+	// And the 2nd test run won't be affects by the metrics from the 1st test run.
 	// Populate a temp map with the new metric names.
 	suffix := fmt.Sprint(time.Now().UnixNano())
 	newMap := map[string]metricInfo{}

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -23,9 +23,10 @@ type StatsdTestRunner struct {
 	test_runner.BaseTestRunner
 }
 
-var (
-	// stopChan is for stopping the goroutine generating statsd metrics.
-	stopChan chan struct{} = make(chan struct{})
+// stopChan is for stopping the goroutine generating statsd metrics.
+var stopChan chan struct{} = make(chan struct{})
+
+const (
 	// aggregationInterval must match the JSON configuration.
 	aggregationInterval = 30 * time.Second
 	runDuration = 3 * time.Minute

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -27,6 +27,8 @@ type metricInfo struct {
 	dimensions []statsd.Tag
 }
 // Map the metricName to metricInfo.
+// The metric generator uses the name, type and dimensions in this map.
+// And the validate function uses it too.
 var metricMap = map[string]metricInfo{
 	"my_statsd_counter_1": {
 		"counter",
@@ -116,7 +118,8 @@ func (t *StatsdTestRunner) validateStatsdMetric(metricName string) status.TestRe
 		return testResult
 	}
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE,
+	// Namespace must match the JSON config.
+	values, err := fetcher.Fetch("statsd_test", metricName, dims, metric.AVERAGE,
 		test_runner.HighResolutionStatPeriod)
 	if err != nil {
 		return testResult

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -6,21 +6,39 @@
 package metric_value_benchmark
 
 import (
+	"log"
 	"time"
 
-	"github.com/aws/amazon-cloudwatch-agent-test/internal/common"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/cactus/go-statsd-client/v5/statsd"
 )
 
 type StatsdTestRunner struct {
 	test_runner.BaseTestRunner
 }
-
 var _ test_runner.ITestRunner = (*StatsdTestRunner)(nil)
+
+type metricInfo struct {
+	metricType string
+	dimensions []statsd.Tag
+}
+// map the metricName to metricInfo
+var metricMap = map[string]metricInfo{
+	"my_statsd_counter_1": {
+		"counter",
+		[]statsd.Tag{{"key1", "val1"}},
+	},
+	"my_statsd_gauge_2": {
+		"gauge",
+		[]statsd.Tag{{"key2", "val2"}, {"key3", "val3"}},
+	},
+}
+
+var stopChan chan struct{} = make(chan struct{})
 
 func (t *StatsdTestRunner) Validate() status.TestGroupResult {
 	metricsToFetch := t.GetMeasuredMetrics()
@@ -47,59 +65,99 @@ func (t *StatsdTestRunner) GetAgentRunDuration() time.Duration {
 	return 5*time.Minute
 }
 
-var metricNames []string = []string{
-	"my_statsd_metric_1",
-	"my_statsd_metric_2",
-	"my_statsd_metric_3",
-}
+
 
 func (t *StatsdTestRunner) SetupAfterAgentRun() error {
-	stop := make(chan struct{})
 	// Send unique metrics each second.
 	// Expect agent to collect every 5 seconds.
 	// Expect agent to aggregate collections into 60 second buckets.
-	common.SendStatsd(stop, metricNames, time.Second)
+	go sendStatsd()
 	return nil
 }
 
 func (t *StatsdTestRunner) GetMeasuredMetrics() []string {
-	return metricNames
+	keys := make([]string, 0, len(metricMap))
+	for k := range metricMap {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func (t *StatsdTestRunner) validateStatsdMetric(metricName string) status.TestResult {
+	// Stop generating metrics.
+	stopChan <- struct{}{}
 	testResult := status.TestResult{
 		Name:   metricName,
 		Status: status.FAILED,
 	}
-
-	dims, failed := t.DimensionFactory.GetDimensions([]dimension.Instruction{
+	// Populate the list of expected dimensions.
+	instructions := []dimension.Instruction{
 		{
 			Key:   "InstanceId",
 			Value: dimension.UnknownDimensionValue(),
 		},
-		{
-			Key:   "metric_type",
-			Value: dimension.ExpectedDimensionValue{Value: aws.String("counter")},
-		},
-	})
-
+	}
+	for _, d := range metricMap[metricName].dimensions {
+		instructions = append(instructions, dimension.Instruction{
+			Key: d[0],
+			Value: dimension.ExpectedDimensionValue{Value: aws.String(d[1])},
+		})
+	}
+	dims, failed := t.DimensionFactory.GetDimensions(instructions)
 	if len(failed) > 0 {
 		return testResult
 	}
-
 	fetcher := metric.MetricValueFetcher{}
 	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
 	if err != nil {
 		return testResult
 	}
-
+	if len(values) > int(t.GetAgentRunDuration().Minutes()) {
+		log.Println("fail: fetched too many metric values")
+	}
+	if len(values) < int(t.GetAgentRunDuration().Minutes()) {
+		log.Println("fail: fetched too few metric values")
+	}
 	if !isAllValuesGreaterThanOrEqualToZero(metricName, values) {
 		return testResult
 	}
-
 	// TODO: Range test with >0 and <100
 	// TODO: Range test: which metric to get? api reference check. should I get average or test every single datapoint for 10 minutes? (and if 90%> of them are in range, we are good)
-
 	testResult.Status = status.SUCCESSFUL
 	return testResult
+}
+
+// SendStatsd will run until signaled to stop.
+// It sends each metric with dimensions at a 1 second interval.
+func sendStatsd() error {
+	config := statsd.ClientConfig{
+		Address:     ":8125",
+		Prefix:      "",
+		UseBuffered: true,
+		FlushInterval: 300 * time.Millisecond,
+	}
+	client, err := statsd.NewClientWithConfig(&config)
+	if err != nil {
+		log.Println("error creating statsd client", err)
+		return err
+	}
+	defer client.Close()
+
+	ticker := time.NewTicker(time.Second)
+	for {
+		select {
+		case <-stopChan:
+			return nil
+		case <-ticker.C:
+			// The type depends on the name.
+			for name, info := range metricMap {
+				switch info.metricType {
+				case "counter":
+					client.Inc(name, 1, 1, info.dimensions...)
+				case "gauge":
+					client.Gauge(name, 1, 1, info.dimensions...)
+				}
+			}
+		}
+	}
 }

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -21,12 +21,14 @@ import (
 type StatsdTestRunner struct {
 	test_runner.BaseTestRunner
 }
+
 var _ test_runner.ITestRunner = (*StatsdTestRunner)(nil)
 
 type metricInfo struct {
 	metricType string
 	dimensions []statsd.Tag
 }
+
 // Map the metricName to metricInfo.
 // The metric generator uses the name, type and dimensions in this map.
 // And the validate function uses it too.
@@ -68,7 +70,7 @@ func (t *StatsdTestRunner) GetAgentConfigFileName() string {
 }
 
 func (t *StatsdTestRunner) GetAgentRunDuration() time.Duration {
-	return 3*time.Minute
+	return 3 * time.Minute
 }
 
 func (t *StatsdTestRunner) SetupAfterAgentRun() error {
@@ -122,7 +124,7 @@ func (t *StatsdTestRunner) validateStatsdMetric(metricName string) status.TestRe
 	}
 	for _, d := range metricInfo.dimensions {
 		instructions = append(instructions, dimension.Instruction{
-			Key: d[0],
+			Key:   d[0],
 			Value: dimension.ExpectedDimensionValue{Value: aws.String(d[1])},
 		})
 	}
@@ -156,9 +158,9 @@ func (t *StatsdTestRunner) validateStatsdMetric(metricName string) status.TestRe
 // It sends each metric with dimensions at a 1 second interval.
 func sendStatsd() error {
 	config := statsd.ClientConfig{
-		Address:     ":8125",
-		Prefix:      "",
-		UseBuffered: true,
+		Address:       ":8125",
+		Prefix:        "",
+		UseBuffered:   true,
 		FlushInterval: 300 * time.Millisecond,
 	}
 	client, err := statsd.NewClientWithConfig(&config)

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -124,11 +124,11 @@ func (t *StatsdTestRunner) validateStatsdMetric(metricName string) status.TestRe
 	if err != nil {
 		return testResult
 	}
-	if len(values) > int(t.GetAgentRunDuration().Minutes()) {
-		log.Println("fail: fetched too many metric values")
-	}
-	if len(values) < int(t.GetAgentRunDuration().Minutes()) {
-		log.Println("fail: fetched too few metric values")
+	// Aggregation interval is 30 seconds, so expect 2 * runTimeInMinutes.
+	numExpected := 2 * int(t.GetAgentRunDuration().Minutes()
+	if len(numExpected) != len(values)) {
+		log.Printf("fail: expected %v data points, got %v",
+			numExpected, len(values))
 	}
 	if !isAllValuesGreaterThanOrEqualToZero(metricName, values) {
 		return testResult

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -120,7 +120,6 @@ func (t *StatsdTestRunner) validateStatsdMetric(metricName string) status.TestRe
 			Value: dimension.ExpectedDimensionValue{Value: &metricInfo.metricType},
 		},
 	}
-	//
 	for _, d := range metricInfo.dimensions {
 		instructions = append(instructions, dimension.Instruction{
 			Key: d[0],

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -141,7 +141,8 @@ func (t *StatsdTestRunner) validateStatsdMetric(metricName string) status.TestRe
 		return testResult
 	}
 	// Aggregation interval is 30 seconds, so expect 2 * runTimeInMinutes.
-	numExpected := 2 * int(t.GetAgentRunDuration().Minutes())
+	// allow for a 1 minute delay in CW-Metrics-Service (so 2 missing data points).
+	numExpected := 2 * int(t.GetAgentRunDuration().Minutes()) - 2
 	if numExpected != len(values) {
 		log.Printf("fail: expected %v data points, got %v",
 			numExpected, len(values))

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -152,7 +152,7 @@ func (t *StatsdTestRunner) validateStatsdMetric(metricName string) status.TestRe
 	return testResult
 }
 
-// SendStatsd will run until signaled to stop.
+// sendStatsd will run until signaled to stop.
 // It sends each metric with dimensions at a 1 second interval.
 func sendStatsd() error {
 	config := statsd.ClientConfig{

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -44,6 +44,7 @@ var metricMap = map[string]metricInfo{
 	},
 }
 
+// stopChan allows the test to stop the goroutine generating statsd metrics.
 var stopChan chan struct{} = make(chan struct{})
 
 func (t *StatsdTestRunner) Validate() status.TestGroupResult {

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -125,8 +125,8 @@ func (t *StatsdTestRunner) validateStatsdMetric(metricName string) status.TestRe
 		return testResult
 	}
 	// Aggregation interval is 30 seconds, so expect 2 * runTimeInMinutes.
-	numExpected := 2 * int(t.GetAgentRunDuration().Minutes()
-	if len(numExpected) != len(values)) {
+	numExpected := 2 * int(t.GetAgentRunDuration().Minutes())
+	if numExpected != len(values) {
 		log.Printf("fail: expected %v data points, got %v",
 			numExpected, len(values))
 	}

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -69,7 +69,7 @@ func (t *StatsdTestRunner) GetAgentRunDuration() time.Duration {
 func (t *StatsdTestRunner) SetupAfterAgentRun() error {
 	// Send unique metrics each second.
 	// Expect agent to collect every 5 seconds.
-	// Expect agent to aggregate collections into 60 second buckets.
+	// Expect agent to aggregate collections into 30 second buckets.
 	go sendStatsd()
 	return nil
 }
@@ -116,7 +116,8 @@ func (t *StatsdTestRunner) validateStatsdMetric(metricName string) status.TestRe
 		return testResult
 	}
 	fetcher := metric.MetricValueFetcher{}
-	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, test_runner.HighResolutionStatPeriod)
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE,
+		test_runner.HighResolutionStatPeriod)
 	if err != nil {
 		return testResult
 	}
@@ -155,6 +156,7 @@ func sendStatsd() error {
 	for {
 		select {
 		case <-stopChan:
+			log.Println("stopping statsd generator")
 			return nil
 		case <-ticker.C:
 			// The type depends on the name.


### PR DESCRIPTION
# Description of the issue
Current statsd test is disabled.
It also relies on a specific bash script existing (part of a custom AMI).

I am re-enabling this test and reducing the need to run this test on a special AMI.

Now developers can run this test on any EC2 instance which has:
1. CWA installed
2. Go installed
3. This code repository checked out.

# Description of changes
Generate statsd metrics from a goroutine instead of relying on a bash script built into the AMI.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- `make compile`
- From an AL2 EC2 instance, `go test -v -p=1 -count=1 -timeout=60m ./test/metric_value_benchmark/ -computeType=EC2`:

```
[ec2-user@ip-172-31-17-153 amazon-cloudwatch-agent-test]$ go test -failfast -p=1 -count=1 -v -timeout=60m ./test/metric_value_benchmark/ -computeType=EC2
=== RUN   TestMetricValueBenchmarkSuite
>>>> Starting MetricBenchmarkTestSuite
=== RUN   TestMetricValueBenchmarkSuite/TestAllInSuite
2023/03/01 22:22:02 Testing all EC2 plugins
2023/03/01 22:22:02 Running Statsd
2023/03/01 22:22:02 Starting agent using agent config file agent_configs/statsd_config.json
2023/03/01 22:22:02 Copy File agent_configs/statsd_config.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/03/01 22:22:02 File agent_configs/statsd_config.json abs path /home/ec2-user/go/src/github.com/aws/amazon-cloudwatch-agent-test/test/metric_value_benchmark/agent_configs/statsd_config.json
2023/03/01 22:22:02 File : agent_configs/statsd_config.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/03/01 22:22:02 Agent has started
2023/03/01 22:25:02 Agent has been running for : 3m0s
2023/03/01 22:25:03 Agent is stopped
2023/03/01 22:25:03 Delete file /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/03/01 22:25:03 Removed file: /opt/aws/amazon-cloudwatch-agent/bin/config.json
2023/03/01 22:25:03 instruction {InstanceId {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {InstanceId {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {0xc0000347d0 0xc0000347e0 {}}
2023/03/01 22:25:03 Result dim is : InstanceId, i-0b4086af301a93a8d
2023/03/01 22:25:03 instruction {metric_type {0xc0002103f0}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {metric_type {0xc0002103f0}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {metric_type {0xc0002103f0}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {metric_type {0xc0002103f0}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {metric_type {0xc0002103f0}} provider CustomDimensionProvider returned dimension {0xc000034860 0xc000034870 {}}
2023/03/01 22:25:03 Result dim is : metric_type, counter
2023/03/01 22:25:03 instruction {key1 {0xc000034170}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {key1 {0xc000034170}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {key1 {0xc000034170}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {key1 {0xc000034170}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {key1 {0xc000034170}} provider CustomDimensionProvider returned dimension {0xc0000348f0 0xc000034900 {}}
2023/03/01 22:25:03 Result dim is : key1, val1
2023/03/01 22:25:03 Metric query input dimensions
2023/03/01 22:25:03 	Dimensions:
2023/03/01 22:25:03 		Dim(name="InstanceId", val="i-0b4086af301a93a8d"
2023/03/01 22:25:03 		Dim(name="metric_type", val="counter"
2023/03/01 22:25:03 		Dim(name="key1", val="val1"
2023/03/01 22:25:03 Metric data input: namespace statsd_test, name my_statsd_counter_1677709322689398517, stat Average, period 30
2023/03/01 22:25:03 Metric values are : [5 5 5 5 5 4.8]
2023/03/01 22:25:03 Values are all greater than or equal to zero for my_statsd_counter_1677709322689398517
2023/03/01 22:25:03 instruction {InstanceId {<nil>}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {InstanceId {<nil>}} provider LocalInstanceIdDimensionProvider returned dimension {0xc00030eb90 0xc00030eba0 {}}
2023/03/01 22:25:03 Result dim is : InstanceId, i-0b4086af301a93a8d
2023/03/01 22:25:03 instruction {metric_type {0xc0003e16b0}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {metric_type {0xc0003e16b0}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {metric_type {0xc0003e16b0}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {metric_type {0xc0003e16b0}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {metric_type {0xc0003e16b0}} provider CustomDimensionProvider returned dimension {0xc00030ec20 0xc00030ec30 {}}
2023/03/01 22:25:03 Result dim is : metric_type, gauge
2023/03/01 22:25:03 instruction {key2 {0xc00030eb60}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {key2 {0xc00030eb60}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {key2 {0xc00030eb60}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {key2 {0xc00030eb60}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {key2 {0xc00030eb60}} provider CustomDimensionProvider returned dimension {0xc00030ecb0 0xc00030ecc0 {}}
2023/03/01 22:25:03 Result dim is : key2, val2
2023/03/01 22:25:03 instruction {key3 {0xc00030eb70}} provider HostDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {key3 {0xc00030eb70}} provider LocalInstanceIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {key3 {0xc00030eb70}} provider LocalImageIdDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {key3 {0xc00030eb70}} provider LocalInstanceTypeDimensionProvider returned dimension {<nil> <nil> {}}
2023/03/01 22:25:03 instruction {key3 {0xc00030eb70}} provider CustomDimensionProvider returned dimension {0xc00030ed40 0xc00030ed50 {}}
2023/03/01 22:25:03 Result dim is : key3, val3
2023/03/01 22:25:03 Metric query input dimensions
2023/03/01 22:25:03 	Dimensions:
2023/03/01 22:25:03 		Dim(name="InstanceId", val="i-0b4086af301a93a8d"
2023/03/01 22:25:03 		Dim(name="metric_type", val="gauge"
2023/03/01 22:25:03 		Dim(name="key2", val="val2"
2023/03/01 22:25:03 		Dim(name="key3", val="val3"
2023/03/01 22:25:03 Metric data input: namespace statsd_test, name my_statsd_gauge_1677709322689398517, stat Average, period 30
2023/03/01 22:25:03 Metric values are : [1 1 1 1 1 1]
2023/03/01 22:25:03 Values are all greater than or equal to zero for my_statsd_gauge_1677709322689398517
2023/03/01 22:25:03 >>>>>>>>>>>>>><<<<<<<<<<<<<<
2023/03/01 22:25:03 >>>>>>>>>>>>>>Successful<<<<<<<<<<<<<<
2023/03/01 22:25:03 ==============Statsd==============
2023/03/01 22:25:03 ==============Successful==============
my_statsd_counter_1677709322689398517   Successful  
my_statsd_gauge_1677709322689398517     Successful  
2023/03/01 22:25:03 ==============================
2023/03/01 22:25:03 >>>>>>>>>>>>>>><<<<<<<<<<<<<<<
>>>> Finished MetricBenchmarkTestSuite
--- PASS: TestMetricValueBenchmarkSuite (181.43s)
    --- PASS: TestMetricValueBenchmarkSuite/TestAllInSuite (181.43s)
PASS
ok  	github.com/aws/amazon-cloudwatch-agent-test/test/metric_value_benchmark	181.432s
[ec2-user@ip-172-31-17-153 amazon-cloudwatch-agent-test]$ 
```

