### PR TITLE
Send metrics to database after query performance metrics from CWA

### DIFF
--- a/generator/resources/ec2_performance_test_matrix.json
+++ b/generator/resources/ec2_performance_test_matrix.json
@@ -6,16 +6,6 @@
         "ami": "cloudwatch-agent-integration-test-al2*",
         "arc": "amd64",
         "binaryName": "amazon-cloudwatch-agent.rpm",
-        "valuesPerMinute": 10,
-        "family": "linux"
-      },
-      {
-        "os": "al2",
-        "username": "ec2-user",
-        "installAgentCommand": "go run ./install/install_agent.go rpm",
-        "ami": "cloudwatch-agent-integration-test-al2*",
-        "arc": "amd64",
-        "binaryName": "amazon-cloudwatch-agent.rpm",
         "valuesPerMinute": 100,
         "family": "linux"
       },
@@ -27,6 +17,16 @@
         "arc": "amd64",
         "binaryName": "amazon-cloudwatch-agent.rpm",
         "valuesPerMinute": 1000,
+        "family": "linux"
+      },
+      {
+        "os": "al2",
+        "username": "ec2-user",
+        "installAgentCommand": "go run ./install/install_agent.go rpm",
+        "ami": "cloudwatch-agent-integration-test-al2*",
+        "arc": "amd64",
+        "binaryName": "amazon-cloudwatch-agent.rpm",
+        "valuesPerMinute": 5000,
         "family": "linux"
       }
 ]

--- a/go.mod
+++ b/go.mod
@@ -18,10 +18,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.33.0
 	github.com/cactus/go-statsd-client/v5 v5.0.0
 	github.com/cenkalti/backoff/v4 v4.2.0
-	github.com/google/uuid v1.3.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/multierr v1.9.0
+	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
 	golang.org/x/sys v0.2.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
@@ -106,6 +104,8 @@ go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=
 go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTVQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/internal/awsservice/dynamodb.go
+++ b/internal/awsservice/dynamodb.go
@@ -45,7 +45,7 @@ func AddItemIntoDatabaseIfNotExist(databaseName string, checkingAttribute, check
 				"#second_attribute": checkingAttribute[1],
 			},
 			ExpressionAttributeValues: map[string]types.AttributeValue{
-				":first_attribute":  &types.AttributeValueMemberN{Value: checkingAttributeValue[0]},
+				":first_attribute":  &types.AttributeValueMemberS{Value: checkingAttributeValue[0]},
 				":second_attribute": &types.AttributeValueMemberS{Value: checkingAttributeValue[1]},
 			},
 		})

--- a/internal/common/metrics.go
+++ b/internal/common/metrics.go
@@ -12,10 +12,8 @@ import (
 	"go.uber.org/multierr"
 )
 
-// StartLogWrite starts go routines to write logs to each of the logs that are monitored by CW Agent according to
-// the config provided
-func StartSendingMetrics(receiver string, agentRunDuration time.Duration, dataRate int) error {
-	//create wait group so main test thread waits for log writing to finish before stopping agent and collecting data
+// StartSendingMetrics will generate metrics load based on the receiver (e.g 5000 statsd metrics per minute)
+func StartSendingMetrics(receiver string, duration time.Duration, metricPerMinute int) error {
 	var (
 		err      error
 		multiErr error
@@ -27,7 +25,7 @@ func StartSendingMetrics(receiver string, agentRunDuration time.Duration, dataRa
 		defer wg.Done()
 		switch receiver {
 		case "statsd":
-			err = sendStatsdMetrics(dataRate, agentRunDuration)
+			err = sendStatsdMetrics(metricPerMinute, duration)
 
 		default:
 		}
@@ -39,7 +37,7 @@ func StartSendingMetrics(receiver string, agentRunDuration time.Duration, dataRa
 	return multiErr
 }
 
-func sendStatsdMetrics(dataRate int, duration time.Duration) error {
+func sendStatsdMetrics(metricPerMinute int, duration time.Duration) error {
 	// https://github.com/cactus/go-statsd-client#example
 	statsdClientConfig := &statsd.ClientConfig{
 		Address:     ":8125",
@@ -64,7 +62,7 @@ func sendStatsdMetrics(dataRate int, duration time.Duration) error {
 	for {
 		select {
 		case <-ticker.C:
-			for time := 0; time < dataRate; time++ {
+			for time := 0; time < metricPerMinute; time++ {
 				go func(time int) {
 					client.Inc(fmt.Sprintf("%v", time), int64(time), 1.0)
 				}(time)

--- a/test/performance/logs/parameters.yml
+++ b/test/performance/logs/parameters.yml
@@ -4,7 +4,7 @@ test_case: "logs_performance"
 validate_type: "performance"
 data_type: "logs"
 # Number of logs being written
-number_monitored_logs: 1000
+number_monitored_logs: 100
 # Number of metrics to be sent or number of log lines being written  each minute
 values_per_minute: "<values_per_minute>"
 # Number of seconds the agent should run and collect the metrics. In this case, 10 minutes

--- a/test/stress/statsd/parameters.yml
+++ b/test/stress/statsd/parameters.yml
@@ -6,8 +6,7 @@ test_case: "statsd_stress"
 validate_type: "stress"
 # Only support metrics/traces/logs
 data_type: "metrics"
-# Number of logs being written
-number_monitored_logs: 1000
+
 # Number of metrics to be sent or number of log lines being written  each minute
 values_per_minute: "<values_per_minute>"
 # Number of seconds the agent should run and collect the metrics. In this case, 10 minutes

--- a/validator/validators/performance/performance_models.go
+++ b/validator/validators/performance/performance_models.go
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package performance
+
+type PerformanceInformation map[string]interface{}
+
+/*
+	Contains the following:
+		// A service name we want to monitor (e.g CloudWatchAgent)
+		"Service":          ServiceName,
+		// A use case for generate metrics loads (e.g statsd, collectd)
+		"UseCase":          receiver,
+		// Commit Information
+		"CommitDate":       commitDate,
+		"CommitHash":       commitHash,
+		// Data type (e.g metrics/traces/logs)
+		"DataType":         dataType,
+		// Performance metrics of the monitored services.
+		"Results":          result,
+		// The duration of time when running the services
+		"CollectionPeriod": collectionPeriod,
+		"InstanceAMI":      instanceAMI,
+		"InstanceType":     instanceType,
+*/

--- a/validator/validators/performance/performance_stats.go
+++ b/validator/validators/performance/performance_stats.go
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package performance
+
+import (
+	"log"
+	"math"
+	"sort"
+)
+
+type Stats struct {
+	Average float64
+	P99     float64 //99% percent process
+	Max     float64
+	Min     float64
+	Period  int //in seconds
+	Std     float64
+}
+
+/*
+CalculateMetricStatisticsBasedOnDataAndPeriod takes in an array of data and returns the average, min, max, p99, and stdev of the data.
+statistics are calculated this way instead of using GetMetricStatistics API because GetMetricStatistics would require multiple
+API calls as only one metric can be requested/processed at a time whereas all metrics can be requested in one GetMetricData request.
+*/
+func CalculateMetricStatisticsBasedOnDataAndPeriod(data []float64, dataPeriod float64) Stats {
+	length := len(data)
+	if length == 0 {
+		return Stats{}
+	}
+
+	sort.Float64s(data)
+
+	min := data[0]
+	max := data[length-1]
+
+	sum := 0.0
+	for _, value := range data {
+		sum += value
+	}
+
+	avg := sum / float64(length)
+
+	if length < 99 {
+		log.Println("Note: less than 99 values given, p99 value will be equal the max value")
+	}
+	p99Index := int(float64(length)*.99) - 1
+	p99Val := data[p99Index]
+
+	stdDevSum := 0.0
+	for _, value := range data {
+		stdDevSum += math.Pow(avg-value, 2)
+	}
+
+	return Stats{
+		Average: avg,
+		Max:     max,
+		Min:     min,
+		P99:     p99Val,
+		Std:     math.Sqrt(stdDevSum / float64(length)),
+		Period:  int(dataPeriod / float64(length)),
+	}
+}

--- a/validator/validators/performance/performance_validator.go
+++ b/validator/validators/performance/performance_validator.go
@@ -4,11 +4,30 @@
 package performance
 
 import (
+	"fmt"
+	"log"
+	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/cenkalti/backoff/v4"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/internal/awsservice"
 	"github.com/aws/amazon-cloudwatch-agent-test/internal/common"
 	"github.com/aws/amazon-cloudwatch-agent-test/validator/models"
+)
+
+const (
+	ServiceName      = "AmazonCloudWatchAgent"
+	DynamoDBDataBase = "CWAPerformanceMetrics"
+)
+
+var (
+	// The default unit for these metrics is byte. However, we want to convert to MB for easier understanding
+	metricsConvertToMB = []string{"mem_total", "procstat_memory_rss", "procstat_memory_swap", "procstat_memory_data", "procstat_memory_vms", "procstat_write_bytes", "procstat_bytes_sent"}
 )
 
 type PerformanceValidator struct {
@@ -42,6 +61,20 @@ func (s *PerformanceValidator) GenerateLoad() (err error) {
 }
 
 func (s *PerformanceValidator) CheckData(startTime, endTime time.Time) error {
+	metrics, err := s.GetPerformanceMetrics(startTime, endTime)
+	if err != nil {
+		return err
+	}
+
+	perfInfo, err := s.CalculateMetricStatsAndPackMetrics(metrics)
+	if err != nil {
+		return err
+	}
+
+	err = s.SendPacketToDatabase(perfInfo)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -56,4 +89,154 @@ func (s *PerformanceValidator) Cleanup() error {
 	}
 
 	return nil
+}
+
+func (s *PerformanceValidator) SendPacketToDatabase(perfInfo PerformanceInformation) error {
+	var (
+		dataType               = s.vConfig.GetDataType()
+		receiver               = s.vConfig.GetPluginsConfig()
+		commitHash, commitDate = s.vConfig.GetCommitInformation()
+		agentCollectionPeriod  = fmt.Sprint(s.vConfig.GetAgentCollectionPeriod().Seconds())
+		// The secondary global index that is used for checking if there are item has already been exist in the table
+		// The performance validator will query based on the UseCaseHash to confirm if the current commit with the use case
+		// has been exist or not? If yes, merge it. If not, sending it to the database
+		// https://github.com/aws/amazon-cloudwatch-agent-test/blob/e07fe7adb1b1d75244d8984507d3f83a7237c3d3/terraform/setup/main.tf#L46-L53
+		kCheckingAttribute = []string{"CommitHash", "UseCase"}
+		vCheckingAttribute = []string{fmt.Sprint(commitHash), receiver}
+	)
+
+	err := backoff.Retry(func() error {
+		existingPerfInfo, err := awsservice.GetItemInDatabase(DynamoDBDataBase, "UseCaseHash", kCheckingAttribute, vCheckingAttribute, perfInfo)
+		if err != nil {
+			return err
+		}
+
+		// Get the latest performance information from the database and update by merging the existing one
+		// and finally replace the packet in the database
+		maps.Copy(existingPerfInfo["Results"].(map[string]interface{}), perfInfo["Results"].(map[string]interface{}))
+
+		finalPerfInfo := packIntoPerformanceInformation(receiver, dataType, agentCollectionPeriod, commitHash, commitDate, existingPerfInfo["Results"])
+
+		err = awsservice.ReplaceItemInDatabase(DynamoDBDataBase, finalPerfInfo)
+
+		if err != nil {
+			return err
+		}
+		return nil
+	}, awsservice.StandardExponentialBackoff)
+
+	return err
+}
+func (s *PerformanceValidator) CalculateMetricStatsAndPackMetrics(metrics []types.MetricDataResult) (PerformanceInformation, error) {
+	var (
+		receiver               = s.vConfig.GetPluginsConfig()
+		commitHash, commitDate = s.vConfig.GetCommitInformation()
+		dataType               = s.vConfig.GetDataType()
+		dataRate               = fmt.Sprint(s.vConfig.GetDataRate())
+		agentCollectionPeriod  = s.vConfig.GetAgentCollectionPeriod().Seconds()
+	)
+	performanceMetricResults := make(map[string]Stats)
+
+	for _, metric := range metrics {
+		metricLabel := strings.Split(*metric.Label, " ")
+		metricName := metricLabel[len(metricLabel)-1]
+		metricValues := metric.Values
+		//Convert every bytes to MB
+		if slices.Contains(metricsConvertToMB, metricName) {
+			for i, val := range metricValues {
+				metricValues[i] = val / (1024 * 1024)
+			}
+		}
+		log.Printf("Start calculate metric statictics for metric %s %v", metricName, metricValues)
+		if !isAllValuesGreaterThanOrEqualToZero(metricValues) {
+			return nil, fmt.Errorf("values are not all greater than or equal to zero for metric %s with values: %v", metricName, metricValues)
+		}
+		metricStats := CalculateMetricStatisticsBasedOnDataAndPeriod(metricValues, agentCollectionPeriod)
+		log.Printf("Finished calculate metric statictics for metric %s: %v", metricName, metricStats)
+		performanceMetricResults[metricName] = metricStats
+	}
+
+	return packIntoPerformanceInformation(receiver, dataType, fmt.Sprint(agentCollectionPeriod), commitHash, commitDate, map[string]interface{}{dataRate: performanceMetricResults}), nil
+}
+
+func (s *PerformanceValidator) GetPerformanceMetrics(startTime, endTime time.Time) ([]types.MetricDataResult, error) {
+	var (
+		metricNamespace              = s.vConfig.GetMetricNamespace()
+		validationMetric             = s.vConfig.GetMetricValidation()
+		ec2InstanceId                = awsservice.GetInstanceId()
+		performanceMetricDataQueries = []types.MetricDataQuery{}
+	)
+	log.Printf("Start getting performance metrics from CloudWatch")
+	for _, metric := range validationMetric {
+		metricDimensions := []types.Dimension{
+			{
+				Name:  aws.String("InstanceId"),
+				Value: aws.String(ec2InstanceId),
+			},
+		}
+		for _, dimension := range metric.MetricDimension {
+			metricDimensions = append(metricDimensions, types.Dimension{
+				Name:  aws.String(dimension.Name),
+				Value: aws.String(dimension.Value),
+			})
+		}
+		performanceMetricDataQueries = append(performanceMetricDataQueries, s.buildStressMetricQueries(metric.MetricName, metricNamespace, metricDimensions))
+	}
+
+	metrics, err := awsservice.GetMetricData(performanceMetricDataQueries, startTime, endTime)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return metrics.MetricDataResults, nil
+}
+
+func (s *PerformanceValidator) buildStressMetricQueries(metricName, metricNamespace string, metricDimensions []types.Dimension) types.MetricDataQuery {
+	metricInformation := types.Metric{
+		Namespace:  aws.String(metricNamespace),
+		MetricName: aws.String(metricName),
+		Dimensions: metricDimensions,
+	}
+
+	metricDataQuery := types.MetricDataQuery{
+		MetricStat: &types.MetricStat{
+			Metric: &metricInformation,
+			Period: aws.Int32(10),
+			Stat:   aws.String(string(models.AVERAGE)),
+		},
+		Id: aws.String(strings.ToLower(metricName)),
+	}
+	return metricDataQuery
+}
+
+// packIntoPerformanceInformation will package all the information into the required format of MongoDb Database
+// https://github.com/aws/amazon-cloudwatch-agent-test/blob/e07fe7adb1b1d75244d8984507d3f83a7237c3d3/terraform/setup/main.tf#L8-L63
+func packIntoPerformanceInformation(receiver, dataType, collectionPeriod, commitHash string, commitDate int64, result interface{}) PerformanceInformation {
+	instanceAMI := awsservice.GetImageId()
+	instanceType := awsservice.GetInstanceType()
+
+	return PerformanceInformation{
+		"Service":          ServiceName,
+		"UseCase":          receiver,
+		"CommitDate":       commitDate,
+		"CommitHash":       commitHash,
+		"DataType":         dataType,
+		"Results":          result,
+		"CollectionPeriod": collectionPeriod,
+		"InstanceAMI":      instanceAMI,
+		"InstanceType":     instanceType,
+	}
+}
+
+func isAllValuesGreaterThanOrEqualToZero(values []float64) bool {
+	if len(values) == 0 {
+		return false
+	}
+	for _, value := range values {
+		if value < 0 {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
# Description of the issue
Continue as part of onboarding metrics load to [performance validator test](https://github.com/aws/amazon-cloudwatch-agent-test/pull/151). As discussed in the previous PR,  there are three stages when starting the validator:

* [GenerateLoad](https://github.com/aws/amazon-cloudwatch-agent-test/blob/main/validator/models/validator_factory.go#L10): Sending the load to CloudWatchAgent
* [CheckData](https://github.com/aws/amazon-cloudwatch-agent-test/blob/main/validator/models/validator_factory.go#L11) : To get metrics defined [by the yaml and validate the metrics](https://github.com/aws/amazon-cloudwatch-agent-test/compare/main...khanhntd:amazon-cloudwatch-agent-test:add_performance?expand=1#diff-4182821602cec8db84c8b29427a65c5a63beff4c19bcf93e305966bed05a721eR20-R72)
* [Cleanup](https://github.com/aws/amazon-cloudwatch-agent-test/blob/main/validator/models/validator_factory.go#L12) to clean up all the resources created by the validator.

As part of previous PR, we already have `GenerateLoad` and `CleanUp`. Therefore, we are  adding the remaining part with `CheckData` since the whole operations inside the CheckData for performance test would be:
* [Get the performance metrics of CWA](https://github.com/aws/amazon-cloudwatch-agent-test/pull/153/files#diff-334efd747575193d3505843e769add29bb2818c73a18ca77c9c4f97105ec3104R162-R193) after [generate loads to CWA ](https://github.com/aws/amazon-cloudwatch-agent-test/pull/153/files#diff-334efd747575193d3505843e769add29bb2818c73a18ca77c9c4f97105ec3104R45-R60)based on the required metrics by the generator configuration: `parameters.yml` (e.g logs)
*[ Calculate the performance metrics and generate metrics with statistical value](https://github.com/aws/amazon-cloudwatch-agent-test/pull/153/files#diff-334efd747575193d3505843e769add29bb2818c73a18ca77c9c4f97105ec3104R151-R156) (e.g max, min, p99, stddev) - porting from intern project
* Send the [final performance metrics of CWA  with statistical values to database ](https://github.com/aws/amazon-cloudwatch-agent-test/pull/153/files#diff-334efd747575193d3505843e769add29bb2818c73a18ca77c9c4f97105ec3104R94-R129)

# Description of changes
Sending the performance metrics to Database will help us in recording the performance metrics of CWA during each commit and will reflect in the [FrontEnd Page](https://aws.github.io/amazon-cloudwatch-agent/)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
By running the fork, I have able to validate [the performance test with logs successfully](https://github.com/khanhntd/amazon-cloudwatch-agent/actions/runs/4310619379)

We can see the performance metrics results with before calculate statistics
```
null_resource.integration_test (remote-exec): 2023/03/02 06:02:03 Start calculate metric statictics for metric net_packets_sent [2.1 2.7 5.2 2.8 1107 1939.4 2.2 2.4 5.6 2.5 999.1 1974.7 2.4 2.6 5.3 2.7 952.4 1793.5 2.5 2.5 5.2 2.8 1140.7 2129.8 2.2 2.9 5.8 2.4 993.7 1788.2 2.1 2.9 5.3 2.9 1011.2 2019.7 2 2.7 5.5 2.8 1036.2 2129.3 2.1 2.5 7.1 4 1146.4 1955.6 2.8 101.3 1674.9 6445.9 10610.5 3926.1 2.4 4.1 5.2 2.6 513.5 998.5]
```

and after calculating it,
```
Finished calculate metric statictics for metric net_packets_sent: {440.21999999999997 1905 7416.3 2 10 1110.0022529706866}
```
which will have the following results in the database
```
{"100":{"M":{"net_bytes_sent":{"M":{"Average":{"N":"101782.97666666667"},"P99":{"N":"444492.2"},"Period":{"N":"10"},"Std":{"N":"262448.01973010856"},"Min":{"N":"204"},"Max":{"N":"1754209.5"}}},"procstat_memory_rss":{"M":{"Average":{"N":"583.3093119999997"},"P99":{"N":"664.543232"},"Period":{"N":"10"},"Std":{"N":"110.14129714232358"},"Min":{"N":"142.7677184"},"Max":{"N":"664.543232"}}},"procstat_memory_data":{"M":{"Average":{"N":"892.3917516799997"},"P99":{"N":"934.526976"},"Period":{"N":"10"},"Std":{"N":"121.28089734791472"},"Min":{"N":"364.0348672"},"Max":{"N":"934.526976"}}},"procstat_write_bytes":{"M":{"Average":{"N":"19.91503872"},"P99":{"N":"40.026112"},"Period":{"N":"10"},"Std":{"N":"12.497415181559536"},"Min":{"N":"0.606208"},"Max":{"N":"40.026112"}}},"procstat_num_fds":{"M":{"Average":{"N":"1018.4249999999996"},"Period":{"N":"10"},"P99":{"N":"1100"},"Std":{"N":"42.473586399863485"},"Min":{"N":"817.9"},"Max":{"N":"1182.9"}}},"procstat_memory_vms":{"M":{"Average":{"N":"1621.6943274666667"},"Period":{"N":"10"},"P99":{"N":"1663.004672"},"Std":{"N":"119.11964320756728"},"Min":{"N":"1103.4177536"},"Max":{"N":"1663.004672"}}},"net_packets_sent":{"M":{"Average":{"N":"440.21999999999997"},"Period":{"N":"10"},"P99":{"N":"1905"},"Std":{"N":"1110.0022529706866"},"Min":{"N":"2"},"Max":{"N":"7416.3"}}},"procstat_memory_swap":{"M":{"Average":{"N":"0"},"P99":{"N":"0"},"Period":{"N":"10"},"Std":{"N":"0"},"Min":{"N":"0"},"Max":{"N":"0"}}},"procstat_cpu_usage":{"M":{"Average":{"N":"38.337993510195396"},"P99":{"N":"70.25992208910591"},"Period":{"N":"10"},"Std":{"N":"18.821200930328175"},"Min":{"N":"26.799011825037034"},"Max":{"N":"143.73881954361354"}}},"mem_total":{"M":{"Average":{"N":"16629.624832"},"Period":{"N":"10"},"P99":{"N":"16629.624832"},"Std":{"N":"0"},"Min":{"N":"16629.624832"},"Max":{"N":"16629.624832"}}}}},"1000":{"M":{"net_bytes_sent":{"M":{"Average":{"N":"262898.7233333333"},"P99":{"N":"1777264.6"},"Period":{"N":"10"},"Std":{"N":"497871.2742885174"},"Min":{"N":"204"},"Max":{"N":"2745740.6"}}},"procstat_memory_rss":{"M":{"Average":{"N":"1011.03736832"},"P99":{"N":"1415.094272"},"Period":{"N":"10"},"Std":{"N":"318.7403520065071"},"Min":{"N":"155.6729856"},"Max":{"N":"1451.515904"}}},"procstat_memory_data":{"M":{"Average":{"N":"1518.9065864533325"},"Period":{"N":"10"},"P99":{"N":"1677.258752"},"Std":{"N":"344.9219847555371"},"Min":{"N":"408.28887039999995"},"Max":{"N":"1677.258752"}}},"procstat_write_bytes":{"M":{"Average":{"N":"35.32088661333332"},"Period":{"N":"10"},"P99":{"N":"71.811072"},"Std":{"N":"22.709789979639456"},"Min":{"N":"0.6168576"},"Max":{"N":"71.811072"}}},"procstat_num_fds":{"M":{"Average":{"N":"1022.5049999999997"},"Period":{"N":"10"},"P99":{"N":"1106.1"},"Std":{"N":"40.53155324353279"},"Min":{"N":"918.1"},"Max":{"N":"1234.9"}}},"procstat_memory_vms":{"M":{"Average":{"N":"2272.375343786666"},"Period":{"N":"10"},"P99":{"N":"2435.096576"},"Std":{"N":"346.1554123972458"},"Min":{"N":"1145.1551744"},"Max":{"N":"2435.096576"}}},"net_packets_sent":{"M":{"Average":{"N":"808.5233333333332"},"P99":{"N":"6445.9"},"Period":{"N":"10"},"Std":{"N":"1704.3037622801346"},"Min":{"N":"2"},"Max":{"N":"10610.5"}}},"procstat_memory_swap":{"M":{"Average":{"N":"0"},"Period":{"N":"10"},"P99":{"N":"0"},"Std":{"N":"0"},"Min":{"N":"0"},"Max":{"N":"0"}}},"procstat_cpu_usage":{"M":{"Average":{"N":"74.2988991248597"},"P99":{"N":"260.1542794940978"},"Period":{"N":"10"},"Std":{"N":"76.76523848282207"},"Min":{"N":"30.397399469761876"},"Max":{"N":"276.58494463653733"}}},"mem_total":{"M":{"Average":{"N":"16629.633023999988"},"P99":{"N":"16629.633024"},"Period":{"N":"10"},"Std":{"N":"0.000000000010913936421275139"},"Min":{"N":"16629.633024"},"Max":{"N":"16629.633024"}}}}},"5000":{"M":{"net_bytes_sent":{"M":{"Average":{"N":"721695.5458796296"},"P99":{"N":"2645431.7"},"Period":{"N":"10"},"Std":{"N":"786688.2384752069"},"Min":{"N":"204"},"Max":{"N":"2887132.4"}}},"procstat_memory_rss":{"M":{"Average":{"N":"1842.593798516364"},"P99":{"N":"2544.0067584000003"},"Period":{"N":"10"},"Std":{"N":"632.5301123247696"},"Min":{"N":"156.5376512"},"Max":{"N":"2718.820352"}}},"procstat_memory_data":{"M":{"Average":{"N":"2489.3376261688873"},"P99":{"N":"2948.247552"},"Period":{"N":"10"},"Std":{"N":"744.5015757734853"},"Min":{"N":"393.41096960000004"},"Max":{"N":"2948.247552"}}},"procstat_write_bytes":{"M":{"Average":{"N":"73.25300389494949"},"Period":{"N":"10"},"P99":{"N":"163.950592"},"Std":{"N":"52.61340434165167"},"Min":{"N":"0.6180864"},"Max":{"N":"164.708352"}}},"procstat_num_fds":{"M":{"Average":{"N":"1112.151022727273"},"Period":{"N":"10"},"P99":{"N":"1370.75"},"Std":{"N":"127.7780998979802"},"Min":{"N":"873.7"},"Max":{"N":"1471.5454545454545"}}},"procstat_memory_vms":{"M":{"Average":{"N":"3227.111095561484"},"P99":{"N":"3701.886976"},"Period":{"N":"10"},"Std":{"N":"746.683073865154"},"Min":{"N":"1124.405248"},"Max":{"N":"3701.886976"}}},"net_packets_sent":{"M":{"Average":{"N":"1792.2091919191919"},"P99":{"N":"9117"},"Period":{"N":"10"},"Std":{"N":"2150.6997429231947"},"Min":{"N":"2"},"Max":{"N":"11005.7"}}},"procstat_memory_swap":{"M":{"Average":{"N":"0"},"Period":{"N":"10"},"P99":{"N":"0"},"Std":{"N":"0"},"Min":{"N":"0"},"Max":{"N":"0"}}},"procstat_cpu_usage":{"M":{"Average":{"N":"185.19243401744816"},"Period":{"N":"10"},"P99":{"N":"398.0546356201349"},"Std":{"N":"136.71815787944305"},"Min":{"N":"24.401007856901565"},"Max":{"N":"398.23272558931444"}}},"mem_total":{"M":{"Average":{"N":"16629.633023999988"},"P99":{"N":"16629.633024"},"Period":{"N":"10"},"Std":{"N":"0.000000000010913936421275139"},"Min":{"N":"16629.633024"},"Max":{"N":"16629.633024"}}}}}}
```

![image](https://user-images.githubusercontent.com/91758108/222344762-aba3f122-9b66-4678-b4f5-54b4f86e26ec.png)
