### PR TITLE
Arm64 Mac Needs To Use mac2.metal

### DIFF
--- a/generator/resources/ec2_mac_test_matrix.json
+++ b/generator/resources/ec2_mac_test_matrix.json
@@ -1,7 +1,7 @@
 [
       {
         "os": "macOS Big Sur Arm64",
-        "instanceType":"mac1.metal",
+        "instanceType":"mac2.metal",
         "ami": "amzn-ec2-macos-11.*",
         "arc": "arm64"
       },


### PR DESCRIPTION
# Description of the issue
│ Error: creating EC2 Instance: InvalidParameterValue: The architecture 'x86_64_mac' of the specified instance type does not match the architecture 'arm64_mac' of the specified AMI. Specify an instance type and an AMI that have matching architectures, and try again. You can use 'describe-instance-types' or 'describe-images' to discover the architecture of the instance type or AMI.

# Description of changes
Fix the issue by matching arc to instance tpye

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
None
