### PR TITLE
Sleep for 5 secs between flush cycles for collectd metrics

### DIFF
--- a/internal/common/metrics.go
+++ b/internal/common/metrics.go
@@ -89,6 +89,8 @@ func SendCollectDMetrics(metricPerInterval int, sendingInterval, duration time.D
 		return err
 	}
 
+	time.Sleep(5 * time.Second)
+
 	for {
 		select {
 		case <-ticker.C:

--- a/test/test_runner/base_test_runner.go
+++ b/test/test_runner/base_test_runner.go
@@ -63,7 +63,7 @@ func (t *TestRunner) Run(s ITestSuite) {
 	}
 	s.AddToSuiteResult(testGroupResult)
 	if testGroupResult.GetStatus() != status.SUCCESSFUL {
-		log.Printf("%v test group failed", testName)
+		log.Printf("%v test group failed due to %v", testName, err)
 	}
 }
 


### PR DESCRIPTION
# Description of the issue
Collectd tests are currently failing with the following error:
```
2023/05/07 06:10:11 CollectD test group failed due to: %!w(*fmt.wrapError=&{Failed to complete setup after agent run due to: write udp 127.0.0.1:44705->127.0.0.1:25826: write: connection refused 0xc00026f400})
```

# Description of changes
Adding a small sleep between the flush cycles seemingly fixes the issue but root cause analysis to understand why the [first flush call](https://github.com/sky333999/amazon-cloudwatch-agent-test/blob/f36ca319f7683c8a41a2451a5c053d44d33ade3b/internal/common/metrics.go#L88) does not receive a connection refused but the [subsequent one](https://github.com/sky333999/amazon-cloudwatch-agent-test/blob/f36ca319f7683c8a41a2451a5c053d44d33ade3b/internal/common/metrics.go#L125) does is pending.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* GHA tests no longer fail
