### PR TITLE
Use new name tag for canary test

### DIFF
--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -52,7 +52,7 @@ resource "aws_instance" "cwagent" {
   }
 
   tags = {
-    Name = "cwagent-integ-test-ec2-${var.test_name}-${module.common.testing_id}"
+    Name = var.is_canary ? "cwagent-canary-test-ec2-${var.test_name}-${module.common.testing_id}" : "cwagent-integ-test-ec2-${var.test_name}-${module.common.testing_id}"
   }
 }
 


### PR DESCRIPTION
# Description of the issue
Canary tests have the same naming scheme as other regular integration tests which can make it hard to distinguish the instances being generated. This also causes issue if daily resource cleanup code terminates all integration tests on a daily basis which will also terminate canary at the same time.

# Description of changes
Change the name of canary tests instance name with the pattern of `cwagent-canary-test-ec2-${var.test_name}-${module.common.testing_id}`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Verified on personal account that the instances have been created correctly based on the new naming pattern.
