### PR TITLE
Container insights

### DIFF
--- a/docs/getting-start.md
+++ b/docs/getting-start.md
@@ -169,6 +169,7 @@ required for testing locally but is required for testing on your personal fork.
             "autoscaling:SetInstanceProtection",
             "autoscaling:UpdateAutoScalingGroup",
             "cloudwatch:GetMetricData",
+            "cloudwatch:ListMetrics",
             "dynamodb:*",
             "ec2:AuthorizeSecurityGroupEgress",
             "ec2:AuthorizeSecurityGroupIngress",

--- a/generator/resources/eks_daemon_test_matrix.json
+++ b/generator/resources/eks_daemon_test_matrix.json
@@ -1,16 +1,5 @@
 [
   {
-    "k8s_version": "1.24",
-    "test_dir": "./test/metric_value_benchmark"
-  },
-  {
-    "k8s_version": "1.24",
-    "test_dir": "./test/emf",
-    "terraform_dir": "terraform/eks/daemon/emf"
-  },
-  {
-    "k8s_version": "1.24",
-    "test_dir": "./test/statsd",
-    "terraform_dir":"terraform/eks/daemon/statsd"
+    "k8s_version": "1.24"
   }
 ]

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -94,8 +94,8 @@ var testTypeToTestConfig = map[string][]testConfig{
 
 	"eks_daemon": {
 		{"./test/metric_value_benchmark", ""},
-		// {"./test/statsd", "terraform/eks/daemon/statsd"},
-		// {"./test/emf", "terraform/eks/daemon/emf"},
+		{"./test/statsd", "terraform/eks/daemon/statsd"},
+		{"./test/emf", "terraform/eks/daemon/emf"},
 	},
 	"eks_deployment": {
 		{"./test/metric_value_benchmark", ""},

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -94,8 +94,8 @@ var testTypeToTestConfig = map[string][]testConfig{
 
 	"eks_daemon": {
 		{"./test/metric_value_benchmark", ""},
-		{"./test/statsd", "terraform/eks/daemon/statsd"},
-		{"./test/emf", "terraform/eks/daemon/emf"},
+		// {"./test/statsd", "terraform/eks/daemon/statsd"},
+		// {"./test/emf", "terraform/eks/daemon/emf"},
 	},
 	"eks_deployment": {
 		{"./test/metric_value_benchmark", ""},

--- a/test/metric/metric_list_query.go
+++ b/test/metric/metric_list_query.go
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package metric
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/internal/awsservice"
+)
+
+type MetricListFetcher struct {
+}
+
+func (n *MetricListFetcher) Fetch(namespace, metricName string, dimensions []types.Dimension) ([]types.Metric, error) {
+	var dims []types.DimensionFilter
+	for _, dim := range dimensions {
+		dims = append(dims, types.DimensionFilter{
+			Name:  dim.Name,
+			Value: dim.Value,
+		})
+	}
+
+	listMetricInput := cloudwatch.ListMetricsInput{
+		Namespace:  aws.String(namespace),
+		MetricName: aws.String(metricName),
+		Dimensions: dims,
+	}
+
+	log.Printf("Metric data input: namespace %v, name %v", namespace, metricName)
+
+	output, err := awsservice.CwmClient.ListMetrics(context.Background(), &listMetricInput)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting metric data %v", err)
+	}
+
+	log.Printf("Metrics fetched : %s", fmt.Sprint(output))
+
+	return output.Metrics, nil
+}

--- a/test/metric_value_benchmark/eks_daemonset_test.go
+++ b/test/metric_value_benchmark/eks_daemonset_test.go
@@ -77,6 +77,7 @@ func (e *EKSDaemonTestRunner) validateInstanceMetrics(name string) status.TestRe
 		}
 
 		if len(metrics) < 1 {
+			log.Println("metric list is empty")
 			return testResult
 		}
 

--- a/test/metric_value_benchmark/eks_daemonset_test.go
+++ b/test/metric_value_benchmark/eks_daemonset_test.go
@@ -150,14 +150,31 @@ func (e *EKSDaemonTestRunner) GetAgentRunDuration() time.Duration {
 
 func (e *EKSDaemonTestRunner) GetMeasuredMetrics() []string {
 	return []string{
+		"cluster_failed_node_count",
+		"cluster_node_count",
+		"namespace_number_of_running_pods",
+		"node_cpu_limit",
 		"node_cpu_reserved_capacity",
+		"node_cpu_usage_total",
 		"node_cpu_utilization",
-		"node_network_total_bytes",
 		"node_filesystem_utilization",
-		"node_number_of_running_pods",
-		"node_number_of_running_containers",
-		"node_memory_utilization",
+		"node_memory_limit",
 		"node_memory_reserved_capacity",
+		"node_memory_utilization",
+		"node_memory_working_set",
+		"node_network_total_bytes",
+		"node_number_of_running_containers",
+		"node_number_of_running_pods",
+		"pod_cpu_reserved_capacity",
+		"pod_cpu_utilization",
+		"pod_cpu_utilization_over_pod_limit",
+		"pod_memory_reserved_capacity",
+		"pod_memory_utilization",
+		"pod_memory_utilization_over_pod_limit",
+		"pod_network_rx_bytes",
+		"pod_network_tx_bytes",
+		"pod_number_of_container_restarts",
+		"service_number_of_running_pods",
 	}
 }
 


### PR DESCRIPTION
# Description of the issue
Container Insights test is missing all available metrics

# Description of changes
- Add metric list fetcher to fetch CI metrics with cluster name
- Add all CI metrics to `metric_value_benchmark` test


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested in personal fork
```
null_resource.validator (local-exec): 2023/06/01 12:48:29 Metric query input dimensions
null_resource.validator (local-exec): 2023/06/01 12:48:29 	Dimensions:
null_resource.validator (local-exec): 2023/06/01 12:48:29 		Dim(name="ClusterName", val="cwagent-eks-integ-3337d937533484d6"
null_resource.validator (local-exec): 2023/06/01 12:48:29 		Dim(name="PodName", val="aws-node"
null_resource.validator (local-exec): 2023/06/01 12:48:29 		Dim(name="ClusterName", val="cwagent-eks-integ-3337d937533484d6"
null_resource.validator (local-exec): 2023/06/01 12:48:29 		Dim(name="Namespace", val="kube-system"
null_resource.validator (local-exec): 2023/06/01 12:48:29 Metric data input: namespace ContainerInsights, name pod_number_of_container_restarts, stat Average, period 10
null_resource.validator (local-exec): 2023/06/01 12:48:29 Metric values are : [0 0 0 0]
null_resource.validator (local-exec): 2023/06/01 12:48:29 The average value 0.000000 for metric pod_number_of_container_restarts are within bound [0.000000, 0.000000]
null_resource.validator (local-exec): 2023/06/01 12:48:29 instruction {ClusterName {<nil>}} provider EKSClusterNameProvider returned dimension {0xc0000a35a0 0xc0000a35b0 {}}
null_resource.validator (local-exec): 2023/06/01 12:48:29 Result dim is : ClusterName, cwagent-eks-integ-3337d937533484d6
null_resource.validator (local-exec): 2023/06/01 12:48:29 Metric query input dimensions
null_resource.validator (local-exec): 2023/06/01 12:48:29 	Dimensions:
null_resource.validator (local-exec): 2023/06/01 12:48:29 		Dim(name="ClusterName", val="cwagent-eks-integ-3337d937533484d6"
null_resource.validator (local-exec): 2023/06/01 12:48:29 Metric data input: namespace ContainerInsights, name service_number_of_running_pods, stat Average, period 10
null_resource.validator (local-exec): 2023/06/01 12:48:29 Metric values are : [2 2 2 2 2]
null_resource.validator (local-exec): 2023/06/01 12:48:29 The average value 2.000000 for metric service_number_of_running_pods are within bound [0.000000, 0.000000]
...
null_resource.validator (local-exec): 2023/06/01 12:48:30 ==============EKSContainerInstance==============
null_resource.validator (local-exec): 2023/06/01 12:48:30 ==============Successful==============
null_resource.validator (local-exec): cluster_failed_node_count               Successful
null_resource.validator (local-exec): cluster_node_count                      Successful
null_resource.validator (local-exec): namespace_number_of_running_pods        Successful
null_resource.validator (local-exec): node_cpu_limit                          Successful
null_resource.validator (local-exec): node_cpu_reserved_capacity              Successful
null_resource.validator (local-exec): node_cpu_usage_total                    Successful
null_resource.validator (local-exec): node_cpu_utilization                    Successful
null_resource.validator (local-exec): node_filesystem_utilization             Successful
null_resource.validator (local-exec): node_memory_limit                       Successful
null_resource.validator (local-exec): node_memory_reserved_capacity           Successful
null_resource.validator (local-exec): node_memory_utilization                 Successful
null_resource.validator (local-exec): node_memory_working_set                 Successful
null_resource.validator (local-exec): node_network_total_bytes                Successful
null_resource.validator (local-exec): node_number_of_running_containers       Successful
null_resource.validator (local-exec): node_number_of_running_pods             Successful
null_resource.validator (local-exec): pod_cpu_reserved_capacity               Successful
null_resource.validator (local-exec): pod_cpu_utilization                     Successful
null_resource.validator (local-exec): pod_cpu_utilization_over_pod_limit      Successful
null_resource.validator (local-exec): pod_memory_reserved_capacity            Successful
null_resource.validator (local-exec): pod_memory_utilization                  Successful
null_resource.validator (local-exec): pod_memory_utilization_over_pod_limit   Successful
null_resource.validator (local-exec): pod_network_rx_bytes                    Successful
null_resource.validator (local-exec): pod_network_tx_bytes                    Successful
null_resource.validator (local-exec): pod_number_of_container_restarts        Successful
null_resource.validator (local-exec): service_number_of_running_pods          Successful
null_resource.validator (local-exec): emf-logs                                Successful
null_resource.validator (local-exec): 2023/06/01 12:48:30 ==============================
null_resource.validator (local-exec): 2023/06/01 12:48:30 >>>>>>>>>>>>>>><<<<<<<<<<<<<<<
null_resource.validator (local-exec): >>>> Finished MetricBenchmarkTestSuite
null_resource.validator (local-exec): --- PASS: TestMetricValueBenchmarkSuite (182.36s)
null_resource.validator (local-exec):     --- PASS: TestMetricValueBenchmarkSuite/TestAllInSuite (182.36s)
```