### PR TITLE
Fix soak test unrecognized flag.

### DIFF
--- a/test/soak/soak_test.go
+++ b/test/soak/soak_test.go
@@ -9,10 +9,17 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/internal/common"
 	"github.com/shirou/gopsutil/v3/process"
 	"github.com/stretchr/testify/require"
 )
+
+var envMetaDataStrings = &(environment.MetaDataStrings{})
+
+func init() {
+	environment.RegisterEnvironmentMetaDataFlags(envMetaDataStrings)
+}
 
 type testConfig struct {
 	logFileCount      int


### PR DESCRIPTION
# Description of the issue
Integration tests get called with `-computeType=` flag.
But the soak test will fail like so:
```
[ec2-user@ip-172-31-17-153 amazon-cloudwatch-agent-test]$ go test ./test/soak -run TestSoakHigh -p 1 -timeout 1h -computeType=EC2
flag provided but not defined: -computeType
Usage of /tmp/go-build1947034016/b001/soak.test:
```

# Description of changes
This test was missing some flag parsing code that all the other tests have.
Added this missing flag parsing.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- Manual ran test on AL2 and it passed:
```
[ec2-user@ip-172-31-17-153 amazon-cloudwatch-agent-test]$ go test ./test/soak -run TestSoakHigh -p 1 -timeout 1h -computeType=EC2
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudformation v1.27.4
ok  	github.com/aws/amazon-cloudwatch-agent-test/test/soak	1.475s
```
