### PR TITLE
Default soak time

### DIFF
--- a/cmd/emf-generator/emf-generator.go
+++ b/cmd/emf-generator/emf-generator.go
@@ -21,6 +21,7 @@ var (
 	eventsPerSecond  = flag.Int("eventsPerSecond", 65, "Identify the structuredLogs event count per second per file.")
 	structuredLogDir = flag.String("path", "", "Identify the directory where the structured log files will be generated.")
 	filePrefix       = flag.String("filePrefix", "structuredLogFile", "Identify the structured log file prefix")
+	runTime   = flag.Duration("runTime", 48*time.Hour, "Run time duration.")
 )
 
 func main() {
@@ -36,8 +37,8 @@ func main() {
 	for i := 0; i < *fileNum; i++ {
 		go writeStructuredLog(i)
 	}
-	// wait forever
-	select {}
+	time.Sleep(*runTime)
+	// No cleanup needed, just exit.
 }
 
 func writeStructuredLog(fileIndex int) {

--- a/cmd/emf-generator/emf-generator.go
+++ b/cmd/emf-generator/emf-generator.go
@@ -21,7 +21,7 @@ var (
 	eventsPerSecond  = flag.Int("eventsPerSecond", 65, "Identify the structuredLogs event count per second per file.")
 	structuredLogDir = flag.String("path", "", "Identify the directory where the structured log files will be generated.")
 	filePrefix       = flag.String("filePrefix", "structuredLogFile", "Identify the structured log file prefix")
-	runTime   = flag.Duration("runTime", 48*time.Hour, "Run time duration.")
+	runTime          = flag.Duration("runTime", 48*time.Hour, "Run time duration.")
 )
 
 func main() {

--- a/cmd/log-generator/log-generator.go
+++ b/cmd/log-generator/log-generator.go
@@ -3,13 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"math"
 	"math/rand"
 	"os"
 	"path"
 	"runtime"
 	"strconv"
-	"sync"
 	"time"
 )
 
@@ -25,7 +23,7 @@ var (
 	eventSize       = flag.Int("eventSize", 120, "Identify the single log line size, in Byte.")
 	outPutPath      = flag.String("path", "", "Identify the path where log files will generate.")
 	filePrefix      = flag.String("filePrefix", "tmp", "Identify the log file prefix")
-	loopNum         = flag.Int64("loopNum", math.MaxInt64, "How many loops to write teh logentry.")
+	runTime         = flag.Duration("runTime", 48*time.Hour, "Run time duration.")
 )
 
 func main() {
@@ -45,16 +43,15 @@ func main() {
 	for i := 0; i < *eventSize-1; i++ {
 		logEntry += "A"
 	}
-	var waitGroup = sync.WaitGroup{}
 	//Start generating log
 	for i := 0; i < *fileNum; i++ {
-		waitGroup.Add(1)
-		go writeLog(logEntry, i, *loopNum, &waitGroup)
+		go writeLog(logEntry, i)
 	}
-	waitGroup.Wait()
+	time.Sleep(*runTime)
+	// No cleanup needed, just exit.
 }
 
-func writeLog(logEntry string, instanceId int, loopNum int64, waitGroup *sync.WaitGroup) {
+func writeLog(logEntry string, instanceId int) {
 	curFilePath := path.Join(*outPutPath, fmt.Sprintf("%s%d.log", *filePrefix, instanceId))
 	fmt.Printf("Creating file %s\n", curFilePath)
 	os.MkdirAll(*outPutPath, 0755)
@@ -64,9 +61,7 @@ func writeLog(logEntry string, instanceId int, loopNum int64, waitGroup *sync.Wa
 	r := time.Duration(rand.Intn(1000))
 	time.Sleep(r * time.Millisecond)
 	ticker := time.NewTicker(time.Second)
-	var j int64
-	for j = 0; j < loopNum; j++ {
-		<-ticker.C
+	for range ticker.C {
 		fmt.Printf("%s Starting...\n", time.Now().Format(layoutFormat))
 		for i := 0; i < *eventsPerSecond; i++ {
 			if i%multilineRatio == 0 {
@@ -88,5 +83,4 @@ func writeLog(logEntry string, instanceId int, loopNum int64, waitGroup *sync.Wa
 		}
 		fmt.Printf("%s Ended.\n", time.Now().Format(layoutFormat))
 	}
-	waitGroup.Done()
 }

--- a/cmd/statsd-generator/statsd-generator.go
+++ b/cmd/statsd-generator/statsd-generator.go
@@ -16,6 +16,7 @@ var (
 	clientNum = flag.Int("clientNum", 1, "The number of statsd client.")
 	tps       = flag.Int("tps", 100, "Transaction per second for each statsd client.")
 	metricNum = flag.Int("metricNum", 100, "The number of unique metrics for each statsd client.")
+	runTime   = flag.Duration("runTime", 48*time.Hour, "Run time duration.")
 )
 
 // sample command:
@@ -27,8 +28,8 @@ func main() {
 	for i := 0; i < *clientNum; i++ {
 		go startStatsDClient(i, *tps, *metricNum)
 	}
-	//wait forever
-	select {}
+	time.Sleep(*runTime)
+	// No cleanup needed, just exit.
 }
 
 func startStatsDClient(clientId, tps, metricNum int) {

--- a/test/soak/soak_test.go
+++ b/test/soak/soak_test.go
@@ -9,10 +9,17 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/internal/common"
 	"github.com/shirou/gopsutil/v3/process"
 	"github.com/stretchr/testify/require"
 )
+
+var envMetaDataStrings = &(environment.MetaDataStrings{})
+
+func init() {
+	environment.RegisterEnvironmentMetaDataFlags(envMetaDataStrings)
+}
 
 type testConfig struct {
 	logFileCount      int


### PR DESCRIPTION
# Description of the issue
The soak test is a short test that just starts the agent and some background generator programs.
The generator programs run indefinitely.
The intention was that the Terraform code would run a bash sleep command followed by a shutdown which would cause the EC2 instance to terminate. While that is still possible, I also think it is a good idea to allow users to control how long the generators run.

# Description of changes
Considered using a channel and having all goroutines check the channel.
Simpler than that is just sleeping the desired amount of time and then exiting.
There is no clean up to worry about.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- Manual testing:
    - `go run ./cmd/statsd-generator -runTime=15s -clientNum=7 -tps=100 -metricNum=10`
    - `go run ./cmd/log-generator -runTime=1m`
    - `go run ./cmd/log-generator -runTime=10s`
    - `go run ./cmd/emf-generator -runTime=10s -fileNum=100 -eventsPerSecond=100`
