### PR TITLE
Mac and windows release

### DIFF
--- a/msi/tools/create_msi.ps1
+++ b/msi/tools/create_msi.ps1
@@ -7,5 +7,10 @@ candle.exe -ext WixUtilExtension.dll ./amazon-cloudwatch-agent.wxs
 light.exe -ext WixUtilExtension.dll ./amazon-cloudwatch-agent.wixobj
 
 # upload to s3
-aws s3 cp ./amazon-cloudwatch-agent.msi "s3://$bucket/integration-test/packaging/$version/amazon-cloudwatch-agent.msi"
-Write-Host "s3 for msi is s3://$bucket/integration-test/packaging/$version/amazon-cloudwatch-agent.msi"
+$bucketPath = "s3://$bucket/integration-test/packaging/$version/amazon-cloudwatch-agent.msi"
+if ($version -eq "") {
+    # This is a prod, nonprod, or nightly build.
+    $bucketPath = "s3://$bucket/$version/amazon-cloudwatch-agent.msi"
+}
+aws s3 cp ./amazon-cloudwatch-agent.msi $bucketPath
+Write-Host "s3 for msi is $bucketPath"

--- a/msi/tools/create_msi.ps1
+++ b/msi/tools/create_msi.ps1
@@ -10,7 +10,7 @@ light.exe -ext WixUtilExtension.dll ./amazon-cloudwatch-agent.wixobj
 $bucketPath = "s3://$bucket/integration-test/packaging/$version/amazon-cloudwatch-agent.msi"
 if ($version -eq "") {
     # This is a prod, nonprod, or nightly build.
-    $bucketPath = "s3://$bucket/$version/amazon-cloudwatch-agent.msi"
+    $bucketPath = "s3://$bucket/amazon-cloudwatch-agent.msi"
 }
 aws s3 cp ./amazon-cloudwatch-agent.msi $bucketPath
 Write-Host "s3 for msi is $bucketPath"

--- a/msi/tools/create_msi.ps1
+++ b/msi/tools/create_msi.ps1
@@ -8,7 +8,7 @@ light.exe -ext WixUtilExtension.dll ./amazon-cloudwatch-agent.wixobj
 
 # upload to s3
 $bucketPath = "s3://$bucket/integration-test/packaging/$version/amazon-cloudwatch-agent.msi"
-if ($version -eq "") {
+if ($version -eq "nosha") {
     # This is a prod, nonprod, or nightly build.
     $bucketPath = "s3://$bucket/amazon-cloudwatch-agent.msi"
 }

--- a/pkg/tools/create_pkg.sh
+++ b/pkg/tools/create_pkg.sh
@@ -24,12 +24,13 @@ chmod +x /tmp/AmazonAgentScripts/postinstall
 rm -rf artifact
 mkdir artifact
 sudo pkgbuild --root /tmp/AmazonCWAgentPackage/ --install-location "/" --scripts /tmp/AmazonAgentScripts --identifier com.amazon.cloudwatch.agent --version=$AGENT_VERSION artifact/amazon-cloudwatch-agent.pkg
-bucketPath = "s3://$1/integration-test/packaging/$2/$3/amazon-cloudwatch-agent.pkg"
+bucketPath="s3://$1/integration-test/packaging/$2/$3/amazon-cloudwatch-agent.pkg"
 if [[ $2 = "" ]]; then
     # SHA parameter is empty, this must be a prod, nonprod, or nightly build.
-    bucketPath = "s3://$1/integration-test/packaging//$3/amazon-cloudwatch-agent.pkg"
+    bucketPath="s3://$1/integration-test/packaging//$3/amazon-cloudwatch-agent.pkg"
 fi
 aws s3 cp ./artifact/amazon-cloudwatch-agent.pkg $bucketPath
+echo "bucket path, $bucketPath"
 
 #TODO uncomment for mac specific signing gpg is supported
 ## create a package.tar.gz for the uploading it to signing bucket

--- a/pkg/tools/create_pkg.sh
+++ b/pkg/tools/create_pkg.sh
@@ -25,7 +25,7 @@ rm -rf artifact
 mkdir artifact
 sudo pkgbuild --root /tmp/AmazonCWAgentPackage/ --install-location "/" --scripts /tmp/AmazonAgentScripts --identifier com.amazon.cloudwatch.agent --version=$AGENT_VERSION artifact/amazon-cloudwatch-agent.pkg
 bucketPath="s3://$1/integration-test/packaging/$2/$3/amazon-cloudwatch-agent.pkg"
-if [[ $2 = "" ]]; then
+if [[ $2 = "nosha" ]]; then
     # SHA parameter is empty, this must be a prod, nonprod, or nightly build.
     bucketPath="s3://$1/$3/amazon-cloudwatch-agent.pkg"
 fi

--- a/pkg/tools/create_pkg.sh
+++ b/pkg/tools/create_pkg.sh
@@ -11,8 +11,8 @@ COMMON_CONFIG_PATH=/tmp/AmazonCWAgentPackage/opt/aws/amazon-cloudwatch-agent/etc
 SAMPLE_SUFFIX=SAMPLE_DO_NOT_MODIFY
 mv ${COMMON_CONFIG_PATH} ${COMMON_CONFIG_PATH}.${SAMPLE_SUFFIX}
 if [ $? -ne 0 ]; then
-     echo "Failed to mv common-config.toml"
-     exit 1
+    echo "Failed to mv common-config.toml"
+    exit 1
 fi
 
 mkdir /tmp/AmazonAgentScripts
@@ -24,7 +24,12 @@ chmod +x /tmp/AmazonAgentScripts/postinstall
 rm -rf artifact
 mkdir artifact
 sudo pkgbuild --root /tmp/AmazonCWAgentPackage/ --install-location "/" --scripts /tmp/AmazonAgentScripts --identifier com.amazon.cloudwatch.agent --version=$AGENT_VERSION artifact/amazon-cloudwatch-agent.pkg
-aws s3 cp ./artifact/amazon-cloudwatch-agent.pkg "s3://$1/integration-test/packaging/$2/$3/amazon-cloudwatch-agent.pkg"
+bucketPath = "s3://$1/integration-test/packaging/$2/$3/amazon-cloudwatch-agent.pkg"
+if [[ $2 = "" ]]; then
+    # SHA parameter is empty, this must be a prod, nonprod, or nightly build.
+    bucketPath = "s3://$1/integration-test/packaging//$3/amazon-cloudwatch-agent.pkg"
+fi
+aws s3 cp ./artifact/amazon-cloudwatch-agent.pkg $bucketPath
 
 #TODO uncomment for mac specific signing gpg is supported
 ## create a package.tar.gz for the uploading it to signing bucket

--- a/pkg/tools/create_pkg.sh
+++ b/pkg/tools/create_pkg.sh
@@ -27,7 +27,7 @@ sudo pkgbuild --root /tmp/AmazonCWAgentPackage/ --install-location "/" --scripts
 bucketPath="s3://$1/integration-test/packaging/$2/$3/amazon-cloudwatch-agent.pkg"
 if [[ $2 = "" ]]; then
     # SHA parameter is empty, this must be a prod, nonprod, or nightly build.
-    bucketPath="s3://$1/integration-test/packaging//$3/amazon-cloudwatch-agent.pkg"
+    bucketPath="s3://$1/$3/amazon-cloudwatch-agent.pkg"
 fi
 aws s3 cp ./artifact/amazon-cloudwatch-agent.pkg $bucketPath
 echo "bucket path, $bucketPath"


### PR DESCRIPTION
# Description of the issue
nightly build, nonprod release, and prod release will want to create Mac and Windows packages at alternate S3 bucket paths.

# Description of changes
Change build scripts

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- none
