### PR TITLE
add missing restart test for windows

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -96,6 +96,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 	},
 	"ec2_windows": {
 		{testDir: "./test/feature/windows"},
+		{testDir: "./test/restart"},
 	},
 	"ec2_performance": {
 		{testDir: "../../test/performance/emf"},


### PR DESCRIPTION
# Description of the issue
- restart integ test is missing for Windows

# Description of changes
- Add missing test back

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

