### PR TITLE
Fix prometheus test bugs

### DIFF
--- a/test/metric/metric_value_query.go
+++ b/test/metric/metric_value_query.go
@@ -24,7 +24,7 @@ func logDimensions(dims []types.Dimension) {
 	log.Printf("\tDimensions:\n")
 	for _, d := range dims {
 		if d.Name != nil && d.Value != nil {
-			log.Printf("\t\tDim(name=%q, val=%q\n", *d.Name, *d.Value)
+			log.Printf("\t\tDim(name=%q, val=%q)\n", *d.Name, *d.Value)
 		}
 	}
 }

--- a/test/metric_value_benchmark/agent_configs/prometheus.yaml
+++ b/test/metric_value_benchmark/agent_configs/prometheus.yaml
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 10s
-  scrape_timeout: 10s
+  scrape_interval: 5s
+  scrape_timeout: 5s
 scrape_configs:
   - job_name: 'prometheus_test_job'
     static_configs:

--- a/test/metric_value_benchmark/prometheus_test.go
+++ b/test/metric_value_benchmark/prometheus_test.go
@@ -73,13 +73,7 @@ func (t *PrometheusTestRunner) GetAgentConfigFileName() string {
 }
 
 func (t *PrometheusTestRunner) SetupBeforeAgentRun() error {
-	agentConfig := test_runner.AgentConfig{
-		ConfigFileName:   t.GetAgentConfigFileName(),
-		SSMParameterName: t.SSMParameterName(),
-		UseSSM:           t.UseSSM(),
-	}
-	t.SetAgentConfig(agentConfig)
-	err := t.SetUpConfig()
+	err := t.BaseTestRunner.SetupBeforeAgentRun()
 	if err != nil {
 		return err
 	}
@@ -93,16 +87,16 @@ func (t *PrometheusTestRunner) SetupBeforeAgentRun() error {
 	if err != nil {
 		return err
 	}
-	return t.SetUpConfig()
+	return nil
 }
 
 func (t *PrometheusTestRunner) GetMeasuredMetrics() []string {
 	return []string{
 		"prometheus_test_counter",
 		"prometheus_test_gauge",
-		//"prometheus_test_summary_count",
-		//"prometheus_test_summary_sum",
-		//"prometheus_test_summary",
+		"prometheus_test_summary_count",
+		"prometheus_test_summary_sum",
+		"prometheus_test_summary",
 	}
 }
 


### PR DESCRIPTION
# Description of the issue
The prometheus test is failing due to bugs that were recently introduced.
* We reduced the metric collection interval so the tests are quicker but the same was not reflected in the prometheus scrape interval, hence not giving it enough time.
* We seem to setup the agent config twice and duplicate code so this cleans that up as well.
* The summary tests that were commented are now expected to work (since we no longer use upstream prometheus_receiver)

# Description of changes
* Reduce prometheus scrape interval
* Cleanup duplicated code
* Uncomment summary tests

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Passing prometheus test: https://github.com/aws/private-amazon-cloudwatch-agent-staging/actions/runs/5236695480/jobs/9454433502
