### PR TITLE
Add back userdata test matrix for generation

### DIFF
--- a/generator/resources/ec2_userdata_test_matrix.json
+++ b/generator/resources/ec2_userdata_test_matrix.json
@@ -1,0 +1,13 @@
+[
+    {
+        "os": "ol9",
+        "username": "ec2-user",
+        "instanceType": "t3a.medium",
+        "installAgentCommand": "go run ./install/install_agent.go rpm",
+        "ami": "cloudwatch-agent-integration-test-ol9*",
+        "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+        "arc": "amd64",
+        "binaryName": "amazon-cloudwatch-agent.rpm",
+        "family": "linux"
+    }
+]


### PR DESCRIPTION
# Description of the issue
There was a bad merge where the userdate test matrix was removed and now causing it to fail on the integration test. 
```
Error when evaluating 'strategy' for job 'EC2UserDataIntegrationTest'. .github/workflows/integration-test.yml (Line: 652, Col: 17): Error parsing fromJson,.github/workflows/integration-test.yml (Line: 652, Col: 17): Error reading JToken from JsonReader. Path '', line 0, position 0.,.github/workflows/integration-test.yml (Line: 652, Col: 17): Unexpected value ''
```

https://github.com/aws/amazon-cloudwatch-agent/actions/runs/5248142140

# Description of changes
Adding back the test matrix will allow the integration test to retrieve proper information for it to execute the userdata test.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Userdata test was previously working when the matrix was still in the repo https://github.com/aws/amazon-cloudwatch-agent/actions/runs/5137268637
