### PR TITLE
Performance test bug fixes

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -92,7 +92,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 		and Mac under the hood share similar plugins with Linux
 	*/
 	"ec2_mac": {
-		{testDir: "./test/feature/mac"},
+		{testDir: "../../../test/feature/mac"},
 	},
 	"ec2_windows": {
 		{testDir: "../../../test/feature/windows"},

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -95,7 +95,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 		{testDir: "./test/feature/mac"},
 	},
 	"ec2_windows": {
-		{testDir: "./test/feature/windows"},
+		{testDir: "../../../test/feature/windows"},
 		{testDir: "./test/restart"},
 	},
 	"ec2_performance": {

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -96,7 +96,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 	},
 	"ec2_windows": {
 		{testDir: "../../../test/feature/windows"},
-		{testDir: "./test/restart"},
+		{testDir: "../../../test/restart"},
 	},
 	"ec2_performance": {
 		{testDir: "../../test/performance/emf"},

--- a/terraform/ec2/win/variable.tf
+++ b/terraform/ec2/win/variable.tf
@@ -53,7 +53,7 @@ variable "test_name" {
 
 variable "test_dir" {
   type    = string
-  default = "./test/feature/windows"
+  default = ""
 }
 
 variable "use_ssm" {

--- a/terraform/validator/main.tf
+++ b/terraform/validator/main.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 resource "local_file" "update-validation-config" {
-  content = replace(replace(replace(replace(file("../../../${var.test_dir}/${local.validator_config}"),
+  content = replace(replace(replace(replace(file("${var.test_dir}/${local.validator_config}"),
     "<values_per_minute>", var.values_per_minute),
     "<commit_hash>", var.cwa_github_sha),
     "<commit_date>", var.cwa_github_sha_date),
@@ -20,7 +20,7 @@ resource "local_file" "update-validation-config" {
 resource "null_resource" "build-validator" {
   provisioner "local-exec" {
     command     = var.action == "upload" ? "make validator-build" : "make dockerized-build"
-    working_dir = split("test", "../../../${var.test_dir}")[0]
+    working_dir = split("test", var.test_dir)[0]
   }
 
   triggers = {
@@ -41,7 +41,7 @@ resource "null_resource" "upload-validator" {
       "aws s3 cp ./build/validator/${var.family}/${var.arc}/validator.exe s3://${var.s3_bucket}/integration-test/validator/${var.cwa_github_sha}/${var.family}/${var.arc}/validator.exe" :
       "aws s3 cp ./build/validator/${var.family}/${var.arc}/validator s3://${var.s3_bucket}/integration-test/validator/${var.cwa_github_sha}/${var.family}/${var.arc}/validator"
     )
-    working_dir = split("test", "../../../${var.test_dir}")[0]
+    working_dir = split("test", var.test_dir)[0]
   }
 
   triggers = {

--- a/test/performance/system/agent_config.json
+++ b/test/performance/system/agent_config.json
@@ -69,8 +69,7 @@
           ],
           "metrics_include": [
             "queue_0_tx_cnt","queue_0_rx_cnt"
-          ],
-          "metrics_collection_interval": 1
+          ]
         },
         "net": {
           "resources": [


### PR DESCRIPTION
# Description of the issue
Bugs were introduced over past commits that break the performance tests.

# Description of changes
* Update test dir paths for win, mac & validator. The validator should not use contextual paths since it can be imported at any level by diff plugnins. For example, mac & win are nested 3 levels deep but performance is nested 2 levels deep. And given they both source in the validator, it cant have relative paths.
* Remove unsuppported `metrics_collection_interval` for ethtool.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Run with passing performance/system tests: https://github.com/aws/private-amazon-cloudwatch-agent-staging/actions/runs/5280181528
* WIP to test win, mac and other performance tests
