### PR TITLE
Update instance types to avoid hitting vCPU limits

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -79,7 +79,7 @@
   {
     "os": "ol7",
     "username": "ec2-user",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-ol7*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
@@ -90,7 +90,7 @@
   {
     "os": "ol8",
     "username": "ec2-user",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-ol8*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
@@ -101,7 +101,7 @@
   {
     "os": "ol9",
     "username": "ec2-user",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-ol9*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
@@ -112,7 +112,7 @@
   {
     "os": "centos-7",
     "username": "centos",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-centos-7*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
@@ -123,7 +123,7 @@
   {
     "os": "centos-stream-8",
     "username": "cloud-user",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-centos-stream-8*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
@@ -134,7 +134,7 @@
   {
     "os": "sles-12",
     "username": "ec2-user",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-sles-12*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
@@ -145,7 +145,7 @@
   {
     "os": "sles-15",
     "username": "ec2-user",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-sles-15*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",

--- a/generator/resources/ec2_windows_test_matrix.json
+++ b/generator/resources/ec2_windows_test_matrix.json
@@ -19,19 +19,19 @@
   },
   {
     "os": "win-2019",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3.medium",
     "ami": "cloudwatch-agent-integration-test-win-2019*",
     "useSSM": false
   },
   {
     "os": "win-2022",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3.medium",
     "ami": "cloudwatch-agent-integration-test-win-2022*",
     "useSSM": false
   },
   {
     "os": "win-2022",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3.medium",
     "ami": "cloudwatch-agent-integration-test-win-2022*",
     "useSSM": true
   }

--- a/terraform/ec2/creds/variables.tf
+++ b/terraform/ec2/creds/variables.tf
@@ -8,7 +8,7 @@ variable "region" {
 
 variable "ec2_instance_type" {
   type    = string
-  default = "t3a.medium"
+  default = "t3a.small"
 }
 
 variable "ssh_key_name" {

--- a/terraform/ec2/userdata/variables.tf
+++ b/terraform/ec2/userdata/variables.tf
@@ -8,7 +8,7 @@ variable "region" {
 
 variable "ec2_instance_type" {
   type    = string
-  default = "t3a.medium"
+  default = "t3a.small"
 }
 
 variable "ssh_key_name" {


### PR DESCRIPTION
# Description of the issue
We see occasional test failures due to `Error: creating EC2 Instance: VcpuLimitExceeded: You have requested more vCPU capacity than your current vCPU limit of 1247 allows for the instance bucket that the specified instance type belongs to. Please visit http://aws.amazon.com/contact-us/ec2-request to request an adjustment to this limit.`

# Description of changes
Use a combination of diff instance types to avoid hitting the vCPU limits.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* https://github.com/aws/private-amazon-cloudwatch-agent-staging/actions/runs/5314342052/jobs/9621614827 shows a passing test that uses `t3.medium`.
