### PR TITLE
Update defaults to avoid terraform destroy issue

### DIFF
--- a/terraform/ec2/mac/variables.tf
+++ b/terraform/ec2/mac/variables.tf
@@ -48,7 +48,7 @@ variable "test_name" {
 
 variable "test_dir" {
   type    = string
-  default = "../../../test/feature/mac"
+  default = "../../../test/feature/mac" # This is really only used during tf destroy. See https://github.com/hashicorp/terraform/issues/23552
 }
 
 variable "cwa_github_sha" {

--- a/terraform/ec2/win/variable.tf
+++ b/terraform/ec2/win/variable.tf
@@ -53,7 +53,7 @@ variable "test_name" {
 
 variable "test_dir" {
   type    = string
-  default = ""
+  default = "../../../test/feature/windows" # This is really only used during tf destroy. See https://github.com/hashicorp/terraform/issues/23552
 }
 
 variable "use_ssm" {

--- a/terraform/performance/variables.tf
+++ b/terraform/performance/variables.tf
@@ -40,7 +40,7 @@ variable "s3_bucket" {
 
 variable "test_dir" {
   type    = string
-  default = "../../test/stress/statsd"
+  default = "../../test/performance/system" # This is really only used during tf destroy. See https://github.com/hashicorp/terraform/issues/23552
 }
 
 variable "cwa_github_sha" {


### PR DESCRIPTION
# Description of the issue
When we call terraform apply, we typically pass vars that are used when creating the resources. But when we call destroy,
we don't pass the vars and rely on the resources that were captured in the tf state to get deleted.
However, for provisioners that rely on functions that have validations (for ex, file existence checks), they fail if destroy
is also not supplied with vars. This is because `terraform destroy` is just syntactic sugar for `terraform apply -destroy` 
so since its really `apply` under the covers, it runs the same validations even while destroying.

More details on this behavior here: https://github.com/hashicorp/terraform/issues/23552

The following simple example showcases the exact issue.
```terraform
variable "test_input" {
  default = ""
}
resource "local_file" "update-validation-config" {
  content  = file("./${var.test_input}")
  filename = "./output.txt"
}
```
```text
% terraform apply -var test_input=./input1.txt -auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # local_file.destroy-test will be created
  + resource "local_file" "destroy-test" {
      + content              = "Hello"
      + content_base64sha256 = (known after apply)
      + content_base64sha512 = (known after apply)
      + content_md5          = (known after apply)
      + content_sha1         = (known after apply)
      + content_sha256       = (known after apply)
      + content_sha512       = (known after apply)
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "./output.txt"
      + id                   = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
local_file.destroy-test: Creating...
local_file.destroy-test: Creation complete after 0s [id=f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

% terraform destroy -auto-approve
local_file.update-validation-config: Refreshing state... [id=f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0]
╷
│ Error: Invalid function argument
│ 
│   on temp.tf line 5, in resource "local_file" "update-validation-config":
│    5:   content  = file("./${var.test_input}")
│     ├────────────────
│     │ while calling file(path)
│     │ var.test_input is ""
│ 
│ Invalid value for "path" parameter: failed to read file: read .: is a directory.

% terraform destroy -var test_input=./input2.txt -auto-approve
local_file.destroy-test: Refreshing state... [id=f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # local_file.destroy-test will be destroyed
  - resource "local_file" "destroy-test" {
      - content              = "Hello" -> null
      - content_base64sha256 = "GF+NsyJx/iX1Yab8k4suJkMG7DBO2lGAB9F2SCY4GWk=" -> null
      - content_base64sha512 = "NhX4DJ0pPtdAJof5SyLVjlKbjMeRb4+sf933+9WvTPd309eVp6AKFr9+fz+5Vh7puq5IDan+ehh2nnGIawPzFQ==" -> null
      - content_md5          = "8b1a9953c4611296a827abf8c47804d7" -> null
      - content_sha1         = "f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0" -> null
      - content_sha256       = "185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969" -> null
      - content_sha512       = "3615f80c9d293ed7402687f94b22d58e529b8cc7916f8fac7fddf7fbd5af4cf777d3d795a7a00a16bf7e7f3fb9561ee9baae480da9fe7a18769e71886b03f315" -> null
      - directory_permission = "0777" -> null
      - file_permission      = "0777" -> null
      - filename             = "./output.txt" -> null
      - id                   = "f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
local_file.destroy-test: Destroying... [id=f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0]
local_file.destroy-test: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```
As can be seen above, when tf destroy is called without passing in the vars, it complains. But when tf destroy is called
with the var supplied (even if it's a diff file from what was passed during apply, it doesn't complain), it is able to successfully
delete the resource. In the example above, note that both the created resource and the destroyed resource id is the same
i.e. `f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0`.

To avoid having to set all the vars at the time of tf destroy as well, a work-around is to specify a default for the vars 
(since as seen above, these vars are only used for validation purposes).

# Description of changes
Setting defaults to avoid failures with tf destroy.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Being tracked in latest integ test run.
