### PR TITLE
Terraform setup for stress tests

### DIFF
--- a/terraform/stress/amis.tf
+++ b/terraform/stress/amis.tf
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+variable "ami_family" {
+  default = {
+    linux = {
+      login_user        = "ec2-user"
+      install_package   = "amazon-cloudwatch-agent.rpm"
+      install_validator = "validator"
+      temp_folder       = "/tmp"
+      install_command   = "sudo rpm -Uvh amazon-cloudwatch-agent.rpm"
+      start_command     = "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:%s"
+      status_command    = "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status"
+      connection_type   = "ssh"
+      wait_cloud_init   = "for i in {1..300}; do [ ! -f /var/lib/cloud/instance/boot-finished ] && echo 'Waiting for cloud-init...'$i && sleep 1 || break; done"
+    }
+    windows = {
+      login_user        = "Administrator"
+      install_package   = "amazon-cloudwatch-agent.msi"
+      install_validator = "validator.exe"
+      temp_folder       = "C:/Users/Administrator/AppData/Local/Temp"
+      install_command   = "msiexec /i C:\\amazon-cloudwatch-agent.msi"
+      start_command     = "powershell \"& 'C:/Program Files/Amazon/AmazonCloudWatchAgent/amazon-cloudwatch-agent-ctl.ps1' -a fetch-config -m ec2 -s -c file:%s\""
+      status_command    = "powershell \"& 'C:/Program Files/Amazon/AmazonCloudWatchAgent/amazon-cloudwatch-agent-ctl.ps1' -a status\""
+      connection_type   = "winrm"
+      wait_cloud_init   = " "
+    }
+  }
+}

--- a/terraform/stress/iam.tf
+++ b/terraform/stress/iam.tf
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+data "aws_iam_instance_profile" "cwagent_instance_profile" {
+  name = module.common.cwa_iam_instance_profile
+}

--- a/terraform/stress/main.tf
+++ b/terraform/stress/main.tf
@@ -1,0 +1,150 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "common" {
+  source = "../common"
+}
+
+module "basic_components" {
+  source = "../basic_components"
+
+  region = var.region
+}
+
+locals {
+  ami_family        = var.ami_family[var.family]
+  login_user        = local.ami_family["login_user"]
+  install_package   = local.ami_family["install_package"]
+  install_validator = local.ami_family["install_validator"]
+  temp_directory    = local.ami_family["temp_folder"]
+  connection_type   = local.ami_family["connection_type"]
+  start_command     = format(local.ami_family["start_command"], module.validator.instance_agent_config)
+}
+
+
+#####################################################################
+# Prepare Parameters Tests
+#####################################################################
+
+module "validator" {
+  source = "../validator"
+
+  arc                 = var.arc
+  family              = var.family
+  action              = "upload"
+  s3_bucket           = var.s3_bucket
+  test_dir            = var.test_dir
+  temp_directory      = local.temp_directory
+  cwa_github_sha      = var.cwa_github_sha
+  cwa_github_sha_date = var.cwa_github_sha_date
+  values_per_minute   = var.values_per_minute
+}
+
+#####################################################################
+# Generate EC2 Instance and execute test commands
+#####################################################################
+resource "aws_instance" "cwagent" {
+
+  ami                                  = data.aws_ami.latest.id
+  instance_type                        = var.ec2_instance_type
+  key_name                             = local.ssh_key_name
+  iam_instance_profile                 = module.basic_components.instance_profile
+  vpc_security_group_ids               = [module.basic_components.security_group]
+  get_password_data                    = local.connection_type == "winrm" ? true : false
+  associate_public_ip_address          = true
+  instance_initiated_shutdown_behavior = "terminate"
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  tags = {
+    Name = "cwagent-stress-${module.common.testing_id}"
+  }
+}
+
+resource "null_resource" "install_binaries" {
+  depends_on = [aws_instance.cwagent, module.validator]
+
+  connection {
+    type        = local.connection_type
+    user        = local.login_user
+    private_key = local.connection_type == "ssh" ? local.private_key_content : null
+    password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.cwagent.password_data, local.private_key_content) : null
+    host        = aws_instance.cwagent.public_dns
+  }
+
+  provisioner "file" {
+    source      = module.validator.agent_config
+    destination = module.validator.instance_agent_config
+  }
+
+  provisioner "file" {
+    source      = module.validator.validator_config
+    destination = module.validator.instance_validator_config
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      local.ami_family["wait_cloud_init"],
+      "aws s3 cp s3://${var.s3_bucket}/integration-test/binary/${var.cwa_github_sha}/${var.family}/${var.arc}/${local.install_package} .",
+      "aws s3 cp s3://${var.s3_bucket}/integration-test/validator/${var.cwa_github_sha}/${var.family}/${var.arc}/${local.install_validator} .",
+      local.ami_family["install_command"],
+    ]
+  }
+}
+
+resource "null_resource" "validator_linux" {
+  count      = var.family != "windows" ? 1 : 0
+  depends_on = [null_resource.install_binaries]
+
+  connection {
+    type        = local.connection_type
+    user        = local.login_user
+    private_key = local.connection_type == "ssh" ? local.private_key_content : null
+    password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.cwagent.password_data, local.private_key_content) : null
+    host        = aws_instance.cwagent.public_dns
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "export AWS_REGION=${var.region}",
+      "sudo chmod +x ./${local.install_validator}",
+      "./${local.install_validator} --validator-config=${module.validator.instance_validator_config} --preparation-mode=true",
+      local.start_command,
+      "./${local.install_validator} --validator-config=${module.validator.instance_validator_config} --preparation-mode=false",
+    ]
+  }
+}
+
+resource "null_resource" "validator_windows" {
+  count      = var.family == "windows" ? 1 : 0
+  depends_on = [null_resource.install_binaries]
+
+  connection {
+    type        = local.connection_type
+    user        = local.login_user
+    private_key = local.connection_type == "ssh" ? local.private_key_content : null
+    password    = local.connection_type == "winrm" ? rsadecrypt(aws_instance.cwagent.password_data, local.private_key_content) : null
+    host        = aws_instance.cwagent.public_dns
+    timeout     = "10m"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "set AWS_REGION=${var.region}",
+      "${local.install_validator} --validator-config=${module.validator.instance_validator_config}--preparation-mode=true",
+      local.start_command,
+      "${local.install_validator} --validator-config=${module.validator.instance_validator_config} --preparation-mode=false",
+    ]
+  }
+}
+
+data "aws_ami" "latest" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = [var.ami]
+  }
+}

--- a/terraform/stress/providers.tf
+++ b/terraform/stress/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.region
+}

--- a/terraform/stress/sshkey.tf
+++ b/terraform/stress/sshkey.tf
@@ -1,0 +1,20 @@
+#####################################################################
+# Generate EC2 Key Pair for log in access to EC2
+#####################################################################
+
+resource "tls_private_key" "ssh_key" {
+  count     = var.ssh_key_name == "" ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "aws_key_pair" "aws_ssh_key" {
+  count      = var.ssh_key_name == "" ? 1 : 0
+  key_name   = "ec2-key-pair-${module.common.testing_id}"
+  public_key = tls_private_key.ssh_key[0].public_key_openssh
+}
+
+locals {
+  ssh_key_name        = var.ssh_key_name != "" ? var.ssh_key_name : aws_key_pair.aws_ssh_key[0].key_name
+  private_key_content = var.ssh_key_name != "" ? var.ssh_key_value : tls_private_key.ssh_key[0].private_key_pem
+}

--- a/terraform/stress/variables.tf
+++ b/terraform/stress/variables.tf
@@ -1,0 +1,68 @@
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "ec2_instance_type" {
+  type    = string
+  default = "t3a.xlarge"
+}
+
+variable "ssh_key_name" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_key_value" {
+  type    = string
+  default = ""
+}
+
+variable "ami" {
+  type    = string
+  default = "cloudwatch-agent-integration-test-al2*"
+}
+
+variable "arc" {
+  type    = string
+  default = "amd64"
+
+  validation {
+    condition     = contains(["amd64", "arm64"], var.arc)
+    error_message = "Valid values for arc are (amd64, arm64)."
+  }
+}
+
+variable "s3_bucket" {
+  type    = string
+  default = ""
+}
+
+variable "test_dir" {
+  type    = string
+  default = "../../test/stress/system" # This is really only used during tf destroy. See https://github.com/hashicorp/terraform/issues/23552
+}
+
+variable "cwa_github_sha" {
+  type    = string
+  default = ""
+}
+
+variable "cwa_github_sha_date" {
+  type    = string
+  default = ""
+}
+variable "values_per_minute" {
+  type    = number
+  default = 10
+}
+
+variable "family" {
+  type    = string
+  default = "linux"
+
+  validation {
+    condition     = contains(["windows", "linux"], var.family)
+    error_message = "Valid values for family are (windows, linux)."
+  }
+}

--- a/terraform/stress/vpc.tf
+++ b/terraform/stress/vpc.tf
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "aws_security_group" "ec2_security_group" {
+  name = module.common.vpc_security_group
+}


### PR DESCRIPTION
# Description of the issue
We are currently missing the terraform setup for stress tests.

# Description of changes
Add the terraform setup for stress tests (mostly structured similarly to the existing performance tf setup)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Test run showing passing stress tests (https://github.com/aws/amazon-cloudwatch-agent/actions/runs/5316367723)
  * [Sidenote] The failing performance tests in the run above are expected and will be fixed with https://github.com/aws/amazon-cloudwatch-agent-test/pull/262
