### PR TITLE
Fix CA cert test for SUSE Linux

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -137,7 +137,7 @@
     "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-sles-12*",
-    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "caCertPath": "/etc/ssl/ca-bundle.pem",
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",
     "family": "linux"
@@ -148,7 +148,7 @@
     "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-sles-15*",
-    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "caCertPath": "/etc/ssl/ca-bundle.pem",
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",
     "family": "linux"

--- a/internal/common/agent_util_unix.go
+++ b/internal/common/agent_util_unix.go
@@ -154,7 +154,7 @@ func StopAgent() {
 
 func ReadAgentOutput(d time.Duration) string {
 	out, err := exec.Command("bash", "-c",
-		fmt.Sprintf("journalctl -u amazon-cloudwatch-agent.service --since \"%s ago\" --no-pager", d.String())).
+		fmt.Sprintf("sudo journalctl -u amazon-cloudwatch-agent.service --since \"%s ago\" --no-pager -q", d.String())).
 		Output()
 
 	if err != nil {


### PR DESCRIPTION
# Description of the issue
integration tests were failing for SUSE specifically

# Description of changes
1. SUSE CA certs are located in a different place than the other flavors of Linux which is why we were failing the initial part of reading the cert file to create a PEM.
2. Calling `journalctl` in SUSE requires sudo permissions

I found the right path for the CA cert by running:
```bash
sh-4.4$ rpm -ql ca-certificates-2+git20210309.21162a6-2.1.noarch | grep ca-bundle
/etc/ssl/ca-bundle.pem
/var/lib/ca-certificates/ca-bundle.pem
```

Running `ls -al /etc/ssl` shows that the file there is a symlink to the one under `/var/lib`, but to keep it somewhat consistent with the other test configurations I used the one under `/etc/ssl`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested with a branch on the main GitHub repo https://github.com/aws/amazon-cloudwatch-agent/actions/runs/5338402082/jobs/9675868143 This passes for SLES 12 and 15 now
