### PR TITLE
add test id to ssm param name to avoid collision

### DIFF
--- a/terraform/ec2/win/main.tf
+++ b/terraform/ec2/win/main.tf
@@ -30,7 +30,7 @@ resource "aws_key_pair" "aws_ssh_key" {
 locals {
   ssh_key_name        = var.ssh_key_name != "" ? var.ssh_key_name : aws_key_pair.aws_ssh_key[0].key_name
   private_key_content = var.ssh_key_name != "" ? var.ssh_key_value : tls_private_key.ssh_key[0].private_key_pem
-  ssm_parameter_name  = "WindowsAgentConfigSSMTest"
+  ssm_parameter_name  = "WindowsAgentConfigSSMTest-${module.common.testing_id}"
 }
 
 #####################################################################


### PR DESCRIPTION
# Description of the issue
Some windows tests are failing due to existing SSM parameter name

# Description of changes
Append test id to parameter name to avoid a collision

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

