### PR TITLE
Add terraform for onprem and refactor for reuse

### DIFF
--- a/terraform/common/output.tf
+++ b/terraform/common/output.tf
@@ -9,6 +9,10 @@ output "cwa_iam_role" {
   value = "cwa-e2e-iam-role"
 }
 
+output "cwa_onprem_assumed_iam_role_arm" {
+  value = "arn:aws:iam::506463145083:role/CloudWatchAgentServerRoleOnPrem"
+}
+
 output "cwa_iam_policy" {
   value = "cwa-e2e-iam-policy"
 }

--- a/terraform/ec2/common/linux/main.tf
+++ b/terraform/ec2/common/linux/main.tf
@@ -1,0 +1,126 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "common" {
+  source = "../../../common"
+}
+
+module "basic_components" {
+  source = "../../../basic_components"
+
+  region = var.region
+}
+
+#####################################################################
+# Generate EC2 Key Pair for log in access to EC2
+#####################################################################
+
+resource "tls_private_key" "ssh_key" {
+  count     = var.ssh_key_name == "" ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "aws_key_pair" "aws_ssh_key" {
+  count      = var.ssh_key_name == "" ? 1 : 0
+  key_name   = "ec2-key-pair-${module.common.testing_id}"
+  public_key = tls_private_key.ssh_key[0].public_key_openssh
+}
+
+locals {
+  ssh_key_name        = var.ssh_key_name != "" ? var.ssh_key_name : aws_key_pair.aws_ssh_key[0].key_name
+  private_key_content = var.ssh_key_name != "" ? var.ssh_key_value : tls_private_key.ssh_key[0].private_key_pem
+}
+
+# create a proxy instance for tests using proxy instsance
+module "proxy_instance" {
+  source              = "../../proxy"
+  create              = length(regexall("proxy", var.test_dir)) > 0 ? 1 : 0
+  ssh_key_name        = local.ssh_key_name
+  private_key_content = local.private_key_content
+  test_dir            = var.test_dir
+  test_name           = var.test_name
+  region              = var.region
+  user                = var.user
+}
+
+#####################################################################
+# Generate EC2 Instance and execute test commands
+#####################################################################
+resource "aws_instance" "cwagent" {
+  ami                                  = data.aws_ami.latest.id
+  instance_type                        = var.ec2_instance_type
+  key_name                             = local.ssh_key_name
+  iam_instance_profile                 = module.basic_components.instance_profile
+  vpc_security_group_ids               = [module.basic_components.security_group]
+  associate_public_ip_address          = true
+  instance_initiated_shutdown_behavior = "terminate"
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  tags = {
+    Name = var.is_canary ? "cwagent-canary-test-ec2-${var.test_name}-${module.common.testing_id}" : "cwagent-integ-test-ec2-${var.test_name}-${module.common.testing_id}"
+  }
+}
+
+resource "null_resource" "integration_test_fips_setup" {
+  # run go test when it's not feature test
+  count = length(regexall("fips", var.test_dir)) > 0 ? 1 : 0
+
+  connection {
+    type        = "ssh"
+    user        = var.user
+    private_key = local.private_key_content
+    host        = aws_instance.cwagent.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo enabling fips",
+      "sudo yum install -y dracut-fips",
+      "sudo dracut -f",
+      "sudo /sbin/grubby --update-kernel=ALL --args=\"fips=1\"",
+      "sudo reboot &",
+    ]
+  }
+
+  depends_on = [
+    aws_instance.cwagent,
+  ]
+}
+
+resource "null_resource" "integration_test_fips_check" {
+  # run go test when it's not feature test
+  count = length(regexall("fips", var.test_dir)) > 0 ? 1 : 0
+
+  connection {
+    type        = "ssh"
+    user        = var.user
+    private_key = local.private_key_content
+    host        = aws_instance.cwagent.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo `cat /proc/sys/crypto/fips_enabled`",
+      "echo `sysctl crypto.fips_enabled`",
+      "if [ `cat /proc/sys/crypto/fips_enabled` -ne \"1\" ];then echo \"FIPS is not enabled, please check file /proc/sys/crypto/fips_enabled.\";exit 1; fi",
+    ]
+  }
+
+  depends_on = [
+    null_resource.integration_test_fips_setup,
+  ]
+}
+
+data "aws_ami" "latest" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = [var.ami]
+  }
+}

--- a/terraform/ec2/common/linux/output.tf
+++ b/terraform/ec2/common/linux/output.tf
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+output "private_key_content" {
+  value = local.private_key_content
+}
+
+output "cwagent_public_ip" {
+  value = aws_instance.cwagent.public_ip
+}
+
+output "cwagent_id" {
+  value = aws_instance.cwagent.id
+}
+
+output "proxy_instance_proxy_ip" {
+  value = module.proxy_instance.proxy_ip
+}
+

--- a/terraform/ec2/common/linux/providers.tf
+++ b/terraform/ec2/common/linux/providers.tf
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+provider "aws" {
+  region = var.region
+}

--- a/terraform/ec2/common/linux/variables.tf
+++ b/terraform/ec2/common/linux/variables.tf
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "ec2_instance_type" {
+  type    = string
+  default = "t3a.medium"
+}
+
+variable "ssh_key_name" {
+  type    = string
+  default = ""
+}
+
+variable "ami" {
+  type    = string
+  default = "cloudwatch-agent-integration-test-ubuntu*"
+}
+
+variable "ssh_key_value" {
+  type    = string
+  default = ""
+}
+
+variable "user" {
+  type    = string
+  default = ""
+}
+
+variable "arc" {
+  type    = string
+  default = "amd64"
+
+  validation {
+    condition     = contains(["amd64", "arm64"], var.arc)
+    error_message = "Valid values for arc are (amd64, arm64)."
+  }
+}
+
+variable "test_name" {
+  type    = string
+  default = ""
+}
+
+variable "test_dir" {
+  type    = string
+  default = ""
+}
+
+variable "is_canary" {
+  type    = bool
+  default = false
+}

--- a/terraform/ec2/common/linux_reboot/main.tf
+++ b/terraform/ec2/common/linux_reboot/main.tf
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+#####################################################################
+# Execute test
+#####################################################################
+
+## reboot when only needed
+resource "null_resource" "integration_test_reboot" {
+  count = contains(var.reboot_required_tests, var.test_dir) ? 1 : 0
+
+  connection {
+    type        = "ssh"
+    user        = var.user
+    private_key = var.private_key_content
+    host        = var.cwagent_public_ip
+  }
+
+  # Prepare Integration Test
+  provisioner "remote-exec" {
+    inline = [
+      "echo reboot instance",
+      "sudo shutdown -r now &",
+    ]
+  }
+}
+
+resource "null_resource" "integration_test_wait" {
+  count = contains(var.reboot_required_tests, var.test_dir) ? 1 : 0
+  provisioner "local-exec" {
+    command = "echo Sleeping for 3m after initiating instance restart && sleep 180"
+  }
+  depends_on = [
+    null_resource.integration_test_reboot,
+  ]
+}

--- a/terraform/ec2/common/linux_reboot/variables.tf
+++ b/terraform/ec2/common/linux_reboot/variables.tf
@@ -7,7 +7,7 @@ variable "test_dir" {
 }
 
 variable "reboot_required_tests" {
-  type    = list
+  type    = list(any)
   default = []
 }
 

--- a/terraform/ec2/common/linux_reboot/variables.tf
+++ b/terraform/ec2/common/linux_reboot/variables.tf
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+variable "test_dir" {
+  type    = string
+  default = ""
+}
+
+variable "reboot_required_tests" {
+  type    = list
+  default = []
+}
+
+variable "private_key_content" {
+  type    = string
+  default = ""
+}
+
+variable "cwagent_public_ip" {
+  type    = string
+  default = ""
+}
+
+variable "user" {
+  type    = string
+  default = ""
+}

--- a/terraform/ec2/creds/main.tf
+++ b/terraform/ec2/creds/main.tf
@@ -161,6 +161,7 @@ resource "null_resource" "integration_test_run" {
       "echo run integration test",
       "cd ~/amazon-cloudwatch-agent-test",
       "echo run sanity test && go test ./test/sanity -p 1 -v",
+      "echo assume role arn is ${aws_iam_role.assume_role.arn}",
       "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -assumeRoleArn=${aws_iam_role.assume_role.arn} -instanceId=${aws_instance.cwagent.id} -v"
     ]
   }

--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -86,7 +86,7 @@ resource "null_resource" "integration_test_run" {
       "echo run integration test",
       "cd ~/amazon-cloudwatch-agent-test",
       "echo run sanity test && go test ./test/sanity -p 1 -v",
-      "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.linux_common.proxy_instance_proxy_ip} -instanceId=${module.linux_common.cwagent_id} -v"
+      "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.linux_common.proxy_instance_proxy_ip} -instanceId=${module.linux_common.cwagent_id} -v",
       var.pre_test_setup,
       "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.proxy_instance.proxy_ip} -instanceId=${aws_instance.cwagent.id} -v"
     ]

--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -1,131 +1,52 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-module "common" {
-  source = "../../common"
-}
-
-module "basic_components" {
-  source = "../../basic_components"
+module "linux_common" {
+  source = "../common/linux"
 
   region = var.region
+  ec2_instance_type = var.ec2_instance_type
+  ssh_key_name = var.ssh_key_name
+  ami = var.ami
+  ssh_key_value = var.ssh_key_value
+  user = var.user
+  arc = var.arc
+  test_name = var.test_name
+  test_dir = var.test_dir
+  is_canary = var.is_canary
 }
 
-#####################################################################
-# Generate EC2 Key Pair for log in access to EC2
-#####################################################################
+module "reboot_common" {
+  source = "../common/linux_reboot"
 
-resource "tls_private_key" "ssh_key" {
-  count     = var.ssh_key_name == "" ? 1 : 0
-  algorithm = "RSA"
-  rsa_bits  = 4096
-}
+  test_dir = var.test_dir
+  reboot_required_tests = local.reboot_required_tests
+  private_key_content = module.linux_common.private_key_content
+  cwagent_public_ip = module.linux_common.cwagent_public_ip
+  user = var.user
 
-resource "aws_key_pair" "aws_ssh_key" {
-  count      = var.ssh_key_name == "" ? 1 : 0
-  key_name   = "ec2-key-pair-${module.common.testing_id}"
-  public_key = tls_private_key.ssh_key[0].public_key_openssh
+  depends_on = [
+      null_resource.integration_test_setup,
+  ]
 }
 
 locals {
-  ssh_key_name        = var.ssh_key_name != "" ? var.ssh_key_name : aws_key_pair.aws_ssh_key[0].key_name
-  private_key_content = var.ssh_key_name != "" ? var.ssh_key_value : tls_private_key.ssh_key[0].private_key_pem
   // Canary downloads latest binary. Integration test downloads binary connect to git hash.
   binary_uri = var.is_canary ? "${var.s3_bucket}/release/amazon_linux/${var.arc}/latest/${var.binary_name}" : "${var.s3_bucket}/integration-test/binary/${var.cwa_github_sha}/linux/${var.arc}/${var.binary_name}"
   // list of test that require instance reboot
   reboot_required_tests = tolist(["./test/restart"])
 }
 
-# create a proxy instance for tests using proxy instsance
-module "proxy_instance" {
-  source              = "../proxy"
-  create              = length(regexall("proxy", var.test_dir)) > 0 ? 1 : 0
-  ssh_key_name        = local.ssh_key_name
-  private_key_content = local.private_key_content
-  test_dir            = var.test_dir
-  test_name           = var.test_name
-  region              = var.region
-  user                = var.user
-}
-
 #####################################################################
-# Generate EC2 Instance and execute test commands
+# Execute tests
 #####################################################################
-resource "aws_instance" "cwagent" {
-  ami                                  = data.aws_ami.latest.id
-  instance_type                        = var.ec2_instance_type
-  key_name                             = local.ssh_key_name
-  iam_instance_profile                 = module.basic_components.instance_profile
-  vpc_security_group_ids               = [module.basic_components.security_group]
-  associate_public_ip_address          = true
-  instance_initiated_shutdown_behavior = "terminate"
-
-  metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = "required"
-  }
-
-  tags = {
-    Name = var.is_canary ? "cwagent-canary-test-ec2-${var.test_name}-${module.common.testing_id}" : "cwagent-integ-test-ec2-${var.test_name}-${module.common.testing_id}"
-  }
-}
-
-resource "null_resource" "integration_test_fips_setup" {
-  # run go test when it's not feature test
-  count = length(regexall("fips", var.test_dir)) > 0 ? 1 : 0
-
-  connection {
-    type        = "ssh"
-    user        = var.user
-    private_key = local.private_key_content
-    host        = aws_instance.cwagent.public_ip
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "echo enabling fips",
-      "sudo yum install -y dracut-fips",
-      "sudo dracut -f",
-      "sudo /sbin/grubby --update-kernel=ALL --args=\"fips=1\"",
-      "sudo reboot &",
-    ]
-  }
-
-  depends_on = [
-    aws_instance.cwagent,
-  ]
-}
-
-resource "null_resource" "integration_test_fips_check" {
-  # run go test when it's not feature test
-  count = length(regexall("fips", var.test_dir)) > 0 ? 1 : 0
-
-  connection {
-    type        = "ssh"
-    user        = var.user
-    private_key = local.private_key_content
-    host        = aws_instance.cwagent.public_ip
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "echo `cat /proc/sys/crypto/fips_enabled`",
-      "echo `sysctl crypto.fips_enabled`",
-      "if [ `cat /proc/sys/crypto/fips_enabled` -ne \"1\" ];then echo \"FIPS is not enabled, please check file /proc/sys/crypto/fips_enabled.\";exit 1; fi",
-    ]
-  }
-
-  depends_on = [
-    null_resource.integration_test_fips_setup,
-  ]
-}
 
 resource "null_resource" "integration_test_setup" {
   connection {
     type        = "ssh"
     user        = var.user
-    private_key = local.private_key_content
-    host        = aws_instance.cwagent.public_ip
+    private_key = module.linux_common.private_key_content
+    host        = module.linux_common.cwagent_public_ip
   }
 
   # Prepare Integration Test
@@ -143,41 +64,7 @@ resource "null_resource" "integration_test_setup" {
   }
 
   depends_on = [
-    null_resource.integration_test_fips_check,
-  ]
-}
-
-## reboot when only needed
-resource "null_resource" "integration_test_reboot" {
-  count = contains(local.reboot_required_tests, var.test_dir) ? 1 : 0
-
-  connection {
-    type        = "ssh"
-    user        = var.user
-    private_key = local.private_key_content
-    host        = aws_instance.cwagent.public_ip
-  }
-
-  # Prepare Integration Test
-  provisioner "remote-exec" {
-    inline = [
-      "echo reboot instance",
-      "sudo shutdown -r now &",
-    ]
-  }
-
-  depends_on = [
-    null_resource.integration_test_setup,
-  ]
-}
-
-resource "null_resource" "integration_test_wait" {
-  count = contains(local.reboot_required_tests, var.test_dir) ? 1 : 0
-  provisioner "local-exec" {
-    command = "echo Sleeping for 3m after initiating instance restart && sleep 180"
-  }
-  depends_on = [
-    null_resource.integration_test_reboot,
+    module.linux_common,
   ]
 }
 
@@ -185,8 +72,8 @@ resource "null_resource" "integration_test_run" {
   connection {
     type        = "ssh"
     user        = var.user
-    private_key = local.private_key_content
-    host        = aws_instance.cwagent.public_ip
+    private_key = module.linux_common.private_key_content
+    host        = module.linux_common.cwagent_public_ip
   }
 
   #Run sanity check and integration test
@@ -199,21 +86,12 @@ resource "null_resource" "integration_test_run" {
       "echo run integration test",
       "cd ~/amazon-cloudwatch-agent-test",
       "echo run sanity test && go test ./test/sanity -p 1 -v",
-      "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.proxy_instance.proxy_ip} -instanceId=${aws_instance.cwagent.id} -v"
+      "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.linux_common.proxy_instance_proxy_ip} -instanceId=${module.linux_common.cwagent_id} -v"
     ]
   }
 
   depends_on = [
     null_resource.integration_test_setup,
-    null_resource.integration_test_wait,
+    module.reboot_common,
   ]
-}
-
-data "aws_ami" "latest" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = [var.ami]
-  }
 }

--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -4,29 +4,29 @@
 module "linux_common" {
   source = "../common/linux"
 
-  region = var.region
+  region            = var.region
   ec2_instance_type = var.ec2_instance_type
-  ssh_key_name = var.ssh_key_name
-  ami = var.ami
-  ssh_key_value = var.ssh_key_value
-  user = var.user
-  arc = var.arc
-  test_name = var.test_name
-  test_dir = var.test_dir
-  is_canary = var.is_canary
+  ssh_key_name      = var.ssh_key_name
+  ami               = var.ami
+  ssh_key_value     = var.ssh_key_value
+  user              = var.user
+  arc               = var.arc
+  test_name         = var.test_name
+  test_dir          = var.test_dir
+  is_canary         = var.is_canary
 }
 
 module "reboot_common" {
   source = "../common/linux_reboot"
 
-  test_dir = var.test_dir
+  test_dir              = var.test_dir
   reboot_required_tests = local.reboot_required_tests
-  private_key_content = module.linux_common.private_key_content
-  cwagent_public_ip = module.linux_common.cwagent_public_ip
-  user = var.user
+  private_key_content   = module.linux_common.private_key_content
+  cwagent_public_ip     = module.linux_common.cwagent_public_ip
+  user                  = var.user
 
   depends_on = [
-      null_resource.integration_test_setup,
+    null_resource.integration_test_setup,
   ]
 }
 

--- a/terraform/ec2/linux_onprem/main.tf
+++ b/terraform/ec2/linux_onprem/main.tf
@@ -67,11 +67,11 @@ resource "null_resource" "integration_test_setup" {
       "sudo mkdir -p /.aws",
       "echo creating credentials file that the agent uses by default for onprem",
       "printf '\n[profile AmazonCloudWatchAgent]\nregion = us-west-2' | sudo tee -a /.aws/config",
-      "printf '\n[AmazonCloudWatchAgent]\naws_access_key_id=%s\naws_secret_access_key=%s\naws_session_token=%s' $(aws sts assume-role --role-arn arn:aws:iam::506463145083:role/CloudWatchAgentServerRoleOnPrem --role-session-name onpremtest --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text) | sudo tee -a /.aws/credentials>/dev/null",
+      "printf '\n[AmazonCloudWatchAgent]\naws_access_key_id=%s\naws_secret_access_key=%s\naws_session_token=%s' $(aws sts assume-role --role-arn ${module.common.cwa_onprem_assumed_iam_role_arm} --role-session-name onpremtest --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text) | sudo tee -a /.aws/credentials>/dev/null",
       "printf '[credentials]\n  shared_credential_profile = \"AmazonCloudWatchAgent\"\n  shared_credential_file = \"/.aws/credentials\"' | sudo tee /opt/aws/amazon-cloudwatch-agent/etc/common-config.toml>/dev/null",
       "echo write the same credentials as default profile as well. AWS SDK clients used for testing looks for default. Without this, would have needed to specify profile name in the test code",
       "printf '\n[default]\nregion = us-west-2' | sudo tee -a ~/.aws/config",
-      "printf '\n[default]\naws_access_key_id=%s\naws_secret_access_key=%s\naws_session_token=%s' $(aws sts assume-role --role-arn arn:aws:iam::506463145083:role/CloudWatchAgentServerRoleOnPrem --role-session-name test --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text) | sudo tee -a ~/.aws/credentials>/dev/null",
+      "printf '\n[default]\naws_access_key_id=%s\naws_secret_access_key=%s\naws_session_token=%s' $(aws sts assume-role --role-arn ${module.common.cwa_onprem_assumed_iam_role_arm} --role-session-name test --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text) | sudo tee -a ~/.aws/credentials>/dev/null",
       "echo turning off imds access in order to make agent start with onprem mode",
       "aws ec2 modify-instance-metadata-options --instance-id ${module.linux_common.cwagent_id} --http-endpoint disabled",
     ]

--- a/terraform/ec2/linux_onprem/main.tf
+++ b/terraform/ec2/linux_onprem/main.tf
@@ -4,29 +4,29 @@
 module "linux_common" {
   source = "../common/linux"
 
-  region = var.region
+  region            = var.region
   ec2_instance_type = var.ec2_instance_type
-  ssh_key_name = var.ssh_key_name
-  ami = var.ami
-  ssh_key_value = var.ssh_key_value
-  user = var.user
-  arc = var.arc
-  test_name = var.test_name
-  test_dir = var.test_dir
-  is_canary = var.is_canary
+  ssh_key_name      = var.ssh_key_name
+  ami               = var.ami
+  ssh_key_value     = var.ssh_key_value
+  user              = var.user
+  arc               = var.arc
+  test_name         = var.test_name
+  test_dir          = var.test_dir
+  is_canary         = var.is_canary
 }
 
 module "reboot_common" {
   source = "../common/linux_reboot"
 
-  test_dir = var.test_dir
+  test_dir              = var.test_dir
   reboot_required_tests = local.reboot_required_tests
-  private_key_content = module.linux_common.private_key_content
-  cwagent_public_ip = module.linux_common.cwagent_public_ip
-  user = var.user
+  private_key_content   = module.linux_common.private_key_content
+  cwagent_public_ip     = module.linux_common.cwagent_public_ip
+  user                  = var.user
 
   depends_on = [
-      null_resource.integration_test_setup,
+    null_resource.integration_test_setup,
   ]
 }
 

--- a/terraform/ec2/linux_onprem/main.tf
+++ b/terraform/ec2/linux_onprem/main.tf
@@ -1,0 +1,111 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "linux_common" {
+  source = "../common/linux"
+
+  region = var.region
+  ec2_instance_type = var.ec2_instance_type
+  ssh_key_name = var.ssh_key_name
+  ami = var.ami
+  ssh_key_value = var.ssh_key_value
+  user = var.user
+  arc = var.arc
+  test_name = var.test_name
+  test_dir = var.test_dir
+  is_canary = var.is_canary
+}
+
+module "reboot_common" {
+  source = "../common/linux_reboot"
+
+  test_dir = var.test_dir
+  reboot_required_tests = local.reboot_required_tests
+  private_key_content = module.linux_common.private_key_content
+  cwagent_public_ip = module.linux_common.cwagent_public_ip
+  user = var.user
+
+  depends_on = [
+      null_resource.integration_test_setup,
+  ]
+}
+
+locals {
+  // list of test that require instance reboot
+  reboot_required_tests = tolist(["./test/restart"])
+  // Canary downloads latest binary. Integration test downloads binary connect to git hash.
+  binary_uri = var.is_canary ? "${var.s3_bucket}/release/amazon_linux/${var.arc}/latest/${var.binary_name}" : "${var.s3_bucket}/integration-test/binary/${var.cwa_github_sha}/linux/${var.arc}/${var.binary_name}"
+}
+
+#####################################################################
+# Execute test
+#####################################################################
+
+resource "null_resource" "integration_test_setup" {
+  connection {
+    type        = "ssh"
+    user        = var.user
+    private_key = module.linux_common.private_key_content
+    host        = module.linux_common.cwagent_public_ip
+  }
+
+  # Prepare Integration Test.
+  ## Disabling imds endpoint here in order to keep the ability to ssh. If launching an instance with it disabled, ssh doesn't work.
+  ## If imds is not accessible, and RUN_IN_AWS env variable isn't set to true, then the agent considers it being in an onprem host.
+  provisioner "remote-exec" {
+    inline = [
+      "echo sha ${var.cwa_github_sha}",
+      "sudo cloud-init status --wait",
+      "echo clone and install agent",
+      "git clone --branch ${var.github_test_repo_branch} ${var.github_test_repo}",
+      "cd amazon-cloudwatch-agent-test",
+      "aws s3 cp s3://${local.binary_uri} .",
+      "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
+      "echo installing agent",
+      var.install_agent,
+      "sudo mkdir -p ~/.aws",
+      "sudo mkdir -p /.aws",
+      "echo creating credentials file that the agent uses by default for onprem",
+      "printf '\n[profile AmazonCloudWatchAgent]\nregion = us-west-2' | sudo tee -a /.aws/config",
+      "printf '\n[AmazonCloudWatchAgent]\naws_access_key_id=%s\naws_secret_access_key=%s\naws_session_token=%s' $(aws sts assume-role --role-arn arn:aws:iam::506463145083:role/CloudWatchAgentServerRoleOnPrem --role-session-name onpremtest --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text) | sudo tee -a /.aws/credentials>/dev/null",
+      "printf '[credentials]\n  shared_credential_profile = \"AmazonCloudWatchAgent\"\n  shared_credential_file = \"/.aws/credentials\"' | sudo tee /opt/aws/amazon-cloudwatch-agent/etc/common-config.toml>/dev/null",
+      "echo write the same credentials as default profile as well. AWS SDK clients used for testing looks for default. Without this, would have needed to specify profile name in the test code",
+      "printf '\n[default]\nregion = us-west-2' | sudo tee -a ~/.aws/config",
+      "printf '\n[default]\naws_access_key_id=%s\naws_secret_access_key=%s\naws_session_token=%s' $(aws sts assume-role --role-arn arn:aws:iam::506463145083:role/CloudWatchAgentServerRoleOnPrem --role-session-name test --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text) | sudo tee -a ~/.aws/credentials>/dev/null",
+      "echo turning off imds access in order to make agent start with onprem mode",
+      "aws ec2 modify-instance-metadata-options --instance-id ${module.linux_common.cwagent_id} --http-endpoint disabled",
+    ]
+  }
+
+  depends_on = [
+    module.linux_common,
+  ]
+}
+
+resource "null_resource" "integration_test_run" {
+  connection {
+    type        = "ssh"
+    user        = var.user
+    private_key = module.linux_common.private_key_content
+    host        = module.linux_common.cwagent_public_ip
+  }
+
+  #Run sanity check and integration test
+  provisioner "remote-exec" {
+    inline = [
+      "echo prepare environment",
+      "export LOCAL_STACK_HOST_NAME=${var.local_stack_host_name}",
+      "export AWS_REGION=${var.region}",
+      "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
+      "echo run integration test",
+      "cd ~/amazon-cloudwatch-agent-test",
+      "echo run sanity test && go test ./test/sanity -p 1 -v",
+      "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.linux_common.proxy_instance_proxy_ip} -instanceId=${module.linux_common.cwagent_id} -agentStartCommand='${var.agent_start}' -v",
+    ]
+  }
+
+  depends_on = [
+    null_resource.integration_test_setup,
+    module.reboot_common,
+  ]
+}

--- a/terraform/ec2/linux_onprem/providers.tf
+++ b/terraform/ec2/linux_onprem/providers.tf
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+provider "aws" {
+  region = var.region
+}

--- a/terraform/ec2/linux_onprem/variables.tf
+++ b/terraform/ec2/linux_onprem/variables.tf
@@ -104,6 +104,6 @@ variable "plugin_tests" {
 
 variable "agent_start" {
   description = "default command is for ec2 with linux"
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
 }

--- a/terraform/ec2/linux_onprem/variables.tf
+++ b/terraform/ec2/linux_onprem/variables.tf
@@ -1,0 +1,109 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "ec2_instance_type" {
+  type    = string
+  default = "t3a.medium"
+}
+
+variable "ssh_key_name" {
+  type    = string
+  default = ""
+}
+
+variable "ami" {
+  type    = string
+  default = "cloudwatch-agent-integration-test-ubuntu*"
+}
+
+variable "ssh_key_value" {
+  type    = string
+  default = ""
+}
+
+variable "user" {
+  type    = string
+  default = ""
+}
+
+variable "install_agent" {
+  description = "go run ./install/install_agent.go deb or go run ./install/install_agent.go rpm"
+  type        = string
+  default     = "go run ./install/install_agent.go rpm"
+}
+
+variable "ca_cert_path" {
+  type    = string
+  default = ""
+}
+
+variable "arc" {
+  type    = string
+  default = "amd64"
+
+  validation {
+    condition     = contains(["amd64", "arm64"], var.arc)
+    error_message = "Valid values for arc are (amd64, arm64)."
+  }
+}
+
+variable "binary_name" {
+  type    = string
+  default = ""
+}
+
+variable "local_stack_host_name" {
+  type    = string
+  default = "localhost.localstack.cloud"
+}
+
+variable "s3_bucket" {
+  type    = string
+  default = ""
+}
+
+variable "test_name" {
+  type    = string
+  default = ""
+}
+
+variable "test_dir" {
+  type    = string
+  default = ""
+}
+
+variable "cwa_github_sha" {
+  type    = string
+  default = ""
+}
+
+variable "github_test_repo" {
+  type    = string
+  default = "https://github.com/aws/amazon-cloudwatch-agent-test.git"
+}
+
+variable "github_test_repo_branch" {
+  type    = string
+  default = "main"
+}
+
+variable "is_canary" {
+  type    = bool
+  default = false
+}
+
+variable "plugin_tests" {
+  type    = string
+  default = ""
+}
+
+variable "agent_start" {
+  description = "default command is for ec2 with linux"
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
# Description of the issue
Agent is currently not being tested on on-premise environment. 
(ECS and EKS with on-prem instances will be addressed in a separate PR)

# Description of changes
Created a new terraform module for onprem usecases, and since most of the file is redundant with the existing ec2 terraform module, refactored them out.

The agent treats a host as onprem instead of EC2 if IMDS is not reachable AND at the same time RUN_AS_AWS environment variable is not set to true. 

This spins up an EC2 instance with IMDS on on purpose even though there's an option to launch with IMDS off. The test run currently needs to ssh into the instance, and if the instance was launched without IMDS connection, for some reason ssh will never be possible. (Behavior not officially documented)
This also allows us to pull down a credential credential via assume-role, so that the agent can use the credentials and not rely on instance IAM role which requires IMDS connection. This particular IAM role has both policies that tests require AND the ones the agent requires, although it could be separated. 


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
1) Verified that the agent can start in on-prem environment. Verified that agent start when the ec2(ec2 mode), and after IMDS connection is turned off, agent cannot start anymore (onprem mode). After storing credentials, agent could start wihtout IMDS connection (onprem mode). Verified that metrics were queriable by the test.
<img width="1116" alt="Screenshot 2023-06-22 at 14 49 11" src="https://github.com/aws/amazon-cloudwatch-agent-test/assets/24197975/daee4576-bebd-4ca6-bfcb-4e6a1c100daa">

2) Verified that after the refactoring, existing EC2 tests are not broken.

<img width="1152" alt="Screenshot 2023-06-23 at 11 51 37" src="https://github.com/aws/amazon-cloudwatch-agent-test/assets/24197975/40d6b10b-2363-443d-a282-cefda7765a71">




