### PR TITLE
Add optional pre_test_setup.

### DIFF
--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -199,6 +199,7 @@ resource "null_resource" "integration_test_run" {
       "echo run integration test",
       "cd ~/amazon-cloudwatch-agent-test",
       "echo run sanity test && go test ./test/sanity -p 1 -v",
+      var.pre_test_setup,
       "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.proxy_instance.proxy_ip} -instanceId=${aws_instance.cwagent.id} -v"
     ]
   }

--- a/terraform/ec2/linux/variables.tf
+++ b/terraform/ec2/linux/variables.tf
@@ -101,3 +101,8 @@ variable "plugin_tests" {
   type    = string
   default = ""
 }
+
+variable "pre_test_setup" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
# Description of the issue
Need to change some of the test environment prior to running the test.

# Description of changes
Gives the option to have the remote-exec run pre-test setup command.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
