### PR TITLE
Implement fix for sles linux integ-test

### DIFF
--- a/environment/metadata.go
+++ b/environment/metadata.go
@@ -33,6 +33,7 @@ type MetaData struct {
 	ProxyUrl                  string
 	AssumeRoleArn             string
 	InstanceId                string
+	OS                        string
 }
 
 type MetaDataStrings struct {
@@ -52,6 +53,7 @@ type MetaDataStrings struct {
 	ProxyUrl                  string
 	AssumeRoleArn             string
 	InstanceId                string
+	OS                        string
 }
 
 func registerComputeType(dataString *MetaDataStrings) {
@@ -69,6 +71,10 @@ func registerCwaCommitSha(dataString *MetaDataStrings) {
 }
 func registerCaCertPath(dataString *MetaDataStrings) {
 	flag.StringVar(&(dataString.CaCertPath), "caCertPath", "", "ec2 path to crts ex /etc/ssl/certs/ca-certificates.crt")
+}
+
+func registerOS(dataString *MetaDataStrings) {
+	flag.StringVar(&(dataString.OS), "OS", "", "OS of ec2 instance")
 }
 func registerECSData(dataString *MetaDataStrings) {
 	flag.StringVar(&(dataString.EcsLaunchType), "ecsLaunchType", "", "EC2 or Fargate")
@@ -178,6 +184,7 @@ func RegisterEnvironmentMetaDataFlags(metaDataStrings *MetaDataStrings) *MetaDat
 	registerProxyUrl(metaDataStrings)
 	registerAssumeRoleArn(metaDataStrings)
 	registerInstanceId(metaDataStrings)
+	registerOS(metaDataStrings)
 	return metaDataStrings
 }
 
@@ -191,6 +198,7 @@ func GetEnvironmentMetaData(data *MetaDataStrings) *MetaData {
 	metaData.S3Key = data.S3Key
 	metaData.CwaCommitSha = data.CwaCommitSha
 	metaData.CaCertPath = data.CaCertPath
+	metaData.OS = data.OS
 	metaData.ProxyUrl = data.ProxyUrl
 	metaData.AssumeRoleArn = data.AssumeRoleArn
 	metaData.InstanceId = data.InstanceId

--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -200,7 +200,7 @@ resource "null_resource" "integration_test_run" {
       "cd ~/amazon-cloudwatch-agent-test",
       "echo run sanity test && go test ./test/sanity -p 1 -v",
       var.pre_test_setup,
-      "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.proxy_instance.proxy_ip} -instanceId=${aws_instance.cwagent.id} -v"
+      "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.proxy_instance.proxy_ip} -OS=${var.os} -instanceId=${aws_instance.cwagent.id} -v"
     ]
   }
 

--- a/terraform/ec2/linux/variables.tf
+++ b/terraform/ec2/linux/variables.tf
@@ -106,3 +106,8 @@ variable "pre_test_setup" {
   type    = string
   default = "echo no pre-test setup"
 }
+
+variable "os" {
+  type    = string
+  default = ""
+}

--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -108,7 +108,7 @@ func getEc2TestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 			{TestRunner: &MemTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &ProcStatTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &DiskIOTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &NetTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &NetTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}, env}},
 			{TestRunner: &EthtoolTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &EMFTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &SwapTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},


### PR DESCRIPTION
# Description of the issue
EC2 Linux SLES integ-tests were failing due to the test checking for the `docker0` interface dimension for the net plugin on all EC2 instances. 

SLES versions of Linux do not publish net metrics to `docker0`. They only publish to the `eth0` interface dimension.

# Description of changes
This change passes the OS using terraform, allowing us to check for the `eth0` dimension when it's an SLES version of Linux

```
 {
  "test_dir": "./test/metric_value_benchmark",
  "os": "sles-15",
  "family": "linux",
  "testType": "ec2_linux",
  "arc": "amd64",
  "instanceType": "t3a.medium",
  "ami": "cloudwatch-agent-integration-test-sles-15*",
  "binaryName": "amazon-cloudwatch-agent.rpm",
  "username": "ec2-user",
  "installAgentCommand": "go run ./install/install_agent.go rpm",
  "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
  "values_per_minute": 0,
  "k8s_version": "",
  "terraform_dir": "",
  "useSSM": false
 },
```

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Successfully tested by running the workflow
