### PR TITLE
Raising memory data limit for statsd 5000 values per minute test

### DIFF
--- a/validator/validators/stress/stress_validator.go
+++ b/validator/validators/stress/stress_validator.go
@@ -86,7 +86,7 @@ var (
 				"procstat_memory_rss":  float64(130000000),
 				"procstat_memory_swap": float64(0),
 				"procstat_memory_vms":  float64(888000000),
-				"procstat_memory_data": float64(135000000),
+				"procstat_memory_data": float64(140000000),
 				"procstat_num_fds":     float64(15),
 				"net_bytes_sent":       float64(524000),
 				"net_packets_sent":     float64(520),


### PR DESCRIPTION
# Description of the issue
This test fails https://github.com/aws/private-amazon-cloudwatch-agent-staging/actions/runs/5405319175/jobs/9821174404#step:7:1191

# Description of changes
Raises the limit by roughly 3.7% to pass the test

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
none
