### PR TITLE
Increase statsd stress test bound for procstat_memory_data

### DIFF
--- a/validator/validators/stress/stress_validator.go
+++ b/validator/validators/stress/stress_validator.go
@@ -86,7 +86,7 @@ var (
 				"procstat_memory_rss":  float64(130000000),
 				"procstat_memory_swap": float64(0),
 				"procstat_memory_vms":  float64(888000000),
-				"procstat_memory_data": float64(140000000),
+				"procstat_memory_data": float64(145000000),
 				"procstat_num_fds":     float64(15),
 				"net_bytes_sent":       float64(524000),
 				"net_packets_sent":     float64(520),


### PR DESCRIPTION
# Description of the issue
The tests are flaky since the memory_data for statsd in the 5000 test is right around the current bound. The memory_data which is an indicator of the address space isnt the most critical memory stat and moreover, the 1000, 10000 & 50000 scenarios are all passing with their current bounds.

# Description of changes
Increasing the bound for procstat_memory_data for statsd in the 5000 case from 140MB -> 145MB.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A
