### PR TITLE
Update Fluentd test image to v1.10.3

### DIFF
--- a/terraform/eks/daemon/fluent/d/main.tf
+++ b/terraform/eks/daemon/fluent/d/main.tf
@@ -394,7 +394,7 @@ kubernetes.conf
 resource "kubernetes_daemonset" "fluentd_daemon" {
   depends_on = [
     module.fluent_common,
-    kubernetes_cluster_role_binding.fluentd_rolebinding
+    kubernetes_cluster_role_binding.fluentd_rolebinding,
     kubernetes_config_map.fluentd_config,
   ]
   metadata {

--- a/terraform/eks/daemon/fluent/d/main.tf
+++ b/terraform/eks/daemon/fluent/d/main.tf
@@ -394,7 +394,7 @@ kubernetes.conf
 resource "kubernetes_daemonset" "fluentd_daemon" {
   depends_on = [
     module.fluent_common,
-    kubernetes_service_account.fluentd_service,
+    kubernetes_cluster_role_binding.fluentd_rolebinding
     kubernetes_config_map.fluentd_config,
   ]
   metadata {
@@ -436,7 +436,7 @@ resource "kubernetes_daemonset" "fluentd_daemon" {
         }
         container {
           name  = "fluentd-cloudwatch"
-          image = "fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0"
+          image = "fluent/fluentd-kubernetes-daemonset:v1.10.3-debian-cloudwatch-1.0"
           env {
             name = "AWS_REGION"
             value_from {


### PR DESCRIPTION
# Description of the issue
Fluentd on EKS integration test keep failing due to missing log groups

# Description of changes
Use a newer `v.1.10.3` fluentd/debian-cloudwatch image.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manual execution of EKS integ test on a fork.
