### PR TITLE
Win2012 test fix

### DIFF
--- a/terraform/ec2/win/main.tf
+++ b/terraform/ec2/win/main.tf
@@ -153,7 +153,7 @@ resource "null_resource" "integration_test_run_restart" {
     user     = "Administrator"
     password = rsadecrypt(aws_instance.cwagent.password_data, local.private_key_content)
     host     = aws_instance.cwagent.public_dns
-    timeout = "2m"
+    timeout = "5m"
   }
 
   provisioner "file" {

--- a/terraform/ec2/win/main.tf
+++ b/terraform/ec2/win/main.tf
@@ -140,12 +140,40 @@ resource "null_resource" "integration_test_wait" {
   ]
 }
 
-resource "null_resource" "integration_test_run" {
+resource "null_resource" "integration_test_run_restart" {
   # run go test when it's not feature test
-  count = length(regexall("/feature/windows", var.test_dir)) < 1 ? 1 : 0
+  count = length(regexall("restart", var.test_dir)) > 0 ? 1 : 0
   depends_on = [
     null_resource.integration_test_setup,
     null_resource.integration_test_wait,
+  ]
+
+  connection {
+    type     = "winrm"
+    user     = "Administrator"
+    password = rsadecrypt(aws_instance.cwagent.password_data, local.private_key_content)
+    host     = aws_instance.cwagent.public_dns
+    timeout = "10m"
+  }
+
+  provisioner "file" {
+    source      = module.validator.agent_config
+    destination = module.validator.instance_agent_config
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "set AWS_REGION=${var.region}",
+      "validator.exe --test-name=${var.test_dir}"
+    ]
+  }
+}
+
+resource "null_resource" "integration_test_run_acceptance" {
+  # run go test when it's not feature test
+  count = length(regexall("acceptance", var.test_dir)) > 0 ? 1 : 0
+  depends_on = [
+    null_resource.integration_test_setup,
   ]
 
   connection {
@@ -163,7 +191,8 @@ resource "null_resource" "integration_test_run" {
   provisioner "remote-exec" {
     inline = [
       "set AWS_REGION=${var.region}",
-      "validator.exe --test-name=${var.test_dir}"
+      var.use_ssm ? "powershell \"& 'C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1' -a fetch-config -m ec2 -s -c ssm:${local.ssm_parameter_name}\"" : "powershell \"& 'C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1' -a fetch-config -m ec2 -s -c file:${module.validator.instance_agent_config}\"",
+      "validator.exe --test-name=${var.test_dir}",
     ]
   }
 }

--- a/terraform/ec2/win/main.tf
+++ b/terraform/ec2/win/main.tf
@@ -153,7 +153,7 @@ resource "null_resource" "integration_test_run_restart" {
     user     = "Administrator"
     password = rsadecrypt(aws_instance.cwagent.password_data, local.private_key_content)
     host     = aws_instance.cwagent.public_dns
-    timeout = "10m"
+    timeout = "2m"
   }
 
   provisioner "file" {

--- a/terraform/ec2/win/main.tf
+++ b/terraform/ec2/win/main.tf
@@ -153,7 +153,6 @@ resource "null_resource" "integration_test_run_restart" {
     user     = "Administrator"
     password = rsadecrypt(aws_instance.cwagent.password_data, local.private_key_content)
     host     = aws_instance.cwagent.public_dns
-    timeout = "5m"
   }
 
   provisioner "file" {

--- a/util/common/agent_util_windows.go
+++ b/util/common/agent_util_windows.go
@@ -33,8 +33,9 @@ func CopyFile(pathIn string, pathOut string) error {
 	}
 
 	log.Printf("File %s abs path %s", pathIn, pathInAbs)
-	params := append([]string{"-NoProfile", "-NonInteractive", "-NoExit", "cp " + pathInAbs + " " + pathOut})
+	params := append([]string{"-NoProfile", "-NonInteractive",  "cp " + pathInAbs + " " + pathOut})
 	out, err := exec.Command(ps, params...).Output()
+
 
 	if err != nil {
 		log.Printf("Copy file failed: %v; the output is: %s", err, string(out))
@@ -78,7 +79,7 @@ func StartAgent(configOutputPath string, fatalOnFailure bool, ssm bool) error {
 		return err
 	}
 
-	params := append([]string{"-NoProfile", "-NonInteractive", "-NoExit", "& \"C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1\" -a fetch-config -m ec2 -s -c file:" + configOutputPath})
+	params := append([]string{"-NoProfile", "-NonInteractive", "& \"C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1\" -a fetch-config -m ec2 -s -c file:" + configOutputPath})
 	out, err := exec.Command(ps, params...).Output()
 
 	if err != nil && fatalOnFailure {
@@ -100,7 +101,7 @@ func StopAgent() error {
 		return err
 	}
 
-	params := append([]string{"-NoProfile", "-NonInteractive", "-NoExit", "& \"C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1\" -a stop"})
+	params := append([]string{"-NoProfile", "-NonInteractive", "& \"C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1\" -a stop"})
 	out, err := exec.Command(ps, params...).Output()
 
 	if err != nil {
@@ -140,9 +141,9 @@ func RunShellScript(path string, args ...string) (string, error) {
 // printOutputAndError does nothing if there was no error.
 // Else it prints stdout and stderr.
 func printOutputAndError(stdout []byte, err error) {
-	//if err == nil {
-	//	return
-	//}
+	if err == nil {
+		return
+	}
 	stderr := ""
 	ee, ok := err.(*exec.ExitError)
 	if ok {

--- a/util/common/agent_util_windows.go
+++ b/util/common/agent_util_windows.go
@@ -152,7 +152,7 @@ func printOutputAndError(stdout []byte, err error) {
 }
 
 func RunCommand(cmd string) (string, error) {
-	log.Printf("running cmd, %s", cmd)
+	log.Printf("running cmd, %s %s %s %s %s", "powershell.exe", "-NoProfile", "-NonInteractive", "-NoExit", cmd)
 	out, err := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-NoExit", cmd).Output()
 	printOutputAndError(out, err)
 	return string(out), err

--- a/util/common/agent_util_windows.go
+++ b/util/common/agent_util_windows.go
@@ -141,9 +141,9 @@ func RunShellScript(path string, args ...string) (string, error) {
 // printOutputAndError does nothing if there was no error.
 // Else it prints stdout and stderr.
 func printOutputAndError(stdout []byte, err error) {
-	if err == nil {
-		return
-	}
+	//if err == nil {
+	//	return
+	//}
 	stderr := ""
 	ee, ok := err.(*exec.ExitError)
 	if ok {

--- a/util/common/agent_util_windows.go
+++ b/util/common/agent_util_windows.go
@@ -152,8 +152,8 @@ func printOutputAndError(stdout []byte, err error) {
 }
 
 func RunCommand(cmd string) (string, error) {
-	log.Printf("running cmd, %s %s %s %s %s", "powershell.exe", "-NoProfile", "-NonInteractive", "-NoExit", cmd)
-	out, err := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-NoExit", cmd).Output()
+	log.Printf("running cmd, %s %s %s %s %s", "powershell.exe", "-NoProfile", "-NonInteractive", cmd)
+	out, err := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", cmd).Output()
 	printOutputAndError(out, err)
 	return string(out), err
 }

--- a/util/common/agent_util_windows.go
+++ b/util/common/agent_util_windows.go
@@ -141,9 +141,9 @@ func RunShellScript(path string, args ...string) (string, error) {
 // printOutputAndError does nothing if there was no error.
 // Else it prints stdout and stderr.
 func printOutputAndError(stdout []byte, err error) {
-	//if err == nil {
-	//	return
-	//}
+	if err == nil {
+		return
+	}
 	stderr := ""
 	ee, ok := err.(*exec.ExitError)
 	if ok {

--- a/util/common/agent_util_windows.go
+++ b/util/common/agent_util_windows.go
@@ -140,9 +140,9 @@ func RunShellScript(path string, args ...string) (string, error) {
 // printOutputAndError does nothing if there was no error.
 // Else it prints stdout and stderr.
 func printOutputAndError(stdout []byte, err error) {
-	if err == nil {
-		return
-	}
+	//if err == nil {
+	//	return
+	//}
 	stderr := ""
 	ee, ok := err.(*exec.ExitError)
 	if ok {

--- a/util/common/agent_util_windows.go
+++ b/util/common/agent_util_windows.go
@@ -153,7 +153,6 @@ func printOutputAndError(stdout []byte, err error) {
 }
 
 func RunCommand(cmd string) (string, error) {
-	log.Printf("running cmd, %s %s %s %s %s", "powershell.exe", "-NoProfile", "-NonInteractive", cmd)
 	out, err := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", cmd).Output()
 	printOutputAndError(out, err)
 	return string(out), err


### PR DESCRIPTION
# Description of the issue
Resolves issue with windows 2012 acceptance and restart testing not passing

# Description of changes
The `-NoExit` parameter causes the command to not exit after finishing, ultimately timing out. I've removed the calls from `NoExit` from the functions that are called from these tests

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Integration testing
