### PR TITLE
Add drop original metrics test.

### DIFF
--- a/test/metric_dimension/agent_configs/drop_original_metrics.json
+++ b/test/metric_dimension/agent_configs/drop_original_metrics.json
@@ -30,7 +30,7 @@
       "cpu": {
         "drop_original_metrics": ["usage_guest", "usage_idle"],
         "measurement": [
-          "usage_guest",
+          {"name": "usage_guest", "rename": "cpu_usage_visitor"},
           "usage_idle",
           "usage_user"
         ]

--- a/test/metric_dimension/agent_configs/drop_original_metrics.json
+++ b/test/metric_dimension/agent_configs/drop_original_metrics.json
@@ -1,0 +1,47 @@
+{
+  "agent": {
+    "metrics_collection_interval": 10
+  },
+  "metrics": {
+    "force_flush_interval": 5,
+    "namespace": "TestDropOriginalMetrics",
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}",
+      "InstanceType": "${aws:InstanceType}"
+    },
+    "aggregation_dimensions": [
+      [],
+      [
+        "InstanceId"
+      ],
+      [
+        "InstanceId",
+        "InstanceType"
+      ]
+    ],
+    "metrics_collected": {
+      "mem": {
+        "drop_original_metrics": ["*"],
+        "measurement": [
+          "available",
+          "used_percent"
+        ]
+      },
+      "cpu": {
+        "drop_original_metrics": ["usage_guest", "usage_idle"],
+        "measurement": [
+          "usage_guest",
+          "usage_idle",
+          "usage_user"
+        ]
+      },
+      "swap": {
+        "drop_original_metrics": [],
+        "measurement": [
+          "free",
+          "used"
+        ]
+      }
+    }
+  }
+}

--- a/test/metric_dimension/drop_original_test.go
+++ b/test/metric_dimension/drop_original_test.go
@@ -1,0 +1,179 @@
+//go:build !windows
+
+package metric_dimension
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
+)
+
+const (
+	testNamespace = "TestDropOriginalMetrics"
+)
+
+type DropOriginalMetricsTestRunner struct {
+	test_runner.BaseTestRunner
+}
+
+type expectation struct {
+	shouldExist bool
+	metricNames []string
+	dimensions  []dimension.Instruction
+}
+
+var _ test_runner.ITestRunner = (*DropOriginalMetricsTestRunner)(nil)
+
+func (t *DropOriginalMetricsTestRunner) Validate() status.TestGroupResult {
+	var results []status.TestResult
+
+	for name, wants := range t.testCases() {
+		result := status.TestResult{Name: name, Status: status.SUCCESSFUL}
+		for _, want := range wants {
+			if err := t.validate(want); err != nil {
+				log.Printf("failed %s/%s: %v", t.GetTestName(), name, err)
+				result.Status = status.FAILED
+				break
+			}
+		}
+		results = append(results, result)
+	}
+
+	return status.TestGroupResult{
+		Name:        t.GetTestName(),
+		TestResults: results,
+	}
+}
+
+func (t *DropOriginalMetricsTestRunner) GetTestName() string {
+	return "DropOriginalMetrics"
+}
+
+func (t *DropOriginalMetricsTestRunner) GetAgentConfigFileName() string {
+	return "drop_original_metrics.json"
+}
+
+func (t *DropOriginalMetricsTestRunner) GetMeasuredMetrics() []string {
+	return []string{
+		"mem_available",
+		"mem_used_percent",
+		"cpu_usage_guest",
+		"cpu_usage_idle",
+		"cpu_usage_user",
+		"swap_free",
+		"swap_used",
+	}
+}
+
+func (t *DropOriginalMetricsTestRunner) validate(want expectation) error {
+	fetcher := metric.MetricValueFetcher{}
+	dimensions, _ := t.DimensionFactory.GetDimensions(want.dimensions)
+	for _, metricName := range want.metricNames {
+		values, err := fetcher.Fetch(testNamespace, metricName, dimensions, metric.AVERAGE, metric.HighResolutionStatPeriod)
+		if err != nil {
+			return err
+		}
+		if want.shouldExist && len(values) == 0 {
+			return fmt.Errorf("missing metric %q with dimensions %+v", metricName, want.dimensions)
+		}
+		if !want.shouldExist && len(values) > 0 {
+			return fmt.Errorf("found invalid metric %q with dimensions %+v", metricName, want.dimensions)
+		}
+	}
+	return nil
+}
+
+func (t *DropOriginalMetricsTestRunner) testCases() map[string][]expectation {
+	return map[string][]expectation{
+		"None": {
+			{
+				shouldExist: true,
+				metricNames: []string{"swap_free", "swap_used"},
+				dimensions:  []dimension.Instruction{},
+			},
+			{
+				shouldExist: true,
+				metricNames: []string{"swap_free", "swap_used"},
+				dimensions: []dimension.Instruction{
+					{"InstanceId", dimension.UnknownDimensionValue()},
+				},
+			},
+			{
+				shouldExist: true,
+				metricNames: []string{"swap_free", "swap_used"},
+				dimensions: []dimension.Instruction{
+					{"InstanceId", dimension.UnknownDimensionValue()},
+					{"InstanceType", dimension.UnknownDimensionValue()},
+				},
+			},
+		},
+		"Standard": {
+			{
+				shouldExist: true,
+				metricNames: []string{"cpu_usage_guest", "cpu_usage_idle", "cpu_usage_user"},
+				dimensions:  []dimension.Instruction{},
+			},
+			{
+				shouldExist: true,
+				metricNames: []string{"cpu_usage_guest", "cpu_usage_idle", "cpu_usage_user"},
+				dimensions: []dimension.Instruction{
+					{"InstanceId", dimension.UnknownDimensionValue()},
+				},
+			},
+			{
+				shouldExist: true,
+				metricNames: []string{"cpu_usage_guest", "cpu_usage_idle", "cpu_usage_user"},
+				dimensions: []dimension.Instruction{
+					{"InstanceId", dimension.UnknownDimensionValue()},
+					{"InstanceType", dimension.UnknownDimensionValue()},
+				},
+			},
+			{
+				shouldExist: true,
+				metricNames: []string{"cpu_usage_user"},
+				dimensions: []dimension.Instruction{
+					{"InstanceId", dimension.UnknownDimensionValue()},
+					{"InstanceType", dimension.UnknownDimensionValue()},
+					{"cpu", dimension.ExpectedDimensionValue{Value: aws.String("cpu-total")}},
+				},
+			},
+			{
+				shouldExist: false,
+				metricNames: []string{"cpu_usage_guest", "cpu_usage_idle"},
+				dimensions: []dimension.Instruction{
+					{"InstanceId", dimension.UnknownDimensionValue()},
+					{"InstanceType", dimension.UnknownDimensionValue()},
+					{"cpu", dimension.ExpectedDimensionValue{Value: aws.String("cpu-total")}},
+				},
+			},
+		},
+		"Wildcard": {
+			{
+				shouldExist: true,
+				metricNames: []string{"mem_available", "mem_used_percent"},
+				dimensions:  []dimension.Instruction{},
+			},
+			{
+				shouldExist: true,
+				metricNames: []string{"mem_available", "mem_used_percent"},
+				dimensions: []dimension.Instruction{
+					{"InstanceId", dimension.UnknownDimensionValue()},
+				},
+			},
+			{
+				shouldExist: false,
+				metricNames: []string{"mem_available", "mem_used_percent"},
+				dimensions: []dimension.Instruction{
+					{"InstanceId", dimension.UnknownDimensionValue()},
+					{"InstanceType", dimension.UnknownDimensionValue()},
+				},
+			},
+		},
+	}
+}

--- a/test/metric_dimension/drop_original_test.go
+++ b/test/metric_dimension/drop_original_test.go
@@ -59,16 +59,9 @@ func (t *DropOriginalMetricsTestRunner) GetAgentConfigFileName() string {
 	return "drop_original_metrics.json"
 }
 
+// unused
 func (t *DropOriginalMetricsTestRunner) GetMeasuredMetrics() []string {
-	return []string{
-		"mem_available",
-		"mem_used_percent",
-		"cpu_usage_guest",
-		"cpu_usage_idle",
-		"cpu_usage_user",
-		"swap_free",
-		"swap_used",
-	}
+	return []string{}
 }
 
 func (t *DropOriginalMetricsTestRunner) validate(want expectation) error {
@@ -113,22 +106,22 @@ func (t *DropOriginalMetricsTestRunner) testCases() map[string][]expectation {
 				},
 			},
 		},
-		"Standard": {
+		"StandardWithRename": {
 			{
 				shouldExist: true,
-				metricNames: []string{"cpu_usage_guest", "cpu_usage_idle", "cpu_usage_user"},
+				metricNames: []string{"cpu_usage_visitor", "cpu_usage_idle", "cpu_usage_user"},
 				dimensions:  []dimension.Instruction{},
 			},
 			{
 				shouldExist: true,
-				metricNames: []string{"cpu_usage_guest", "cpu_usage_idle", "cpu_usage_user"},
+				metricNames: []string{"cpu_usage_visitor", "cpu_usage_idle", "cpu_usage_user"},
 				dimensions: []dimension.Instruction{
 					{"InstanceId", dimension.UnknownDimensionValue()},
 				},
 			},
 			{
 				shouldExist: true,
-				metricNames: []string{"cpu_usage_guest", "cpu_usage_idle", "cpu_usage_user"},
+				metricNames: []string{"cpu_usage_visitor", "cpu_usage_idle", "cpu_usage_user"},
 				dimensions: []dimension.Instruction{
 					{"InstanceId", dimension.UnknownDimensionValue()},
 					{"InstanceType", dimension.UnknownDimensionValue()},
@@ -145,7 +138,7 @@ func (t *DropOriginalMetricsTestRunner) testCases() map[string][]expectation {
 			},
 			{
 				shouldExist: false,
-				metricNames: []string{"cpu_usage_guest", "cpu_usage_idle"},
+				metricNames: []string{"cpu_usage_visitor", "cpu_usage_idle"},
 				dimensions: []dimension.Instruction{
 					{"InstanceId", dimension.UnknownDimensionValue()},
 					{"InstanceType", dimension.UnknownDimensionValue()},

--- a/test/metric_dimension/metrics_dimension_test.go
+++ b/test/metric_dimension/metrics_dimension_test.go
@@ -47,6 +47,7 @@ func getTestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 			{TestRunner: &GlobalAppendDimensionsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &OneAggregateDimensionTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &AggregationDimensionsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &DropOriginalMetricsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 		}
 	}
 	return testRunners


### PR DESCRIPTION
# Description of the issue
We do not have integration test coverage for the drop original metrics feature.

# Description of changes
Added a test to the aggregate dimensions tests that covers the standard and wildcard cases.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran a minimal test on https://github.com/aws/amazon-cloudwatch-agent/actions/runs/5590470675/jobs/10220269235
>  null_resource.integration_test_run (remote-exec): 2023/07/18 17:30:06 ==============DropOriginalMetrics==============
null_resource.integration_test_run (remote-exec): 2023/07/18 17:30:06 ==============Successful==============
null_resource.integration_test_run (remote-exec): None       Successful
null_resource.integration_test_run (remote-exec): Standard   Successful
null_resource.integration_test_run (remote-exec): Wildcard   Successful

Running another test to include the rename https://github.com/aws/amazon-cloudwatch-agent/actions/runs/5590897820/jobs/10221250864
