### PR TITLE
Fix Mac Tests Fail To Start GHA

### DIFF
--- a/terraform/ec2/mac/main.tf
+++ b/terraform/ec2/mac/main.tf
@@ -156,7 +156,7 @@ resource "null_resource" "integration_test_run" {
   }
 
   depends_on = [
-    null_resource.integration_test_setup,
+    null_resource.integration_test,
     null_resource.integration_test_wait,
   ]
 }
@@ -172,5 +172,14 @@ data "aws_ami" "latest" {
   filter {
     name   = "architecture"
     values = [var.arc == "arm64" ? "arm64_mac" : "x86_64_mac"]
+  }
+}
+
+resource "null_resource" "integration_test_wait" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "Sleeping after initiating instance restart"
+      sleep 180
+    EOT
   }
 }

--- a/terraform/ec2/mac/variables.tf
+++ b/terraform/ec2/mac/variables.tf
@@ -71,3 +71,8 @@ variable "license_manager_arn" {
   default = ""
 }
 
+variable "user" {
+  type    = string
+  default = "ec2-user"
+}
+


### PR DESCRIPTION
# Description of the issue
Mac tests will not start with gha

# Description of changes
Fix the compile of the test and add a default value for user var

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
terraform apply with the same values as the action. 
