### PR TITLE
Change basic validator to check the exact line count.

### DIFF
--- a/validator/validators/basic/basic_validator.go
+++ b/validator/validators/basic/basic_validator.go
@@ -105,13 +105,13 @@ func (s *BasicValidator) Cleanup() error {
 	return nil
 }
 
-func (s *BasicValidator) ValidateLogs(logStream, logLine, logLevel, logSource string, numberOfLogLine int, startTime, endTime time.Time) error {
+func (s *BasicValidator) ValidateLogs(logStream, logLine, logLevel, logSource string, expectedNumberOfLogLine int, startTime, endTime time.Time) error {
 	var (
 		logGroup = awsservice.GetInstanceId()
 	)
-	log.Printf("Start to validate log '%s' with number of logs lines %d within log group %s, log stream %s, start time %v and end time %v", logLine, numberOfLogLine, logGroup, logStream, startTime, endTime)
+	log.Printf("Start to validate log '%s' with number of logs lines %d within log group %s, log stream %s, start time %v and end time %v", logLine, expectedNumberOfLogLine, logGroup, logStream, startTime, endTime)
 	ok, err := awsservice.ValidateLogs(logGroup, logStream, &startTime, &endTime, func(logs []string) bool {
-		if len(logs) < 1 {
+		if len(logs) == 0 {
 			return false
 		}
 		actualNumberOfLogLines := 0
@@ -128,11 +128,11 @@ func (s *BasicValidator) ValidateLogs(logStream, logLine, logLevel, logSource st
 			}
 		}
 
-		return numberOfLogLine <= actualNumberOfLogLines
+		return expectedNumberOfLogLine == actualNumberOfLogLines
 	})
 
 	if !ok || err != nil {
-		return fmt.Errorf("\n the number of log line for '%s' is %d which does not match the actual number with log group %s, log stream %s, start time %v and end time %v with err %v", logLine, numberOfLogLine, logGroup, logStream, startTime, endTime, err)
+		return fmt.Errorf("\n the number of log line for '%s' is %d which does not match the actual number with log group %s, log stream %s, start time %v and end time %v with err %v", logLine, expectedNumberOfLogLine, logGroup, logStream, startTime, endTime, err)
 	}
 
 	return nil


### PR DESCRIPTION
# Description of the issue
The basic validator is used by the windows feature test to validate metrics and logs. Currently, the log validation just checks that the number of actual log lines is greater than or equal to the number of expected log lines. This will not catch duplicate log lines.

# Description of changes
Makes it an equals check instead.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
