### PR TITLE
Revert "Change basic validator to check the exact line count. (#314)"

### DIFF
--- a/validator/validators/basic/basic_validator.go
+++ b/validator/validators/basic/basic_validator.go
@@ -105,13 +105,13 @@ func (s *BasicValidator) Cleanup() error {
 	return nil
 }
 
-func (s *BasicValidator) ValidateLogs(logStream, logLine, logLevel, logSource string, expectedNumberOfLogLine int, startTime, endTime time.Time) error {
+func (s *BasicValidator) ValidateLogs(logStream, logLine, logLevel, logSource string, numberOfLogLine int, startTime, endTime time.Time) error {
 	var (
 		logGroup = awsservice.GetInstanceId()
 	)
-	log.Printf("Start to validate log '%s' with number of logs lines %d within log group %s, log stream %s, start time %v and end time %v", logLine, expectedNumberOfLogLine, logGroup, logStream, startTime, endTime)
+	log.Printf("Start to validate log '%s' with number of logs lines %d within log group %s, log stream %s, start time %v and end time %v", logLine, numberOfLogLine, logGroup, logStream, startTime, endTime)
 	ok, err := awsservice.ValidateLogs(logGroup, logStream, &startTime, &endTime, func(logs []string) bool {
-		if len(logs) == 0 {
+		if len(logs) < 1 {
 			return false
 		}
 		actualNumberOfLogLines := 0
@@ -128,11 +128,11 @@ func (s *BasicValidator) ValidateLogs(logStream, logLine, logLevel, logSource st
 			}
 		}
 
-		return expectedNumberOfLogLine == actualNumberOfLogLines
+		return numberOfLogLine <= actualNumberOfLogLines
 	})
 
 	if !ok || err != nil {
-		return fmt.Errorf("\n the number of log line for '%s' is %d which does not match the actual number with log group %s, log stream %s, start time %v and end time %v with err %v", logLine, expectedNumberOfLogLine, logGroup, logStream, startTime, endTime, err)
+		return fmt.Errorf("\n the number of log line for '%s' is %d which does not match the actual number with log group %s, log stream %s, start time %v and end time %v with err %v", logLine, numberOfLogLine, logGroup, logStream, startTime, endTime, err)
 	}
 
 	return nil


### PR DESCRIPTION
This reverts commit 10e722ec80df960f2bbf1aba4ec64ab18cb0bb9b.

# Description of the issue
Expected the test to validate an exact count of log lines, but it doesn't do that. It's to validate the existence of the log lines at all. The same substring shows up multiple times.

# Description of changes
Reverts the change.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
