### PR TITLE
Add Log For Entry And Json Schema When Log Validation Fails

### DIFF
--- a/test/metric_value_benchmark/eks_daemonset_test.go
+++ b/test/metric_value_benchmark/eks_daemonset_test.go
@@ -156,6 +156,7 @@ func (e *EKSDaemonTestRunner) validateLogs(env *environment.MetaData) status.Tes
 
 				if !awsservice.MatchEMFLogWithSchema(l, rs, validateLogContents) {
 					log.Println("failed to match log with schema")
+					log.Printf("log entry %s json schema %s", l, jsonSchema)
 					return false
 				}
 			}


### PR DESCRIPTION
# Description of the issue
Want to see the log entry and schema for failing emf log. 

# Description of changes
Add log line when emf validation fails for log line entry and schema. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A
