### PR TITLE
Add duplicate logs check.

### DIFF
--- a/test/cloudwatchlogs/publish_logs_test.go
+++ b/test/cloudwatchlogs/publish_logs_test.go
@@ -106,6 +106,7 @@ func TestWriteLogsToCloudWatch(t *testing.T) {
 				&start,
 				&end,
 				awsservice.AssertLogsCount(param.numExpectedLogs),
+				awsservice.AssertNoDuplicateLogs(),
 			)
 			assert.NoError(t, err)
 		})

--- a/test/ecs/ecs_metadata/ecs_metadata_test.go
+++ b/test/ecs/ecs_metadata/ecs_metadata_test.go
@@ -7,12 +7,12 @@ import (
 	_ "embed"
 	"flag"
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"log"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/qri-io/jsonschema"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
@@ -36,8 +36,6 @@ var clusterName = flag.String("clusterName", "", "Please provide the os preferen
 var schema string
 
 func TestValidatingCloudWatchLogs(t *testing.T) {
-	rs := jsonschema.Must(schema)
-
 	start := time.Now()
 
 	logGroupName := fmt.Sprintf(ECSLogGroupNameFormat, *clusterName)
@@ -57,25 +55,25 @@ func TestValidatingCloudWatchLogs(t *testing.T) {
 
 		end := time.Now()
 
-		ok, err := awsservice.ValidateLogs(logGroupName, LogStreamName, &start, &end, func(logs []string) bool {
-			if len(logs) < 1 {
-				return false
-			}
-			for _, l := range logs {
-				if !awsservice.MatchEMFLogWithSchema(l, rs, func(s string) bool {
-					ok := true
-					if strings.Contains(l, "CloudWatchMetrics") {
-						ok = ok && strings.Contains(l, "\"Namespace\":\"ECS/ContainerInsights/Prometheus\"")
+		err := awsservice.ValidateLogs(
+			logGroupName,
+			LogStreamName,
+			&start,
+			&end,
+			awsservice.AssertLogsNotEmpty(),
+			awsservice.AssertPerLog(
+				awsservice.AssertLogSchema(awsservice.WithSchema(schema)),
+				func(event types.OutputLogEvent) error {
+					if strings.Contains(*event.Message, "CloudWatchMetrics") &&
+						!strings.Contains(*event.Message, "\"Namespace\":\"ECS/ContainerInsights/Prometheus\"") {
+						return fmt.Errorf("emf log found for non ECS/ContainerInsights/Prometheus namespace: %s", *event.Message)
 					}
-					return ok && strings.Contains(l, "\"job\":\"prometheus-redis\"")
-				}) {
-					return false
-				}
-			}
-			return true
-		})
+					return nil
+				},
+				awsservice.AssertLogSubstring("\"job\":\"prometheus-redis\""),
+			),
+		)
 		assert.NoError(t, err)
-		assert.True(t, ok)
 
 		break
 	}

--- a/test/ecs/ecs_metadata/ecs_metadata_test.go
+++ b/test/ecs/ecs_metadata/ecs_metadata_test.go
@@ -70,7 +70,7 @@ func TestValidatingCloudWatchLogs(t *testing.T) {
 					}
 					return nil
 				},
-				awsservice.AssertLogSubstring("\"job\":\"prometheus-redis\""),
+				awsservice.AssertLogContainsSubstring("\"job\":\"prometheus-redis\""),
 			),
 		)
 		assert.NoError(t, err)

--- a/test/metric_value_benchmark/container_insights_test.go
+++ b/test/metric_value_benchmark/container_insights_test.go
@@ -130,7 +130,7 @@ func validateLogsForContainerInsights(e *environment.MetaData) status.TestResult
 			awsservice.AssertLogsNotEmpty(),
 			awsservice.AssertPerLog(
 				awsservice.AssertLogSchema(awsservice.WithSchema(emfContainerInsightsSchema)),
-				awsservice.AssertLogSubstring(fmt.Sprintf("\"ContainerInstanceId\":\"%s\"", container.ContainerInstanceId)),
+				awsservice.AssertLogContainsSubstring(fmt.Sprintf("\"ContainerInstanceId\":\"%s\"", container.ContainerInstanceId)),
 			),
 		)
 

--- a/test/metric_value_benchmark/eks_daemonset_test.go
+++ b/test/metric_value_benchmark/eks_daemonset_test.go
@@ -148,7 +148,7 @@ func (e *EKSDaemonTestRunner) validateLogs(env *environment.MetaData) status.Tes
 					}
 					return jsonSchema, nil
 				}),
-				awsservice.AssertLogSubstring(fmt.Sprintf("\"ClusterName\":\"%s\"", env.EKSClusterName)),
+				awsservice.AssertLogContainsSubstring(fmt.Sprintf("\"ClusterName\":\"%s\"", env.EKSClusterName)),
 			),
 		)
 

--- a/test/metric_value_benchmark/eks_daemonset_test.go
+++ b/test/metric_value_benchmark/eks_daemonset_test.go
@@ -7,13 +7,12 @@ package metric_value_benchmark
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
-	"github.com/qri-io/jsonschema"
 	"golang.org/x/exp/slices"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
@@ -127,43 +126,34 @@ func (e *EKSDaemonTestRunner) validateLogs(env *environment.MetaData) status.Tes
 	}
 
 	for _, instance := range eKSInstances {
-		validateLogContents := func(s string) bool {
-			return strings.Contains(s, fmt.Sprintf("\"ClusterName\":\"%s\"", env.EKSClusterName))
-		}
-
-		var ok bool
 		stream := *instance.InstanceName
-		ok, err = awsservice.ValidateLogs(group, stream, nil, &now, func(logs []string) bool {
-			if len(logs) < 1 {
-				log.Println(fmt.Sprintf("failed to get logs for instance: %s", stream))
-				return false
-			}
+		err = awsservice.ValidateLogs(
+			group,
+			stream,
+			nil,
+			&now,
+			awsservice.AssertLogsNotEmpty(),
+			awsservice.AssertPerLog(
+				awsservice.AssertLogSchema(func(message string) (string, error) {
+					var eksClusterType awsservice.EKSClusterType
+					innerErr := json.Unmarshal([]byte(message), &eksClusterType)
+					if innerErr != nil {
+						return "", fmt.Errorf("failed to unmarshal log file: %w", innerErr)
+					}
 
-			for _, l := range logs {
-				var eksClusterType awsservice.EKSClusterType
-				err := json.Unmarshal([]byte(l), &eksClusterType)
-				if err != nil {
-					log.Println("failed to unmarshal log file")
-				}
+					log.Printf("eksClusterType is: %s", eksClusterType.Type)
+					jsonSchema, ok := eks_resources.EksClusterValidationMap[eksClusterType.Type]
+					if !ok {
+						return "", errors.New("invalid cluster type provided")
+					}
+					return jsonSchema, nil
+				}),
+				awsservice.AssertLogSubstring(fmt.Sprintf("\"ClusterName\":\"%s\"", env.EKSClusterName)),
+			),
+		)
 
-				log.Println(fmt.Sprintf("eksClusterType is: %s", eksClusterType.Type))
-				jsonSchema, ok := eks_resources.EksClusterValidationMap[eksClusterType.Type]
-				if !ok {
-					log.Println("invalid cluster type provided")
-					return false
-				}
-				rs := jsonschema.Must(jsonSchema)
-
-				if !awsservice.MatchEMFLogWithSchema(l, rs, validateLogContents) {
-					log.Println("failed to match log with schema")
-					log.Printf("log entry %s json schema %s", l, jsonSchema)
-					return false
-				}
-			}
-			return true
-		})
-
-		if err != nil || !ok {
+		if err != nil {
+			log.Printf("log validation (%s/%s) failed: %v", group, stream, err)
 			return testResult
 		}
 	}

--- a/test/metric_value_benchmark/emf_test.go
+++ b/test/metric_value_benchmark/emf_test.go
@@ -123,7 +123,7 @@ func validateEMFLogs(group, stream string) status.TestResult {
 		awsservice.AssertLogsNotEmpty(),
 		awsservice.AssertPerLog(
 			awsservice.AssertLogSchema(awsservice.WithSchema(emfMetricValueBenchmarkSchema)),
-			awsservice.AssertLogSubstring("\"EMFCounter\":5"),
+			awsservice.AssertLogContainsSubstring("\"EMFCounter\":5"),
 		),
 	)
 	if err != nil {

--- a/util/awsservice/cloudwatchlogs.go
+++ b/util/awsservice/cloudwatchlogs.go
@@ -6,7 +6,9 @@ package awsservice
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -51,21 +53,26 @@ func DeleteLogGroup(logGroupName string) {
 
 // ValidateLogs queries a given LogGroup/LogStream combination given the start and end times, and executes an
 // arbitrary validator function on the found logs.
-func ValidateLogs(logGroup, logStream string, since, until *time.Time, validator func(logs []string) bool) (bool, error) {
-	log.Printf("Checking %s/%s\n", logGroup, logStream)
+func ValidateLogs(logGroup, logStream string, since, until *time.Time, validators ...LogEventsValidator) error {
+	log.Printf("Checking %s/%s", logGroup, logStream)
 
-	foundLogs, err := getLogsSince(logGroup, logStream, since, until)
+	events, err := getLogsSince(logGroup, logStream, since, until)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	return validator(foundLogs), nil
+	for _, validator := range validators {
+		if err = validator(events); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // getLogsSince makes GetLogEvents API calls, paginates through the results for the given time frame, and returns
 // the raw log strings
-func getLogsSince(logGroup, logStream string, since, until *time.Time) ([]string, error) {
-	foundLogs := make([]string, 0)
+func getLogsSince(logGroup, logStream string, since, until *time.Time) ([]types.OutputLogEvent, error) {
+	var events []types.OutputLogEvent
 
 	// https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogEvents.html
 	// GetLogEvents can return an empty result while still having more log events on a subsequent page,
@@ -103,22 +110,22 @@ func getLogsSince(logGroup, logStream string, since, until *time.Time) ([]string
 			}
 
 			// if the error is not a ResourceNotFoundException, we should fail here.
-			return foundLogs, err
+			return events, err
 		}
 
 		for _, e := range output.Events {
-			foundLogs = append(foundLogs, *e.Message)
+			events = append(events, e)
 		}
 
 		if nextToken != nil && output.NextForwardToken != nil && *output.NextForwardToken == *nextToken {
 			// From the docs: If you have reached the end of the stream, it returns the same token you passed in.
-			log.Printf("Done paginating log events for %s/%s and found %d logs", logGroup, logStream, len(foundLogs))
+			log.Printf("Done paginating log events for %s/%s and found %d logs", logGroup, logStream, len(events))
 			break
 		}
 
 		nextToken = output.NextForwardToken
 	}
-	return foundLogs, nil
+	return events, nil
 }
 
 // IsLogGroupExists confirms whether the logGroupName exists or not
@@ -161,15 +168,97 @@ func GetLogStreams(logGroupName string) []types.LogStream {
 	return []types.LogStream{}
 }
 
-func MatchEMFLogWithSchema(logEntry string, s *jsonschema.Schema, logValidator func(string) bool) bool {
-	keyErrors, e := s.ValidateBytes(context.Background(), []byte(logEntry))
-	if e != nil {
-		log.Println("failed to execute schema validator:", e)
-		return false
-	} else if len(keyErrors) > 0 {
-		log.Printf("failed schema validation: %v\n", keyErrors)
-		return false
-	}
+type LogEventValidator func(event types.OutputLogEvent) error
 
-	return logValidator(logEntry)
+type LogEventsValidator func(events []types.OutputLogEvent) error
+
+type SchemaRetriever func(message string) (string, error)
+
+func WithSchema(schema string) SchemaRetriever {
+	return func(_ string) (string, error) {
+		return schema, nil
+	}
+}
+
+func AssertLogSchema(schemaRetriever SchemaRetriever) LogEventValidator {
+	return func(event types.OutputLogEvent) error {
+		message := *event.Message
+		if schemaRetriever == nil {
+			return errors.New("nil schema retriever")
+		}
+		schema, err := schemaRetriever(*event.Message)
+		if err != nil {
+			return fmt.Errorf("unable to retrieve schema: %w", err)
+		}
+		keyErrors, err := jsonschema.Must(schema).ValidateBytes(context.Background(), []byte(message))
+		if err != nil {
+			return fmt.Errorf("failed to execute schema validator: %w", err)
+		} else if len(keyErrors) > 0 {
+			return fmt.Errorf("failed schema validation: %v | schema: %s | log: %s", keyErrors, schema, message)
+		}
+		return nil
+	}
+}
+
+func AssertLogSubstring(substr string) LogEventValidator {
+	return func(event types.OutputLogEvent) error {
+		if !strings.Contains(*event.Message, substr) {
+			return fmt.Errorf("log event message missing substring (%s): %s", substr, *event.Message)
+		}
+		return nil
+	}
+}
+
+// AssertPerLog runs each validator on each of the log events. Fails fast.
+func AssertPerLog(validators ...LogEventValidator) LogEventsValidator {
+	return func(events []types.OutputLogEvent) error {
+		for _, event := range events {
+			for _, validator := range validators {
+				if err := validator(event); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+}
+
+func AssertLogsNotEmpty() LogEventsValidator {
+	return func(events []types.OutputLogEvent) error {
+		if len(events) == 0 {
+			return errors.New("no log events")
+		}
+		return nil
+	}
+}
+
+func AssertLogsCount(count int) LogEventsValidator {
+	return func(events []types.OutputLogEvent) error {
+		if len(events) != count {
+			return fmt.Errorf("actual log events count (%v) does not match expected (%v)", len(events), count)
+		}
+		return nil
+	}
+}
+
+func AssertNoDuplicateLogs() LogEventsValidator {
+	return func(events []types.OutputLogEvent) error {
+		byTimestamp := make(map[int64]map[string]struct{})
+		for _, event := range events {
+			message := *event.Message
+			timestamp := *event.Timestamp
+			messages, ok := byTimestamp[timestamp]
+			if !ok {
+				messages = map[string]struct{}{}
+				byTimestamp[timestamp] = messages
+			}
+			_, ok = messages[message]
+			if !ok {
+				messages[message] = struct{}{}
+				continue
+			}
+			return fmt.Errorf("duplicate message found at %v | message: %s", time.UnixMilli(timestamp), message)
+		}
+		return nil
+	}
 }

--- a/util/awsservice/cloudwatchlogs.go
+++ b/util/awsservice/cloudwatchlogs.go
@@ -200,7 +200,7 @@ func AssertLogSchema(schemaRetriever SchemaRetriever) LogEventValidator {
 	}
 }
 
-func AssertLogSubstring(substr string) LogEventValidator {
+func AssertLogContainsSubstring(substr string) LogEventValidator {
 	return func(event types.OutputLogEvent) error {
 		if !strings.Contains(*event.Message, substr) {
 			return fmt.Errorf("log event message missing substring (%s): %s", substr, *event.Message)
@@ -254,10 +254,9 @@ func AssertNoDuplicateLogs() LogEventsValidator {
 			}
 			_, ok = messages[message]
 			if !ok {
-				messages[message] = struct{}{}
-				continue
+				return fmt.Errorf("duplicate message found at %v | message: %s", time.UnixMilli(timestamp), message)
 			}
-			return fmt.Errorf("duplicate message found at %v | message: %s", time.UnixMilli(timestamp), message)
+			messages[message] = struct{}{}
 		}
 		return nil
 	}


### PR DESCRIPTION
# Description of the issue
Need to be able to detect duplicate logs in the integration tests.

# Description of changes
Adds a duplicate log check to the basic validator. Checks that there aren't any logs for the same timestamp and message. Refactored the log validation a bit to evaluate over LogEvents instead of the log messages to retain the timestamp.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the integration tests and failed on the duplicates.
