### PR TITLE
remove pod_number_of_container_restarts from eks container insights test

### DIFF
--- a/test/metric_value_benchmark/eks_daemonset_test.go
+++ b/test/metric_value_benchmark/eks_daemonset_test.go
@@ -209,7 +209,6 @@ func (e *EKSDaemonTestRunner) GetMeasuredMetrics() []string {
 		"pod_memory_utilization_over_pod_limit",
 		"pod_network_rx_bytes",
 		"pod_network_tx_bytes",
-		"pod_number_of_container_restarts",
 		"service_number_of_running_pods",
 	}
 }


### PR DESCRIPTION
# Description of the issue
EKS Container insights tests are failing with
```
null_resource.validator (local-exec): 2023/08/01 16:15:59 Metric data input: namespace ContainerInsights, name pod_number_of_container_restarts
null_resource.validator (local-exec): 2023/08/01 16:15:59 Metrics fetched : &{[] <nil> [] {map[{}:-1692101626 {}:0xc00012a580 {}:7cbbf801-6edf-4ced-985c-c4d9bca2b4fe {}:{13919053940034413050 183235282108 0xfcd280} {}:{0 63826503358 <nil>} {}:{[{<nil> false false {map[{}:-1692101626 {}:0xc00012a580 {}:7cbbf801-6edf-4ced-985c-c4d9bca2b4fe {}:{13919053940034413050 183235282108 0xfcd280} {}:{0 63826503358 <nil>}]}}]}]} {}}
null_resource.validator (local-exec): 2023/08/01 16:15:59 metric list is empty
```

The root cause is that the agent when configured for non-enhanced container insights is not publishing `pod_number_of_container_restarts` per cluster.   This aggregation is only emitted when enhanced is enabled, when we create enhanced tests we will include this in the list
![Screen Shot 2023-08-02 at 4 34 11 PM](https://github.com/aws/amazon-cloudwatch-agent-test/assets/5192710/d3c09b84-0cbf-4836-a533-2b2b2e2e9b29)

# Description of changes
Remove this metric from the test, document internally to add this in the "enhanced" set of tests

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
n/a
