### PR TITLE
Macos integration test error fix

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -105,7 +105,6 @@ var testTypeToTestConfig = map[string][]testConfig{
 	*/
 	"ec2_mac": {
 		{testDir: "../../../test/feature/mac"},
-		{testDir: "../../../test/run_as_user"},
 	},
 	"ec2_windows": {
 		{testDir: "../../../test/feature/windows"},

--- a/terraform/ec2/mac/main.tf
+++ b/terraform/ec2/mac/main.tf
@@ -123,7 +123,7 @@ resource "null_resource" "integration_test" {
       "NONINTERACTIVE=1 brew install go",
 
       # Run integration test and sanity check
-      "echo run sanity test && sudo go test ./test/sanity -p 1 -v",
+      "echo run sanity test && sudo go test ~/amazon-cloudwatch-agent-test/test/sanity -p 1 -v",
       "echo Execute integration tests",
       "export AWS_REGION=${var.region}",
       "sudo chmod +x ./validator",

--- a/terraform/ec2/mac/main.tf
+++ b/terraform/ec2/mac/main.tf
@@ -73,7 +73,7 @@ resource "aws_instance" "cwagent" {
 }
 
 resource "null_resource" "integration_test" {
-  depends_on = [aws_instance.cwagent, module.validator]
+  depends_on = [aws_instance.cwagent, module.validator, integration_test_wait]
 
   connection {
     type        = "ssh"
@@ -131,10 +131,6 @@ resource "null_resource" "integration_test" {
       "./validator --validator-config=${module.validator.instance_validator_config} --preparation-mode=false",
       "cd ~/amazon-cloudwatch-agent-test",
       "sudo go test ./test/run_as_user -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -cwaCommitSha=${var.cwa_github_sha} -instanceId=${aws_instance.cwagent.id} -v",
-    ]
-
-    depends_on = [
-      null_resource.integration_test_wait,
     ]
   }
 

--- a/terraform/ec2/mac/main.tf
+++ b/terraform/ec2/mac/main.tf
@@ -123,15 +123,16 @@ resource "null_resource" "integration_test" {
       "NONINTERACTIVE=1 brew install go",
 
       # Run integration test and sanity check
-      "echo run sanity test && sudo go test ~/amazon-cloudwatch-agent-test/test/sanity -p 1 -v",
-      "echo Execute integration tests",
       "export AWS_REGION=${var.region}",
+      "cd ~/amazon-cloudwatch-agent-test",
+      "echo run sanity test && sudo go test /amazon-cloudwatch-agent-test/test/sanity -p 1 -v",
+      "sudo go test ./test/run_as_user -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -cwaCommitSha=${var.cwa_github_sha} -instanceId=${aws_instance.cwagent.id} -v",
+      "cd /",
+      "echo Execute integration tests",
       "sudo chmod +x ./validator",
       "./validator --validator-config=${module.validator.instance_validator_config} --preparation-mode=true",
       "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:${module.validator.instance_agent_config}",
       "./validator --validator-config=${module.validator.instance_validator_config} --preparation-mode=false",
-      "cd ~/amazon-cloudwatch-agent-test",
-      "sudo go test ./test/run_as_user -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -cwaCommitSha=${var.cwa_github_sha} -instanceId=${aws_instance.cwagent.id} -v",
     ]
   }
 

--- a/terraform/ec2/mac/main.tf
+++ b/terraform/ec2/mac/main.tf
@@ -134,7 +134,6 @@ resource "null_resource" "integration_test" {
     ]
 
     depends_on = [
-      null_resource.integration_test,
       null_resource.integration_test_wait,
     ]
   }

--- a/terraform/ec2/mac/main.tf
+++ b/terraform/ec2/mac/main.tf
@@ -132,35 +132,14 @@ resource "null_resource" "integration_test" {
       "cd ~/amazon-cloudwatch-agent-test",
       "sudo go test ./test/run_as_user -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -cwaCommitSha=${var.cwa_github_sha} -instanceId=${aws_instance.cwagent.id} -v",
     ]
-  }
 
-}
-
-resource "null_resource" "integration_test_run" {
-  connection {
-    type        = "ssh"
-    user        = var.user
-    private_key = local.private_key_content
-    host        = aws_instance.cwagent.public_ip
-  }
-
-  #Run sanity check and integration test
-  provisioner "remote-exec" {
-    inline = [
-      "echo prepare environment",
-      "export AWS_REGION=${var.region}",
-      "echo run integration test",
-      "cd ~/amazon-cloudwatch-agent-test",
-      "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket}  -cwaCommitSha=${var.cwa_github_sha} -instanceId=${aws_instance.cwagent.id} -v"
+    depends_on = [
+      null_resource.integration_test,
+      null_resource.integration_test_wait,
     ]
   }
 
-  depends_on = [
-    null_resource.integration_test,
-    null_resource.integration_test_wait,
-  ]
 }
-
 data "aws_ami" "latest" {
   most_recent = true
 

--- a/terraform/ec2/mac/main.tf
+++ b/terraform/ec2/mac/main.tf
@@ -122,7 +122,8 @@ resource "null_resource" "integration_test" {
       "echo Install golang",
       "NONINTERACTIVE=1 brew install go",
 
-      # Run Integration test
+      # Run integration test and sanity check
+      "echo run sanity test && go test ./test/sanity -p 1 -v",
       "echo Execute integration tests",
       "export AWS_REGION=${var.region}",
       "sudo chmod +x ./validator",

--- a/terraform/ec2/mac/main.tf
+++ b/terraform/ec2/mac/main.tf
@@ -123,7 +123,7 @@ resource "null_resource" "integration_test" {
       "NONINTERACTIVE=1 brew install go",
 
       # Run integration test and sanity check
-      "echo run sanity test && go test ./test/sanity -p 1 -v",
+      "echo run sanity test && sudo go test ./test/sanity -p 1 -v",
       "echo Execute integration tests",
       "export AWS_REGION=${var.region}",
       "sudo chmod +x ./validator",

--- a/terraform/ec2/mac/main.tf
+++ b/terraform/ec2/mac/main.tf
@@ -101,7 +101,7 @@ resource "null_resource" "integration_test" {
       "sudo installer -pkg AWSCLIV2.pkg -target /",
 
       #Install Brew and set path for mac1 and mac2 instances
-      "NONINTERACTIVE=1 /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+      lp",
       "(echo; echo 'eval \"$(/usr/local/bin/brew shellenv)\"') >> /Users/ec2-user/.zprofile",
       "eval \"$(/usr/local/bin/brew shellenv)\"",
       "(echo; echo 'eval \"$(/opt/homebrew/bin/brew shellenv)\"') >> /Users/ec2-user/.zprofile",

--- a/terraform/ec2/mac/main.tf
+++ b/terraform/ec2/mac/main.tf
@@ -101,7 +101,7 @@ resource "null_resource" "integration_test" {
       "sudo installer -pkg AWSCLIV2.pkg -target /",
 
       #Install Brew and set path for mac1 and mac2 instances
-      lp",
+      "NONINTERACTIVE=1 /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
       "(echo; echo 'eval \"$(/usr/local/bin/brew shellenv)\"') >> /Users/ec2-user/.zprofile",
       "eval \"$(/usr/local/bin/brew shellenv)\"",
       "(echo; echo 'eval \"$(/opt/homebrew/bin/brew shellenv)\"') >> /Users/ec2-user/.zprofile",

--- a/terraform/ec2/mac/main.tf
+++ b/terraform/ec2/mac/main.tf
@@ -73,7 +73,7 @@ resource "aws_instance" "cwagent" {
 }
 
 resource "null_resource" "integration_test" {
-  depends_on = [aws_instance.cwagent, module.validator, integration_test_wait]
+  depends_on = [aws_instance.cwagent, module.validator, null_resource.integration_test_wait]
 
   connection {
     type        = "ssh"

--- a/util/awsservice/constant.go
+++ b/util/awsservice/constant.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	StandardRetries = 1
+	StandardRetries = 3
 )
 
 var (

--- a/util/awsservice/constant.go
+++ b/util/awsservice/constant.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	StandardRetries = 3
+	StandardRetries = 1
 )
 
 var (


### PR DESCRIPTION
# Description of the issue
macOS test is failing because we accidentally added workflow and test path that are not needed for macOS test.

# Description of changes
Remove the unnecessary workflow.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Test run showing all macOS tests passing. https://github.com/aws/private-amazon-cloudwatch-agent-staging/actions/runs/5745725949/job/15576333770 
