### PR TITLE
Fix bug in duplicate check.

### DIFF
--- a/util/awsservice/cloudwatchlogs.go
+++ b/util/awsservice/cloudwatchlogs.go
@@ -253,7 +253,7 @@ func AssertNoDuplicateLogs() LogEventsValidator {
 				byTimestamp[timestamp] = messages
 			}
 			_, ok = messages[message]
-			if !ok {
+			if ok {
 				return fmt.Errorf("duplicate message found at %v | message: %s", time.UnixMilli(timestamp), message)
 			}
 			messages[message] = struct{}{}


### PR DESCRIPTION
# Description of the issue
Currently, it returns the duplicate error if it doesn't find the message for the timestamp. This means it'll fail on the first log message. It should be the opposite.

# Description of changes
Changed the condition.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Checked the log groups for a failing test.
