### PR TITLE
Test auto removal

### DIFF
--- a/test/cloudwatchlogs/publish_logs_test.go
+++ b/test/cloudwatchlogs/publish_logs_test.go
@@ -134,6 +134,9 @@ func TestAutoRemovalStopAgent(t *testing.T) {
 	common.StopAgent()
 	time.Sleep(agentRuntime)
 	assert.FileExists(t, fpath, "file does not exist, {}", fpath)
+	common.StartAgent(configPath, true, false)
+	time.Sleep(agentRuntime)
+	assert.FileExists(t, fpath, "file does not exist, {}", fpath)
 }
 
 // TestRotatingLogsDoesNotSkipLines validates https://github.com/aws/amazon-cloudwatch-agent/issues/447

--- a/test/cloudwatchlogs/publish_logs_test.go
+++ b/test/cloudwatchlogs/publish_logs_test.go
@@ -122,7 +122,7 @@ func TestAutoRemovalStopAgent(t *testing.T) {
 	defer awsservice.DeleteLogGroupAndStream(instanceId, instanceId)
 	configPath := "resources/config_auto_removal.json"
 	fpath := logFilePath + "1"
-	f, err := os.Create(logFilePath)
+	f, err := os.Create(fpath)
 	if err != nil {
 		t.Fatalf("Error occurred creating log file for writing: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestAutoRemovalStopAgent(t *testing.T) {
 	defer os.Remove(fpath)
 	common.StartAgent(configPath, true, false)
 	time.Sleep(agentRuntime)
-	writeLogs(t, f, 100_000)
+	writeLogs(t, f, 1000)
 	common.StopAgent()
 	time.Sleep(agentRuntime)
 	assert.FileExists(t, fpath, "file does not exist, {}", fpath)

--- a/test/cloudwatchlogs/publish_logs_test.go
+++ b/test/cloudwatchlogs/publish_logs_test.go
@@ -24,11 +24,11 @@ import (
 )
 
 const (
-	configOutputPath = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
-	logLineId1       = "foo"
-	logLineId2       = "bar"
-	logFilePath      = "/tmp/cwagent_log_test.log"  // TODO: not sure how well this will work on Windows
-	sleepForFlush    = 20 * time.Second // default flush interval is 5 seconds
+	configOutputPath      = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
+	logLineId1            = "foo"
+	logLineId2            = "bar"
+	logFilePath           = "/tmp/cwagent_log_test.log" // TODO: not sure how well this will work on Windows
+	sleepForFlush         = 20 * time.Second            // default flush interval is 5 seconds
 	configPathAutoRemoval = "resources/config_auto_removal.json"
 )
 
@@ -118,12 +118,11 @@ func autoRemovalTestCleanup() {
 	}
 }
 
-
 // checkData queries CWL and verifies the number of log lines.
 func checkData(t *testing.T, start time.Time, lineCount int) {
 	end := time.Now()
 	// Sleep to ensure backend stores logs.
-	time.Sleep(time.Second*60)
+	time.Sleep(time.Second * 60)
 	instanceId := awsservice.GetInstanceId()
 	err := awsservice.ValidateLogs(
 		instanceId,
@@ -167,7 +166,7 @@ func TestAutoRemovalStopAgent(t *testing.T) {
 	for i := 0; i < loopCount; i++ {
 		writeSleepRestart(t, f, configPathAutoRemoval, linesPerLoop, true)
 	}
-	checkData(t, start, loopCount * linesPerLoop * 2)
+	checkData(t, start, loopCount*linesPerLoop*2)
 }
 
 // TestAutoRemovalFileRotation repeatedly creates files matching the monitored pattern.
@@ -185,7 +184,7 @@ func TestAutoRemovalFileRotation(t *testing.T) {
 		defer f.Close()
 		writeSleepRestart(t, f, configPathAutoRemoval, linesPerLoop, false)
 	}
-	checkData(t, start, loopCount * linesPerLoop * 2)
+	checkData(t, start, loopCount*linesPerLoop*2)
 }
 
 // TestRotatingLogsDoesNotSkipLines validates https://github.com/aws/amazon-cloudwatch-agent/issues/447
@@ -267,4 +266,3 @@ func writeLogLines(t *testing.T, f *os.File, iterations int) {
 		time.Sleep(1 * time.Millisecond)
 	}
 }
-

--- a/test/cloudwatchlogs/publish_logs_test.go
+++ b/test/cloudwatchlogs/publish_logs_test.go
@@ -131,6 +131,7 @@ func TestAutoRemovalStopAgent(t *testing.T) {
 	common.StartAgent(configPath, true, false)
 	time.Sleep(agentRuntime)
 	writeLogs(t, f, 1000)
+	time.Sleep(agentRuntime)
 	common.StopAgent()
 	time.Sleep(agentRuntime)
 	assert.FileExists(t, fpath, "file does not exist, {}", fpath)

--- a/test/cloudwatchlogs/publish_logs_test.go
+++ b/test/cloudwatchlogs/publish_logs_test.go
@@ -120,7 +120,6 @@ func TestAutoRemovalStopAgent(t *testing.T) {
 	// Use instance id so 2 tests in parallel on different machines do not conflict.
 	instanceId := awsservice.GetInstanceId()
 	defer awsservice.DeleteLogGroupAndStream(instanceId, instanceId)
-	configPath := "resources/config_auto_removal.json"
 	fpath := logFilePath + "1"
 	f, err := os.Create(fpath)
 	if err != nil {
@@ -128,15 +127,18 @@ func TestAutoRemovalStopAgent(t *testing.T) {
 	}
 	defer f.Close()
 	defer os.Remove(fpath)
+	configPath := "resources/config_auto_removal.json"
 	common.StartAgent(configPath, true, false)
-	time.Sleep(agentRuntime)
+	// Sleep 20 seconds before and after writing the file to ensure the agent reads it.
+	sleepTime := time.Second*20
+	time.Sleep(sleepTime)
 	writeLogs(t, f, 1000)
-	time.Sleep(agentRuntime)
+	time.Sleep(sleepTime)
 	common.StopAgent()
-	time.Sleep(agentRuntime)
+	time.Sleep(sleepTime)
 	assert.FileExists(t, fpath, "file does not exist, {}", fpath)
 	common.StartAgent(configPath, true, false)
-	time.Sleep(agentRuntime)
+	time.Sleep(sleepTime)
 	assert.FileExists(t, fpath, "file does not exist, {}", fpath)
 }
 

--- a/test/cloudwatchlogs/resources/config_auto_removal.json
+++ b/test/cloudwatchlogs/resources/config_auto_removal.json
@@ -7,7 +7,7 @@
       "files": {
         "collect_list": [
           {
-            "file_path": "/tmp/test.log*",
+            "file_path": "/tmp/cwagent_log_test.log*",
             "log_group_name": "{instance_id}",
             "log_stream_name": "{instance_id}",
             "timezone": "UTC",

--- a/test/cloudwatchlogs/resources/config_auto_removal.json
+++ b/test/cloudwatchlogs/resources/config_auto_removal.json
@@ -1,0 +1,20 @@
+{
+  "agent": {
+    "debug": true
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/tmp/test.log*",
+            "log_group_name": "{instance_id}",
+            "log_stream_name": "{instance_id}",
+            "timezone": "UTC",
+            "auto_removal": true
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/cloudwatchlogs/resources/config_log.json
+++ b/test/cloudwatchlogs/resources/config_log.json
@@ -8,7 +8,7 @@
       "files": {
         "collect_list": [
           {
-            "file_path": "/tmp/test.log",
+            "file_path": "/tmp/cwagent_log_test.log",
             "log_group_name": "{instance_id}",
             "log_stream_name": "{instance_id}",
             "timezone": "UTC"

--- a/test/cloudwatchlogs/resources/config_log_filter.json
+++ b/test/cloudwatchlogs/resources/config_log_filter.json
@@ -8,7 +8,7 @@
       "files": {
         "collect_list": [
           {
-            "file_path": "/tmp/test.log",
+            "file_path": "/tmp/cwagent_log_test.log",
             "log_group_name": "{instance_id}",
             "log_stream_name": "{instance_id}",
             "timezone": "UTC",


### PR DESCRIPTION
# Description of the issue
A customer had concerns over the behavior of the agent's auto_removal feature.
They reported the agent was deleting their file BEFORE they created a 2nd file matching the pattern.
This test just verifies the agent DOES NOT delete the monitored file, even if it is restarted after reading to the EOF.

And I added another test case that verifies the agent DOES DELETE prev_file when new_file matching the pattern is found.

# Description of changes
Adds a new test case.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- SSH'd into an EC2 instance and run the test from shell:
```
[ec2-user@ip-172-31-18-102 ~]$ cd go/src/github.com/aws/amazon-cloudwatch-agent-test/
[ec2-user@ip-172-31-18-102 amazon-cloudwatch-agent-test]$ go test -v -p=1 -count=1  ./test/cloudwatchlogs/... -computeType=EC2 -run TestAutoRemovalFileRotation
=== RUN   TestAutoRemovalFileRotation
2023/09/15 19:06:36 Testing all EC2 plugins
2023/09/15 19:06:36 Testing all EC2 plugins
2023/09/15 19:06:36 Starting agent with command sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:resources/config_auto_removal.json
2023/09/15 19:06:37 Agent has started
2023/09/15 19:06:57 Writing 2000 lines to /tmp/cwagent_log_test.log0
2023/09/15 19:07:39 Writing 2000 lines to /tmp/cwagent_log_test.log1
2023/09/15 19:08:20 Writing 2000 lines to /tmp/cwagent_log_test.log2
2023/09/15 19:09:01 Writing 2000 lines to /tmp/cwagent_log_test.log3
2023/09/15 19:09:42 Writing 2000 lines to /tmp/cwagent_log_test.log4
2023/09/15 19:11:03 Checking i-0fc7939c1328a611e/i-0fc7939c1328a611e
2023/09/15 19:11:04 Done paginating log events for i-0fc7939c1328a611e/i-0fc7939c1328a611e and found 10000 logs
--- PASS: TestAutoRemovalFileRotation (268.16s)
PASS
ok  	github.com/aws/amazon-cloudwatch-agent-test/test/cloudwatchlogs	268.162s
```

And

```
[ec2-user@ip-172-31-18-102 amazon-cloudwatch-agent-test]$ go test -v -p=1 -count=1  ./test/cloudwatchlogs/... -computeType=EC2 -run TestAutoRemovalStopAgent
=== RUN   TestAutoRemovalStopAgent
2023/09/15 19:13:50 Testing all EC2 plugins
2023/09/15 19:13:50 Testing all EC2 plugins
2023/09/15 19:13:50 Starting agent with command sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:resources/config_auto_removal.json
2023/09/15 19:13:52 Agent has started
2023/09/15 19:14:12 Writing 2000 lines to /tmp/cwagent_log_test.log1
2023/09/15 19:14:33 Agent is stopped
2023/09/15 19:14:33 Testing all EC2 plugins
2023/09/15 19:14:33 Testing all EC2 plugins
2023/09/15 19:14:33 Starting agent with command sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:resources/config_auto_removal.json
2023/09/15 19:14:34 Agent has started
2023/09/15 19:14:54 Writing 2000 lines to /tmp/cwagent_log_test.log1
2023/09/15 19:15:16 Agent is stopped
2023/09/15 19:15:16 Testing all EC2 plugins
2023/09/15 19:15:16 Testing all EC2 plugins
2023/09/15 19:15:16 Starting agent with command sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:resources/config_auto_removal.json
2023/09/15 19:15:17 Agent has started
2023/09/15 19:15:37 Writing 2000 lines to /tmp/cwagent_log_test.log1
2023/09/15 19:15:58 Agent is stopped
2023/09/15 19:15:58 Testing all EC2 plugins
2023/09/15 19:15:58 Testing all EC2 plugins
2023/09/15 19:15:58 Starting agent with command sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:resources/config_auto_removal.json
2023/09/15 19:16:00 Agent has started
2023/09/15 19:16:20 Writing 2000 lines to /tmp/cwagent_log_test.log1
2023/09/15 19:16:41 Agent is stopped
2023/09/15 19:16:41 Testing all EC2 plugins
2023/09/15 19:16:41 Testing all EC2 plugins
2023/09/15 19:16:41 Starting agent with command sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:resources/config_auto_removal.json
2023/09/15 19:16:42 Agent has started
2023/09/15 19:17:02 Writing 2000 lines to /tmp/cwagent_log_test.log1
2023/09/15 19:17:24 Agent is stopped
2023/09/15 19:18:24 Checking i-0fc7939c1328a611e/i-0fc7939c1328a611e
2023/09/15 19:18:24 Done paginating log events for i-0fc7939c1328a611e/i-0fc7939c1328a611e and found 10000 logs
--- PASS: TestAutoRemovalStopAgent (274.21s)
PASS
```