### PR TITLE
Adding Logs Only Windows Test

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -112,6 +112,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 		{testDir: "../../../test/feature/windows"},
 		{testDir: "../../../test/restart"},
 		{testDir: "../../../test/acceptance"},
+		{testDir: "../../../test/feature/windows/event_logs"},
 		// assume role test doesn't add much value, and it already being tested with linux
 		//{testDir: "../../../test/assume_role"},
 	},

--- a/test/feature/windows/event_logs/agent_config.json
+++ b/test/feature/windows/event_logs/agent_config.json
@@ -1,0 +1,61 @@
+{
+    "agent": {
+        "debug": true
+    },
+    "logs": {
+      "logs_collected": {
+          "windows_events": {
+            "collect_list": [
+              {
+                "event_name": "Security",
+                "event_levels": [
+                  "INFORMATION",
+                  "WARNING",
+                  "ERROR",
+                  "CRITICAL",
+                  "VERBOSE"
+                ],
+                "log_group_name": "{instance_id}",
+                "log_stream_name": "SecurityEvent"
+              },
+              {
+                "event_name": "System",
+                "event_levels": [
+                  "INFORMATION",
+                  "WARNING",
+                  "ERROR",
+                  "CRITICAL",
+                  "VERBOSE"
+                ],
+                "log_group_name": "{instance_id}",
+                "log_stream_name": "System"
+              },
+              {
+                "event_name": "Application",
+                "event_levels": [
+                  "INFORMATION",
+                  "WARNING",
+                  "ERROR",
+                  "CRITICAL",
+                  "VERBOSE"
+                ],
+                "log_group_name": "{instance_id}",
+                "log_stream_name": "Application"
+              }
+            ]
+          },
+        
+          "files": {
+            "collect_list": [
+              {
+                "file_path": "C:/Users/Administrator/AppData/Local/Temp/test1.log",
+                "log_group_name": "{instance_id}",
+                "log_stream_name": "test1.log",
+                "timezone": "UTC"
+              }
+            ]
+          }
+      },
+      "force_flush_interval": 5
+    }
+}

--- a/test/feature/windows/event_logs/parameters.yml
+++ b/test/feature/windows/event_logs/parameters.yml
@@ -1,0 +1,74 @@
+# Receivers that agent needs to tests
+receivers: []
+
+#Test case name
+test_case: "win_feature_event_log"
+validate_type: "feature"
+# Only support metrics/traces/logs, even in this case we validate more than logs,
+# we only make this data_type as a placeholder
+data_type: "logs"
+
+# Number of logs being written
+number_monitored_logs: 1
+# Number of metrics to be sent or number of log lines being written  each minute
+values_per_minute: "2"
+# Number of seconds the agent should run and collect the metrics. In this case, 1 minutes
+agent_collection_period: 60 
+
+cloudwatch_agent_config: "<cloudwatch_agent_config>"
+
+# Logs that the test needs to validate; moreover, the feature validation already has
+# InstanceID as a log group; therefore, does not need to pass it
+# https://github.com/aws/amazon-cloudwatch-agent-test/blob/96f576e865b55de5e2aa88e4cf80b79c4d3dad70/validator/validators/feature/feature_validator.go#L108-L111
+# Moreover, the logs are being generated at with the generator 
+# https://github.com/aws/amazon-cloudwatch-agent-test/blob/96f576e865b55de5e2aa88e4cf80b79c4d3dad70/internal/common/logs.go#L41-L64
+# and being generated with 2 logs line per minute
+# https://github.com/aws/amazon-cloudwatch-agent-test/blob/96f576e865b55de5e2aa88e4cf80b79c4d3dad70/test/feature/mac/parameters.yml#L14
+# and the collection period is 60. If X minutes, the logs line would be X * log lines
+
+log_validation:
+  - log_value: "Microsoft-Windows-Security-Auditing"
+    log_lines: 1
+    log_stream: "SecurityEvent"
+  - log_value: "Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'"
+    log_lines: 1
+    log_stream: "SecurityEvent"
+  - log_value: "This is a log line."
+    log_lines: 2
+    log_stream: "test1.log"
+  - log_value: "# 0 - This is a log line."
+    log_lines: 1
+    log_stream: "test1.log"
+  - log_value: "# 1 - This is a log line."
+    log_lines: 1
+    log_stream: "test1.log"
+  - log_value: "System information log"
+    log_level: "Information"
+    log_lines: 1
+    log_stream: "System"
+    log_source: "WindowsEvents"
+  - log_value: "System warning log"
+    log_level: "Warning"
+    log_lines: 1
+    log_stream: "System"
+    log_source: "WindowsEvents"
+  - log_value: "System error log"
+    log_level: "Error"
+    log_lines: 1
+    log_stream: "System"
+    log_source: "WindowsEvents"
+  - log_value: "Application information log"
+    log_level: "Information"
+    log_lines: 1
+    log_stream: "Application"
+    log_source: "WindowsEvents"
+  - log_value: "Application warning log"
+    log_level: "Warning"
+    log_lines: 1
+    log_stream: "Application"
+    log_source: "WindowsEvents"
+  - log_value: "Application error log"
+    log_level: "Error"
+    log_lines: 1
+    log_stream: "Application"
+    log_source: "WindowsEvents"


### PR DESCRIPTION
# Description of the issue
Currently when we have only logs in windows we get duplicate logs. This test handles that case and catches it.

# Description of changes
This test creates a terraform instance and runs CWA with only log then check for duplicate logs. 
> [!NOTE]
> This test right now currently fails, which is intentional since the fix for this case has not been merged yet.
Succesfuly run:
# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the test and checked logs
[Successful  run](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/6202303125/job/16841325802)