### PR TITLE
Add E2E test for APM on EC2

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -98,6 +98,12 @@ var testTypeToTestConfig = map[string][]testConfig{
 			terraformDir: "terraform/ec2/creds",
 			targets:      map[string]map[string]struct{}{"os": {"al2": {}}},
 		},
+		{
+			testDir:      "./test/apm_ec2",
+			terraformDir: "terraform/ec2/apm",
+			// we need an image including java sdk
+			targets: map[string]map[string]struct{}{"os": {"ubuntu-22.04": {}}},
+		},
 	},
 	/*
 		You can only place 1 mac instance on a dedicate host a single time.

--- a/terraform/ec2/apm/main.tf
+++ b/terraform/ec2/apm/main.tf
@@ -1,0 +1,108 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "common" {
+  source = "../../common"
+}
+
+module "basic_components" {
+  source = "../../basic_components"
+
+  region = var.region
+}
+
+#####################################################################
+# Generate EC2 Key Pair for log in access to EC2
+#####################################################################
+
+resource "tls_private_key" "ssh_key" {
+  count     = var.ssh_key_name == "" ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "aws_key_pair" "aws_ssh_key" {
+  count      = var.ssh_key_name == "" ? 1 : 0
+  key_name   = "ec2-key-pair-${module.common.testing_id}"
+  public_key = tls_private_key.ssh_key[0].public_key_openssh
+}
+
+locals {
+  ssh_key_name        = var.ssh_key_name != "" ? var.ssh_key_name : aws_key_pair.aws_ssh_key[0].key_name
+  private_key_content = var.ssh_key_name != "" ? var.ssh_key_value : tls_private_key.ssh_key[0].private_key_pem
+}
+
+#####################################################################
+# Generate EC2 Instance and execute test commands
+#####################################################################
+resource "aws_instance" "cwagent" {
+  ami                                  = data.aws_ami.latest.id
+  instance_type                        = var.ec2_instance_type
+  key_name                             = local.ssh_key_name
+  iam_instance_profile                 = module.basic_components.instance_profile
+  vpc_security_group_ids               = [module.basic_components.security_group]
+  associate_public_ip_address          = true
+  instance_initiated_shutdown_behavior = "terminate"
+
+  tags = {
+    Name = "apm-ec2-${module.common.testing_id}"
+  }
+}
+
+data "aws_ami" "latest" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = [var.ami]
+  }
+}
+
+resource "null_resource" "pulse_e2e_install_cwa" {
+  connection {
+    type        = "ssh"
+    user        = var.user
+    private_key = local.private_key_content
+    host        = aws_instance.cwagent.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo sha ${var.cwa_github_sha}",
+      "sudo cloud-init status --wait",
+      "echo clone and install agent",
+      "git clone --branch ${var.github_test_repo_branch} ${var.github_test_repo}",
+      "cd amazon-cloudwatch-agent-test",
+      "aws s3 cp s3://apm-private-beta/amd64/amazon-cloudwatch-agent.deb ./", # replace with the newly built package
+      "aws s3 cp s3://apm-private-beta/amd64/amazon-cloudwatch-agent.rpm ./", # replace with the newly built package
+      # "aws s3 cp s3://${local.binary_uri} .",
+      "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
+      var.install_agent,
+    ]
+  }
+
+  depends_on = [aws_instance.cwagent]
+}
+
+resource "null_resource" "pulse_e2e_run_test" {
+  connection {
+    type        = "ssh"
+    user        = var.user
+    private_key = local.private_key_content
+    host        = aws_instance.cwagent.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "aws s3 cp s3://apm-beta-pre-release-test/e2e/aws-apm-0.3.0.jar ./",
+      "aws s3 cp s3://apm-beta-pre-release-test/e2e/spring-petclinic-api-gateway-2.6.7.jar ./",
+      "export AWS_REGION=${var.region}",
+      "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
+      "echo run pulse e2e test",
+      "cd ~/amazon-cloudwatch-agent-test",
+      "go test ${var.test_dir} -test.id=${module.common.testing_id} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -v"
+    ]
+  }
+
+  depends_on = [null_resource.pulse_e2e_install_cwa]
+}

--- a/terraform/ec2/apm/output.tf
+++ b/terraform/ec2/apm/output.tf
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+output "private_key_content" {
+  value = local.private_key_content
+  sensitive = true
+}
+
+output "cwagent_public_ip" {
+  value = aws_instance.cwagent.public_ip
+}
+
+output "cwagent_id" {
+  value = aws_instance.cwagent.id
+}

--- a/terraform/ec2/apm/providers.tf
+++ b/terraform/ec2/apm/providers.tf
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+provider "aws" {
+  region = var.region
+}

--- a/terraform/ec2/apm/variables.tf
+++ b/terraform/ec2/apm/variables.tf
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "ec2_instance_type" {
+  type    = string
+  default = "t2.micro"
+}
+
+variable "ssh_key_name" {
+  type    = string
+  default = ""
+}
+
+variable "user" {
+  type    = string
+  default = ""
+}
+
+variable "ami" {
+  type    = string
+  default = "cloudwatch-agent-integration-test-ubuntu*"
+}
+
+variable "ssh_key_value" {
+  type    = string
+  default = ""
+}
+
+variable "install_agent" {
+  description = "go run ./install/install_agent.go deb or go run ./install/install_agent.go rpm"
+  type        = string
+  default     = "go run ./install/install_agent.go rpm"
+}
+
+variable "test_name" {
+  type    = string
+  default = ""
+}
+
+variable "test_dir" {
+  type    = string
+  default = ""
+}
+
+variable "ca_cert_path" {
+  type    = string
+  default = ""
+}
+
+variable "arc" {
+  type    = string
+  default = "amd64"
+
+  validation {
+    condition     = contains(["amd64", "arm64"], var.arc)
+    error_message = "Valid values for arc are (amd64, arm64)."
+  }
+}
+
+variable "binary_name" {
+  type    = string
+  default = ""
+}
+
+variable "local_stack_host_name" {
+  type    = string
+  default = "localhost.localstack.cloud"
+}
+
+variable "excluded_tests" {
+  type    = string
+  default = ""
+}
+
+variable "s3_bucket" {
+  type    = string
+  default = ""
+}
+
+variable "cwa_github_sha" {
+  type    = string
+  default = ""
+}
+
+variable "github_test_repo" {
+  type    = string
+  default = "https://github.com/aws/amazon-cloudwatch-agent-test.git"
+}
+
+variable "github_test_repo_branch" {
+  type    = string
+  default = "main"
+}
+
+variable "is_canary" {
+  type    = bool
+  default = false
+}
+
+variable "plugin_tests" {
+  type    = string
+  default = ""
+}
+
+variable "agent_start" {
+  description = "default command should be for ec2 with linux"
+  type        = string
+  default     = "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c "
+}

--- a/test/apm_ec2/agent_configs/config.json
+++ b/test/apm_ec2/agent_configs/config.json
@@ -1,0 +1,19 @@
+{
+  "agent": {
+    "debug": true
+  },
+  "traces": {
+    "traces_collected": {
+      "apm": {
+        "enabled": true
+      }
+    }
+  },
+  "logs": {
+    "metrics_collected": {
+      "apm": {
+        "enabled": true
+      }
+    }
+  }
+}

--- a/test/apm_ec2/apm_test.go
+++ b/test/apm_ec2/apm_test.go
@@ -1,0 +1,147 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package apm_ec2
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
+)
+
+const testRetryCount = 3
+const namespace = "AWS/APM"
+
+var path, testId string
+
+func init() {
+	environment.RegisterEnvironmentMetaDataFlags()
+
+	flag.StringVar(&path, "path", "./resources/run_java_application.sh", "path to java script file.")
+	flag.StringVar(&testId, "test.id", "unknown", "testing id.")
+}
+
+type APMEC2TestRunner struct {
+	test_runner.BaseTestRunner
+}
+
+func (runner *APMEC2TestRunner) SetupAfterAgentRun() error {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return errors.New(fmt.Sprintf("file %s does not exist.", path))
+	}
+	if output, err := exec.Command("bash", "-c", "sudo chmod +x "+path).Output(); err != nil {
+		return errors.New(fmt.Sprintf("failed to execute chmod: %s.", string(output)))
+	}
+
+	cmd := exec.Command("bash", "-c", "./"+path)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "TESTING_ID="+testId)
+
+	if err := cmd.Start(); err != nil {
+		return errors.New(fmt.Sprintf("failed to start application: %v.", err))
+	}
+
+	defer func() {
+		// Using context cancel doesn't kill child process, kill process group instead.
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			log.Fatalf("failed to stop application: %v.", err)
+		} else {
+			log.Printf("stop application.")
+		}
+		cmd.Wait()
+	}()
+
+	success := false
+	for i := 1; i < 10; i++ {
+		if resp, err := http.Get("http://localhost:8080/api/gateway/owners/1"); err != nil {
+			log.Printf("failed to send out request: %v.", err)
+			time.Sleep(time.Duration(i*10) * time.Second)
+		} else if resp.StatusCode >= 500 {
+			log.Printf("returned failure response: %d", resp.StatusCode)
+			time.Sleep(10000)
+		} else {
+			success = true
+			log.Printf("successfully sent out the request.")
+		}
+	}
+
+	if !success {
+		return errors.New("failed to call the test service")
+	}
+
+	// Sleep 1 minute to let metrics and traces be exported.
+	time.Sleep(90 * time.Second)
+
+	return nil
+}
+
+func (runner *APMEC2TestRunner) Validate() status.TestGroupResult {
+	metricsToFetch := runner.GetMeasuredMetrics()
+	testResults := make([]status.TestResult, len(metricsToFetch))
+	instructions := metric.EC2ServerConsumerInstructions
+
+	for i, metricName := range metricsToFetch {
+		var testResult status.TestResult
+		for j := 0; j < testRetryCount; j++ {
+			log.Printf("validating metric - name: %s.", metricName)
+			testResult = metric.ValidateAPMMetric(runner.DimensionFactory, namespace, metricName, instructions)
+			if testResult.Status == status.SUCCESSFUL {
+				break
+			}
+			time.Sleep(15 * time.Second)
+		}
+		testResults[i] = testResult
+	}
+
+	return status.TestGroupResult{
+		Name:        runner.GetTestName(),
+		TestResults: testResults,
+	}
+}
+
+func (runner *APMEC2TestRunner) GetTestName() string {
+	return "APMTest/EC2"
+}
+
+func (runner *APMEC2TestRunner) GetAgentConfigFileName() string {
+	return "config.json"
+}
+
+func (runner *APMEC2TestRunner) GetMeasuredMetrics() []string {
+	return metric.APMMetricNames
+}
+
+func (runner *APMEC2TestRunner) GetAgentRunDuration() time.Duration {
+	return 3 * time.Minute
+}
+
+var _ test_runner.ITestRunner = (*APMEC2TestRunner)(nil)
+
+func TestHostedInAttributes(t *testing.T) {
+	env := environment.GetEnvironmentMetaData()
+	ec2TestRunner := &APMEC2TestRunner{test_runner.BaseTestRunner{
+		DimensionFactory: dimension.GetDimensionFactory(*env),
+	}}
+	testRunner := test_runner.TestRunner{TestRunner: ec2TestRunner}
+	result := testRunner.Run()
+	if result.GetStatus() != status.SUCCESSFUL {
+		t.Fatal("APM test on EC2 failed.")
+		result.Print()
+	}
+}

--- a/test/apm_ec2/resources/run_java_application.sh
+++ b/test/apm_ec2/resources/run_java_application.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+JAVA_TOOL_OPTIONS=" -javaagent:${HOME}/aws-apm-0.3.0.jar" \
+OTEL_METRICS_EXPORTER=none \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4315 \
+OTEL_TRACES_SAMPLER_ARG="1.0" \
+OTEL_RESOURCE_ATTRIBUTES=aws.hostedin.environment=alpha/pet-clinic,service.name=pet-clinic-frontend \
+java -Dspring.cloud.discovery.enabled=false -jar "${HOME}"/spring-petclinic-api-gateway-2.6.7.jar > /tmp/log 2>&1

--- a/test/metric/apm_util.go
+++ b/test/metric/apm_util.go
@@ -67,6 +67,21 @@ var (
 			Value: dimension.ExpectedDimensionValue{Value: aws.String("remote-target")},
 		},
 	}
+
+	EC2ServerConsumerInstructions = []dimension.Instruction{
+		{
+			Key:   "HostedIn.Environment",
+			Value: dimension.ExpectedDimensionValue{Value: aws.String("alpha/pet-clinic")},
+		},
+		{
+			Key:   "Service",
+			Value: dimension.ExpectedDimensionValue{Value: aws.String("pet-clinic-frontend")},
+		},
+		{
+			Key:   "Operation",
+			Value: dimension.ExpectedDimensionValue{Value: aws.String("GET /api/gateway/owners/{ownerId}")},
+		},
+	}
 )
 
 func ValidateAPMMetric(dimFactory dimension.Factory, namespace string, metricName string, instructions []dimension.Instruction) status.TestResult {


### PR DESCRIPTION
# Description of the issue
This PR adds E2E test for APM on EC2.

# Description of changes
In the test case, we
* install CloudWatch agent with APM enabled;
* start an application with ADOT auto-instrumentation java agent;
* send requests to the newly brought up application to generate traces and metrics;
* check CloudWatch to verify whether APM metrics are created.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested through running integration test: https://github.com/aws/private-amazon-cloudwatch-agent-staging/actions/runs/6330956859/job/17204689789
