### PR TITLE
Fix Format Of EKS EMF Assume Role

### DIFF
--- a/terraform/eks/daemon/emf/main.tf
+++ b/terraform/eks/daemon/emf/main.tf
@@ -65,19 +65,19 @@ resource "aws_iam_role" "node_role" {
   name = "cwagent-eks-Worker-Role-${module.common.testing_id}"
 
   assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
     {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Principal": {
-            "Service": "ec2.amazonaws.com"
-          },
-          "Action": "sts:AssumeRole"
-        }
-      ]
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
     }
-    POLICY
+  ]
+}
+POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "node_AmazonEKSWorkerNodePolicy" {


### PR DESCRIPTION
# Description of the issue
EKS emf test will not start for error 
```
│ Error: "assume_role_policy" contains an invalid JSON policy: leading space characters are not allowed
│ 
│   with aws_iam_role.node_role,
│   on main.tf line 67, in resource "aws_iam_role" "node_role":
│   67:   assume_role_policy = <<POLICY
│   68:     {
│   69:       "Version": "2012-10-17",
│   70:       "Statement": [
│   71:         {
│   72:           "Effect": "Allow",
│   73:           "Principal": {
│   74:             "Service": "ec2.amazonaws.com"
│   75:           },
│   76:           "Action": "sts:AssumeRole"
│   77:         }
│   78:       ]
│   79:     }
│   80:     POLICY
```

# Description of changes
Match the format given for other eks test assume role
```
  assume_role_policy = <<POLICY
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Service": "ec2.amazonaws.com"
      },
      "Action": "sts:AssumeRole"
    }
  ]
}
POLICY
}
```

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
None
