### PR TITLE
Add formatter

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Lint Terraform
         if: runner.os == 'Linux'
         run: cd terraform && make check-fmt
+      - name: Lint Go
+        if: runner.os == 'Linux'
+        run: make simple-lint
       - name: Compile tests
         run: |
           echo "Compile tests"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
 BASE_SPACE=$(shell pwd)
 BUILD_SPACE=$(BASE_SPACE)/build
 
+IMPORT_PATH=github.com/aws/amazon-cloudwatch-agent-test
+ALL_SRC := $(shell find . -name '*.go' -type f | sort)
 TOOLS_BIN_DIR := $(abspath ./build/tools)
+
+GOIMPORTS = $(TOOLS_BIN_DIR)/goimports
 LINTER = $(TOOLS_BIN_DIR)/golangci-lint
+IMPI = $(TOOLS_BIN_DIR)/impi
+ADDLICENSE = $(TOOLS_BIN_DIR)/addlicense
+
+GOIMPORTS_OPT?= -w -local $(IMPORT_PATH)
 
 WIN_BUILD = GOOS=windows GOARCH=amd64 go build -trimpath -o $(BUILD_SPACE)
 LINUX_AMD64_BUILD = CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o $(BUILD_SPACE)
@@ -22,13 +30,55 @@ LOADGEN_LINUX_ARM64_BUILD = $(LINUX_ARM64_BUILD)/linux/arm64
 LOADGEN_DARWIN_AMD64_BUILD = $(DARWIN_AMD64_BUILD)/darwin/amd64
 LOADGEN_DARWIN_ARM64_BUILD = $(DARWIN_ARM64_BUILD)/darwin/arm64
 
-install-tools:
+install-goimports:
+	GOBIN=$(TOOLS_BIN_DIR) go install golang.org/x/tools/cmd/goimports
+
+install-impi:
+	GOBIN=$(TOOLS_BIN_DIR) go install github.com/pavius/impi/cmd/impi@v0.0.3
+
+install-addlicense:
+	# Using 04bfe4e to get SPDX template changes that are not present in the most recent tag v1.0.0
+	# This is required to be able to easily omit the year in our license header.
+	GOBIN=$(TOOLS_BIN_DIR) go install github.com/google/addlicense@04bfe4e
+
+install-golang-lint:
 	#Install from source for golangci-lint is not recommended based on https://golangci-lint.run/usage/install/#install-from-source so using binary
 	#installation
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) v1.50.1
 
-lint: install-tools
+fmt: install-goimports addlicense
+	go fmt ./...
+	@echo $(ALL_SRC) | xargs -n 10 $(GOIMPORTS) $(GOIMPORTS_OPT)
+
+impi: install-impi
+	@echo $(ALL_SRC) | xargs -n 10 $(IMPI) --local $(IMPORT_PATH) --scheme stdThirdPartyLocal
+	@echo "Check import order/grouping finished"
+
+simple-lint: checklicense impi
+
+lint: install-golang-lint simple-lint
 	${LINTER} run ./...
+
+addlicense: install-addlicense
+	@ADDLICENSEOUT=`$(ADDLICENSE) -y="" -s=only -l="mit" -c="Amazon.com, Inc. or its affiliates. All Rights Reserved." $(ALL_SRC) 2>&1`; \
+    		if [ "$$ADDLICENSEOUT" ]; then \
+    			echo "$(ADDLICENSE) FAILED => add License errors:\n"; \
+    			echo "$$ADDLICENSEOUT\n"; \
+    			exit 1; \
+    		else \
+    			echo "Add License finished successfully"; \
+    		fi
+
+checklicense: install-addlicense
+	@ADDLICENSEOUT=`$(ADDLICENSE) -check $(ALL_SRC) 2>&1`; \
+    		if [ "$$ADDLICENSEOUT" ]; then \
+    			echo "$(ADDLICENSE) FAILED => add License errors:\n"; \
+    			echo "$$ADDLICENSEOUT\n"; \
+    			echo "Use 'make addlicense' to fix this."; \
+    			exit 1; \
+    		else \
+    			echo "Check License finished successfully"; \
+    		fi
 
 compile:
 	# this is a workaround to compile and cache all of the tests without actually running any of them

--- a/cmd/emf-generator/emf-generator.go
+++ b/cmd/emf-generator/emf-generator.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/log-generator/log-generator.go
+++ b/cmd/log-generator/log-generator.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/statsd-generator/statsd-generator.go
+++ b/cmd/statsd-generator/statsd-generator.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/filesystem/unix_permission.go
+++ b/filesystem/unix_permission.go
@@ -7,8 +7,9 @@ package filesystem
 
 import (
 	"fmt"
-	"golang.org/x/sys/unix"
 	"os/user"
+
+	"golang.org/x/sys/unix"
 )
 
 type FilePermission string

--- a/filesystem/windows_permission.go
+++ b/filesystem/windows_permission.go
@@ -7,9 +7,10 @@ package filesystem
 
 import (
 	"fmt"
-	"golang.org/x/sys/windows"
 	"os"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // CheckFileRights check that the given filename has access controls and system permission for Administrator, Local System

--- a/install/install_agent.go
+++ b/install/install_agent.go
@@ -11,16 +11,16 @@ import (
 )
 
 const (
-	retryNumber       = 10
-	retryTime         = 30 * time.Second
-	debInstall        = "deb"
-	rpmInstall        = "rpm"
+	retryNumber = 10
+	retryTime   = 30 * time.Second
+	debInstall  = "deb"
+	rpmInstall  = "rpm"
 )
 
 func main() {
 	installType := os.Args[1]
 	installCommand := ""
-	
+
 	debInstallCommand := "sudo dpkg -i -E ./amazon-cloudwatch-agent.deb"
 	rpmInstallCommand := "sudo rpm -U ./amazon-cloudwatch-agent.rpm"
 	if os.Geteuid() == 0 {

--- a/test/acceptance/filepermissions_test.go
+++ b/test/acceptance/filepermissions_test.go
@@ -6,14 +6,16 @@ package acceptance
 
 import (
 	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/filesystem"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
-	"github.com/stretchr/testify/assert"
-	"log"
-	"testing"
-	"time"
 )
 
 func init() {

--- a/test/acceptance/filepermissions_windows.go
+++ b/test/acceptance/filepermissions_windows.go
@@ -10,9 +10,10 @@ import (
 	"log"
 	"time"
 
+	"go.uber.org/multierr"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/filesystem"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
-	"go.uber.org/multierr"
 )
 
 const (

--- a/test/assume_role/assume_role_unix.go
+++ b/test/assume_role/assume_role_unix.go
@@ -8,14 +8,15 @@ package assume_role
 import (
 	"log"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 )
 
 const (

--- a/test/assume_role/assume_role_windows.go
+++ b/test/assume_role/assume_role_windows.go
@@ -10,12 +10,13 @@ import (
 	"log"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/filesystem"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 )
 
 const (

--- a/test/ca_bundle/ca_bundle_test.go
+++ b/test/ca_bundle/ca_bundle_test.go
@@ -8,15 +8,16 @@ package ca_bundle
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"log"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common"

--- a/test/canary/canary_test.go
+++ b/test/canary/canary_test.go
@@ -12,11 +12,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/stretchr/testify/require"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
-	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/test/cloudformation/cloudformation_test.go
+++ b/test/cloudformation/cloudformation_test.go
@@ -8,15 +8,17 @@ package cloudformation
 import (
 	"context"
 	"flag"
-	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
-	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"log"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 )
 
 const (

--- a/test/ecs/ecs_metadata/ecs_metadata_test.go
+++ b/test/ecs/ecs_metadata/ecs_metadata_test.go
@@ -7,12 +7,12 @@ import (
 	_ "embed"
 	"flag"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"log"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"

--- a/test/emf/emf_container_test.go
+++ b/test/emf/emf_container_test.go
@@ -1,15 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 //go:build !windows
 
 package emf
 
 import (
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
-	"time"
 )
 
 type EMFTestRunner struct {

--- a/test/emf/emf_test.go
+++ b/test/emf/emf_test.go
@@ -7,14 +7,16 @@ package emf
 
 import (
 	"fmt"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
-	"github.com/stretchr/testify/suite"
-	"log"
-	"testing"
 )
 
 type MetricBenchmarkTestSuite struct {

--- a/test/emf_concurrent/emf_concurrent_test.go
+++ b/test/emf_concurrent/emf_concurrent_test.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package emf_concurrent
 
 import (

--- a/test/emf_concurrent/emitter.go
+++ b/test/emf_concurrent/emitter.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package emf_concurrent
 
 import (

--- a/test/fips/fips_test.go
+++ b/test/fips/fips_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
-	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 const (

--- a/test/lvm/lvm_test.go
+++ b/test/lvm/lvm_test.go
@@ -9,13 +9,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
-	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 const namespace = "LVMTest"

--- a/test/metric/dimension/container_insights_provider.go
+++ b/test/metric/dimension/container_insights_provider.go
@@ -6,11 +6,13 @@
 package dimension
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
+	"log"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
-	"log"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 )
 
 type ContainerInsightsDimensionProvider struct {

--- a/test/metric/dimension/emf_ecs_dimension_provider.go
+++ b/test/metric/dimension/emf_ecs_dimension_provider.go
@@ -6,9 +6,10 @@
 package dimension
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
 )
 
 type EMFECSDimensionProvider struct {

--- a/test/metric/dimension/host_provider.go
+++ b/test/metric/dimension/host_provider.go
@@ -6,10 +6,12 @@
 package dimension
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
+	"os"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
-	"os"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
 )
 
 type HostDimensionProvider struct {

--- a/test/metric/dimension/imageid_provider.go
+++ b/test/metric/dimension/imageid_provider.go
@@ -6,10 +6,11 @@
 package dimension
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 )
 
 type LocalImageIdDimensionProvider struct {

--- a/test/metric/dimension/instanceid_provider.go
+++ b/test/metric/dimension/instanceid_provider.go
@@ -6,11 +6,13 @@
 package dimension
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
+	"log"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
-	"log"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 )
 
 type ECSInstanceIdDimensionProvider struct {

--- a/test/metric/dimension/instancetype_provider.go
+++ b/test/metric/dimension/instancetype_provider.go
@@ -6,10 +6,11 @@
 package dimension
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 )
 
 type LocalInstanceTypeDimensionProvider struct {

--- a/test/metric/dimension/provider.go
+++ b/test/metric/dimension/provider.go
@@ -8,8 +8,9 @@ package dimension
 import (
 	"log"
 
-	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 )
 
 type ExpectedDimensionValue struct {

--- a/test/metric/metric_validation_util.go
+++ b/test/metric/metric_validation_util.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package metric
 
 import "log"

--- a/test/metric/statsd_util.go
+++ b/test/metric/statsd_util.go
@@ -6,12 +6,14 @@
 package metric
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
-	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 )
 
 const (

--- a/test/metric_dimension/aggregation_dimensions_test.go
+++ b/test/metric_dimension/aggregation_dimensions_test.go
@@ -8,11 +8,12 @@ package metric_dimension
 import (
 	"log"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
-	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 type AggregationDimensionsTestRunner struct {

--- a/test/metric_dimension/drop_original_test.go
+++ b/test/metric_dimension/drop_original_test.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 //go:build !windows
 
 package metric_dimension

--- a/test/metric_dimension/global_append_dimensions_test.go
+++ b/test/metric_dimension/global_append_dimensions_test.go
@@ -6,12 +6,14 @@
 package metric_dimension
 
 import (
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"log"
 )
 
 type GlobalAppendDimensionsTestRunner struct {

--- a/test/metric_dimension/metrics_dimension_test.go
+++ b/test/metric_dimension/metrics_dimension_test.go
@@ -10,11 +10,12 @@ import (
 	"log"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
-	"github.com/stretchr/testify/suite"
 )
 
 type MetricsAppendDimensionTestSuite struct {

--- a/test/metric_value_benchmark/eks_deployment_prometheus_test.go
+++ b/test/metric_value_benchmark/eks_deployment_prometheus_test.go
@@ -6,9 +6,10 @@
 package metric_value_benchmark
 
 import (
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"log"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"

--- a/test/metric_value_benchmark/eks_resources/util.go
+++ b/test/metric_value_benchmark/eks_resources/util.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package eks_resources
 
 import _ "embed"

--- a/test/metric_value_benchmark/emf_test.go
+++ b/test/metric_value_benchmark/emf_test.go
@@ -10,13 +10,14 @@ import (
 	"log"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
-	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 type EMFTestRunner struct {

--- a/test/metric_value_benchmark/net_test.go
+++ b/test/metric_value_benchmark/net_test.go
@@ -6,13 +6,13 @@
 package metric_value_benchmark
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
 	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
 )
 
 type NetTestRunner struct {

--- a/test/metric_value_benchmark/statsd_test.go
+++ b/test/metric_value_benchmark/statsd_test.go
@@ -6,11 +6,12 @@
 package metric_value_benchmark
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 )

--- a/test/otlp/trace_test.go
+++ b/test/otlp/trace_test.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package otlp
 
 import (
@@ -5,11 +8,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common/traces/base"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common/traces/otlp"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 const (

--- a/test/proxy/proxy_unix_test.go
+++ b/test/proxy/proxy_unix_test.go
@@ -6,10 +6,11 @@
 package proxy
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent-test/environment"
-	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 )
 
 const commonConfigPath = "/opt/aws/amazon-cloudwatch-agent/etc/common-config.toml"

--- a/test/soak/soak_test.go
+++ b/test/soak/soak_test.go
@@ -9,10 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/amazon-cloudwatch-agent-test/environment"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
 	"github.com/shirou/gopsutil/v3/process"
 	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
 )
 
 func init() {

--- a/test/statsd/default_test.go
+++ b/test/statsd/default_test.go
@@ -6,11 +6,12 @@
 package statsd
 
 import (
+	"strings"
+	"time"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
-	"strings"
-	"time"
 )
 
 const testRetryCount = 3

--- a/test/statsd/statsd_test.go
+++ b/test/statsd/statsd_test.go
@@ -7,13 +7,13 @@ package statsd
 
 import (
 	"fmt"
-	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
 	"log"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"

--- a/test/test_runner/ecs_test_runner.go
+++ b/test/test_runner/ecs_test_runner.go
@@ -7,13 +7,13 @@ package test_runner
 
 import (
 	"fmt"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 	"log"
 	"os"
 	"time"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 )
 
 type IAgentRunStrategy interface {

--- a/test/test_runner/eks_test_runner.go
+++ b/test/test_runner/eks_test_runner.go
@@ -6,10 +6,11 @@
 package test_runner
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent-test/environment"
-	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"log"
 	"time"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 )
 
 type EKSTestRunner struct {

--- a/test/test_runner/test_suite.go
+++ b/test/test_runner/test_suite.go
@@ -7,6 +7,7 @@ package test_runner
 
 import (
 	"fmt"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 )
 

--- a/test/userdata/userdata_test.go
+++ b/test/userdata/userdata_test.go
@@ -8,9 +8,9 @@ import (
 	"log"
 	"testing"
 
-	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/aws-sdk-go-v2/aws"
 
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"

--- a/test/xray/trace_test.go
+++ b/test/xray/trace_test.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package xray
 
 import (
@@ -5,10 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common/traces/base"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common/traces/xray"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/util/awsservice/cloudformation.go
+++ b/util/awsservice/cloudformation.go
@@ -1,13 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package awsservice
 
 import (
 	"context"
+	"log"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/google/uuid"
-	"log"
-	"time"
 )
 
 const instanceIdKey = "InstanceId"

--- a/util/awsservice/constant.go
+++ b/util/awsservice/constant.go
@@ -5,11 +5,11 @@ package awsservice
 
 import (
 	"context"
-	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"

--- a/util/common/logs.go
+++ b/util/common/logs.go
@@ -14,8 +14,9 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/aws/amazon-cloudwatch-agent-test/validator/models"
 	"go.uber.org/multierr"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/validator/models"
 )
 
 const logLine = "# %d - This is a log line. \n"

--- a/util/common/traces/base/base.go
+++ b/util/common/traces/base/base.go
@@ -1,17 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package base
 
 import (
 	"context"
 	"encoding/json"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
+	"reflect"
+	"testing"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
-	"reflect"
-	"testing"
-	"time"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
 )
 
 const (

--- a/util/common/traces/generate.go
+++ b/util/common/traces/generate.go
@@ -1,10 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package traces
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common/traces/base"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common/traces/xray"
-	"time"
 )
 
 func StartTraceGeneration(receiver string, agentConfigPath string, agentRuntime time.Duration, traceSendingInterval time.Duration) error {

--- a/util/common/traces/otlp/generator.go
+++ b/util/common/traces/otlp/generator.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package otlp
 
 import (
@@ -5,7 +8,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/aws/amazon-cloudwatch-agent-test/util/common/traces/base"
 	"go.opentelemetry.io/contrib/propagators/aws/xray"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -15,6 +17,8 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/exp/maps"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/util/common/traces/base"
 )
 
 var generatorError = errors.New("Generator error")

--- a/util/common/traces/xray/generator.go
+++ b/util/common/traces/xray/generator.go
@@ -1,16 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package xray
 
 import (
 	"context"
 	"errors"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/common/traces/base"
-	"github.com/aws/aws-xray-sdk-go/strategy/sampling"
-	"github.com/aws/aws-xray-sdk-go/xray"
-	"github.com/aws/aws-xray-sdk-go/xraylog"
 	"log"
 	"os"
 	"path"
 	"time"
+
+	"github.com/aws/aws-xray-sdk-go/strategy/sampling"
+	"github.com/aws/aws-xray-sdk-go/xray"
+	"github.com/aws/aws-xray-sdk-go/xraylog"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/util/common/traces/base"
 )
 
 var generatorError = errors.New("Generator error")

--- a/validator/validators/performance/performance_validator.go
+++ b/validator/validators/performance/performance_validator.go
@@ -5,11 +5,11 @@ package performance
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"log"
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/cenkalti/backoff/v4"

--- a/validator/validators/util/common.go
+++ b/validator/validators/util/common.go
@@ -5,6 +5,7 @@ package util
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 )
 
@@ -17,4 +18,3 @@ func LogCloudWatchDimension(dims []types.Dimension) string {
 	}
 	return dimension
 }
-


### PR DESCRIPTION
# Description of the issue
Missing formatter and lint checks. Most files missing copyright license. We've done a good job of keeping formatting consistent. Should be easier to run and keep standardized.

# Description of changes
Adds `fmt` (`goimports`, `addlicense`) and `simple-lint` (`checklicense`, `impi`).

Ran `make fmt simple-lint`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
