### PR TITLE
Fix EKS EMF test inline policy

### DIFF
--- a/terraform/eks/daemon/emf/main.tf
+++ b/terraform/eks/daemon/emf/main.tf
@@ -65,19 +65,19 @@ resource "aws_iam_role" "node_role" {
   name = "cwagent-eks-Worker-Role-${module.common.testing_id}"
 
   assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
     {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Principal": {
-            "Service": "ec2.amazonaws.com"
-          },
-          "Action": "sts:AssumeRole"
-        }
-      ]
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
     }
-    POLICY
+  ]
+}
+POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "node_AmazonEKSWorkerNodePolicy" {


### PR DESCRIPTION
# Description of the issue
Leading space characters are not allowed for inline policies, which is causing this test to [fail before it runs](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/6618427034/job/18019771184#step:7:85).

Not sure why this is only starting to impact us now. The test [ran fine before](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/5904588679/job/16017599809#step:7:65) with `hashicorp/aws v5.13.0` and that [already had this rule](https://github.com/hashicorp/terraform-provider-aws/blob/v5.13.0/internal/verify/validate.go#L162).

# Description of changes
Removes the leading spaces and brings it inline with [other inline policies](https://github.com/search?q=repo%3Aaws%2Famazon-cloudwatch-agent-test%20%3C%3CPOLICY&type=code) we have (e.g. [eks/daemon/main.tf](https://github.com/aws/amazon-cloudwatch-agent-test/blob/757a5a75c6636cb65ac4f3b1c2c6179ea803f85b/terraform/eks/daemon/main.tf#L68))

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A
