### PR TITLE
Add Rocky Linux integration tests for CloudWatch Agent

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -153,5 +153,27 @@
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",
     "family": "linux"
+  },
+  {
+    "os": "rocky-linux-8",
+    "username": "rocky",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-rocky-linux-8*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
+  {
+    "os": "rocky-linux-9",
+    "username": "rocky",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-rocky-linux-9*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
   }
 ]


### PR DESCRIPTION
# Description of the issue
In order to increases adoptions for CloudWatch Agent, we want to validate CloudWatch Agent support for Rocky Linux 8 & 9 so we can expand the customer base to these OS users.

# Description of changes
Add Rocky Linux 8 & 9 integration tests to the Linux test suite. Created EC2 Image Pipeline for each OS so they can be automatically generated.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/6962001932
