### PR TITLE
Add ALMA Linux and AL2023 tests

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -59,7 +59,7 @@
     "username": "ec2-user",
     "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
-    "ami": "cloudwatch-agent-integration-test-al2023*",
+    "ami": "cloudwatch-agent-integration-test-x86-al2023*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
     "arc": "arm64",
     "binaryName": "amazon-cloudwatch-agent.rpm",

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -81,7 +81,7 @@
     "username": "ec2-user",
     "instanceType":"m7g.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
-    "ami": "cloudwatch-agent-integration-test-al2023*",
+    "ami": "cloudwatch-agent-integration-test-aarch64-al2023*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
     "arc": "arm64",
     "binaryName": "amazon-cloudwatch-agent.rpm",

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -175,5 +175,27 @@
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",
     "family": "linux"
+  },
+  {
+    "os": "alma-linux-8",
+    "username": "ec2-user",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-alma-linux-8*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
+  {
+    "os": "alma-linux-9",
+    "username": "ec2-user",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-alma-linux-9*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
   }
 ]

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -55,6 +55,17 @@
     "family": "linux"
   },
   {
+    "os": "al2",
+    "username": "ec2-user",
+    "instanceType":"m7g.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-arm64-al2*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "arm64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
+  {
     "os": "al2023",
     "username": "ec2-user",
     "instanceType":"t3a.medium",

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -61,7 +61,7 @@
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-x86-al2023*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
-    "arc": "arm64",
+    "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",
     "family": "linux"
   },

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -55,6 +55,28 @@
     "family": "linux"
   },
   {
+    "os": "al2023",
+    "username": "ec2-user",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-al2023*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
+  {
+    "os": "al2023",
+    "username": "ec2-user",
+    "instanceType":"m7g.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-al2023*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
+  {
     "os": "rhel7",
     "username": "ec2-user",
     "instanceType":"t3a.medium",

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -61,7 +61,7 @@
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-al2023*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
-    "arc": "amd64",
+    "arc": "arm64",
     "binaryName": "amazon-cloudwatch-agent.rpm",
     "family": "linux"
   },
@@ -72,7 +72,7 @@
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-al2023*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
-    "arc": "amd64",
+    "arc": "arm64",
     "binaryName": "amazon-cloudwatch-agent.rpm",
     "family": "linux"
   },


### PR DESCRIPTION
# Description of the issue
In order to increases adoptions for CloudWatch Agent, we want to validate CloudWatch Agent support for Alma Linux 8 & 9, AL2023 for both arm64 (Graviton instance) and x86 so we can expand the customer base to these OS users.

# Description of changes
- Add Alma Linux 8 x86
- Add Alma Linux 9 x86 
- Add AL2 arm64 (Graviton type instance)
- Add AL2023 x86 
- Add AL2023 arm64 (Graviton type instance)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Run integration tests and validated newly added OS tests all pass
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/7091951758/job/19302433042