### PR TITLE
Add Sanity Test To Darwin And Win

### DIFF
--- a/terraform/ec2/mac/main.tf
+++ b/terraform/ec2/mac/main.tf
@@ -130,6 +130,7 @@ resource "null_resource" "integration_test" {
       "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:${module.validator.instance_agent_config}",
       "./validator --validator-config=${module.validator.instance_validator_config} --preparation-mode=false",
       "cd ~/amazon-cloudwatch-agent-test",
+      "echo run sanity test && sudo go test ./test/sanity -p 1 -v",
       "sudo go test ./test/run_as_user -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -cwaCommitSha=${var.cwa_github_sha} -instanceId=${aws_instance.cwagent.id} -v",
     ]
   }

--- a/terraform/ec2/win/main.tf
+++ b/terraform/ec2/win/main.tf
@@ -230,6 +230,10 @@ resource "null_resource" "integration_test_run_validator" {
       "powershell.exe -Command \"Start-Sleep -s 60\"",
       "powershell.exe -Command \"Invoke-WebRequest -Uri http://localhost:9404 -UseBasicParsing\"",
       "set AWS_REGION=${var.region}",
+      "git clone --branch ${var.github_test_repo_branch} ${var.github_test_repo}",
+      "cd amazon-cloudwatch-agent-test",
+      "go test ./test/sanity -p 1 -v",
+      "cd ..",
       "validator.exe --validator-config=${module.validator.instance_validator_config} --preparation-mode=true",
       var.use_ssm ? "powershell \"& 'C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1' -a fetch-config -m ec2 -s -c ssm:${local.ssm_parameter_name}\"" : "powershell \"& 'C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1' -a fetch-config -m ec2 -s -c file:${module.validator.instance_agent_config}\"",
       "validator.exe --validator-config=${module.validator.instance_validator_config} --preparation-mode=false"


### PR DESCRIPTION
# Description of the issue
No sanity test for darwin and windows

# Description of changes
Add sanity check to darwin and windows run

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/7426148498

Darwin is missing ami it has nothing to do with this change. The command for darwin is the same as linux so this should be fine. The failing windows tests are for missing ami reasons. 
