### PR TITLE
Move Localstack To AL2023 ARM

### DIFF
--- a/localstack/docker-compose.yml
+++ b/localstack/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
     # @TODO use latest when this is fixed https://github.com/localstack/localstack/issues/5502
-    # Use 0.12.20 since this is last version that worked for now
-    image: localstack/localstack:0.12.20
+    # Use 0.13.0 since this is last version that worked for now
+    image: localstack/localstack:0.13.0
     network_mode: bridge
     ports:
       - "127.0.0.1:53:53"

--- a/terraform/ec2/localstack/main.tf
+++ b/terraform/ec2/localstack/main.tf
@@ -52,7 +52,7 @@ resource "aws_instance" "integration-test" {
     inline = [
       "cloud-init status --wait",
       "clone the agent and start the localstack",
-      "git clone ${var.github_test_repo}",
+      "git clone --branch ${var.github_test_repo_branch} ${var.github_test_repo}",
       "cd amazon-cloudwatch-agent-test",
       "git reset --hard ${var.cwa_test_github_sha}",
       "echo set up ssl pem for localstack, then start localstack",
@@ -67,7 +67,7 @@ resource "aws_instance" "integration-test" {
     ]
     connection {
       type        = "ssh"
-      user        = "ubuntu"
+      user        = "ec2-user"
       private_key = local.private_key_content
       host        = self.public_dns
     }
@@ -83,6 +83,6 @@ data "aws_ami" "latest" {
 
   filter {
     name   = "name"
-    values = ["cloudwatch-agent-integration-test-ubuntu*"]
+    values = ["cloudwatch-agent-integration-test-aarch64-al2023*"]
   }
 }

--- a/terraform/ec2/localstack/variables.tf
+++ b/terraform/ec2/localstack/variables.tf
@@ -3,7 +3,7 @@
 
 variable "ec2_instance_type" {
   type    = string
-  default = "t3a.medium"
+  default = "m6g.medium"
 }
 
 variable "ssh_key_name" {
@@ -39,4 +39,8 @@ variable "github_test_repo" {
 variable "s3_bucket" {
   type    = string
   default = ""
+}
+
+variable "github_test_repo_branch" {
+  default = "main"
 }


### PR DESCRIPTION
# Description of the issue
Localstack is on ubuntu
We only want to move a single ami to other partitions and localstack is required
Approve localstack for al2023 arm instance

# Description of changes
localstack uses al2023 arm64

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/7965568387/job/21745789788
