### PR TITLE
add macOS sonoma

### DIFF
--- a/generator/resources/ec2_mac_test_matrix.json
+++ b/generator/resources/ec2_mac_test_matrix.json
@@ -34,5 +34,17 @@
         "instanceType":"mac1.metal",
         "ami": "cloudwatch-agent-integration-test-mac-monterey-x86",
         "arc": "amd64"
+      },
+      {
+        "os": "macOS Sonoma Arm64",
+        "instanceType":"mac2.metal",
+        "ami": "cloudwatch-agent-integration-test-mac-sonoma-arm64",
+        "arc": "arm64"
+      },
+      {
+        "os": "macOS Sonoma Amd64",
+        "instanceType":"mac1.metal",
+        "ami": "cloudwatch-agent-integration-test-mac-sonoma-x86",
+        "arc": "amd64"
       }
 ]

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -81,11 +81,11 @@ resource "aws_ec2_host" "dedicated_host" {
   ## and upper bound for the newest version of Mac we support MacOS Ventura)
   for_each = {
     "Ventura_x86_64" : "mac1.metal"
-    "Sonoma_x86_64"  : "mac1.metal"
+    "Sonoma_x86_64" : "mac1.metal"
     "Big_Sur_x86_64" : "mac1.metal"
     "Ventura_arm64" : "mac2.metal"
     "Big_Sur_arm64" : "mac2.metal"
-    "Sonoma_arm64"  : "mac2.metal"
+    "Sonoma_arm64" : "mac2.metal"
   }
 
   ## Map 4x1 for avoid claimng resources

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -81,9 +81,11 @@ resource "aws_ec2_host" "dedicated_host" {
   ## and upper bound for the newest version of Mac we support MacOS Ventura)
   for_each = {
     "Ventura_x86_64" : "mac1.metal"
+    "Sonoma_x86_64"  : "mac1.metal"
     "Big_Sur_x86_64" : "mac1.metal"
     "Ventura_arm64" : "mac2.metal"
     "Big_Sur_arm64" : "mac2.metal"
+    "Sonoma_arm64"  : "mac2.metal"
   }
 
   ## Map 4x1 for avoid claimng resources


### PR DESCRIPTION
# Description of the issue
No testing support for macOS Sonoma arm64 and x86_64

# Description of changes
- Add testing support for macOS Sonoma arm64 and x86_64

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
## Manual testing
### x86_64
```
vtayyare@88665a54407b Downloads % ssh -i "test_macos.pem" ec2-user@ec2-52-89-104-182.us-west-2.compute.amazonaws.com
Last login: Tue Mar  5 20:54:28 2024 from 205.251.233.236

    ┌───┬──┐   __|  __|_  )
    │ ╷╭╯╷ │   _|  (     /
    │  └╮  │  ___|\___|___|
    │ ╰─┼╯ │  Amazon EC2
    └───┴──┘  macOS Sonoma 14.3

ec2-user@ip-172-31-40-218 ~ % sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status
{
  "status": "running",
  "starttime": "2024-03-05T20:55:34+0000",
  "configstatus": "configured",
  "version": "1.300033.0b462"
}
```

<img width="1618" alt="Screenshot 2024-03-05 at 3 58 46 PM" src="https://github.com/aws/amazon-cloudwatch-agent-test/assets/45324375/347649c2-71b6-4de0-989f-63d23982dc99">
<img width="1631" alt="Screenshot 2024-03-05 at 3 57 10 PM" src="https://github.com/aws/amazon-cloudwatch-agent-test/assets/45324375/18826070-e0f9-440d-a14f-a0a7637461b2">

### arm64
```
vtayyare@88665a54407b Downloads % ssh -i "test_macos.pem" ec2-user@ec2-52-10-210-245.us-west-2.compute.amazonaws.com
Last login: Tue Mar  5 22:39:01 2024 from 205.251.233.176

    ┌───┬──┐   __|  __|_  )
    │ ╷╭╯╷ │   _|  (     /
    │  └╮  │  ___|\___|___|
    │ ╰─┼╯ │  Amazon EC2
    └───┴──┘  macOS Sonoma 14.3

ec2-user@ip-172-31-41-93 ~ % sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status
{
  "status": "running",
  "starttime": "2024-03-05T22:45:24+0000",
  "configstatus": "configured",
  "version": "1.300033.0b462"
}
ec2-user@ip-172-31-41-93 ~ %
```


<img width="1653" alt="Screenshot 2024-03-05 at 5 47 23 PM" src="https://github.com/aws/amazon-cloudwatch-agent-test/assets/45324375/c51f0061-f89d-429f-a69e-d80ec28648e4">
<img width="1622" alt="Screenshot 2024-03-05 at 5 52 36 PM" src="https://github.com/aws/amazon-cloudwatch-agent-test/assets/45324375/178edb0e-3ed1-4bd2-9a75-636a20ebb249">




## Integration testing 
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/8162039788




