### PR TITLE
Added debian-12 to our integration test

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -44,6 +44,17 @@
     "family": "linux"
   },
   {
+    "os": "debian-12",
+    "username": "admin",
+    "instanceType": "c6g.large",
+    "installAgentCommand": "/snap/bin/go run ./install/install_agent.go deb",
+    "ami": "cloudwatch-agent-integration-test-debian-12-arm64*",
+    "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
+    "arc": "arm64",
+    "binaryName": "amazon-cloudwatch-agent.deb",
+    "family": "linux"
+  },
+  {
     "os": "al2",
     "username": "ec2-user",
     "instanceType":"t3a.medium",


### PR DESCRIPTION
# Description of the issue
We want to support newer version of debian for our customers. In order to support it we want to test it with our integration test.

# Description of changes
I have added debian-12 to our integration test by adding it to generator configs and making a custom image builder.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
I ran the linux integration test [here](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/8271534214)
