### PR TITLE
Add Hop Limit Test For EKS metric_value_benchmark Test

### DIFF
--- a/generator/resources/eks_daemon_test_matrix.json
+++ b/generator/resources/eks_daemon_test_matrix.json
@@ -1,12 +1,19 @@
 [
   {
-    "k8s_version": "1.24",
+    "k8sVersion": "1.24",
     "ami": "AL2_x86_64",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3.medium",
     "arc": "amd64"
   },
   {
-    "k8s_version": "1.24",
+    "k8sVersion": "1.24",
+    "ami": "AL2_x86_64",
+    "instanceType":"t3.medium",
+    "arc": "amd64",
+    "hopLimit": 1
+  },
+  {
+    "k8sVersion": "1.24",
     "ami": "AL2_ARM_64",
     "instanceType":"m6g.large",
     "arc": "arm64"

--- a/terraform/ecs_ec2/daemon/main.tf
+++ b/terraform/ecs_ec2/daemon/main.tf
@@ -39,7 +39,7 @@ resource "aws_launch_configuration" "cluster" {
   metadata_options {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
-    http_put_response_hop_limit = 2
+    http_put_response_hop_limit = var.hop_limit
   }
 }
 

--- a/terraform/ecs_ec2/daemon/variables.tf
+++ b/terraform/ecs_ec2/daemon/variables.tf
@@ -32,3 +32,8 @@ variable "metadataEnabled" {
   type    = string
   default = "enabled"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}

--- a/terraform/eks/daemon/app_signals/variables.tf
+++ b/terraform/eks/daemon/app_signals/variables.tf
@@ -35,3 +35,8 @@ variable "instance_type" {
   type    = string
   default = "t3a.medium"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}

--- a/terraform/eks/daemon/emf/variables.tf
+++ b/terraform/eks/daemon/emf/variables.tf
@@ -35,3 +35,8 @@ variable "instance_type" {
   type    = string
   default = "t3a.medium"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}

--- a/terraform/eks/daemon/fluent/bit/variables.tf
+++ b/terraform/eks/daemon/fluent/bit/variables.tf
@@ -35,3 +35,8 @@ variable "instance_type" {
   type    = string
   default = "t3a.medium"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}

--- a/terraform/eks/daemon/fluent/common/variables.tf
+++ b/terraform/eks/daemon/fluent/common/variables.tf
@@ -36,3 +36,8 @@ variable "instance_type" {
   type    = string
   default = "t3a.medium"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}

--- a/terraform/eks/daemon/fluent/d/variables.tf
+++ b/terraform/eks/daemon/fluent/d/variables.tf
@@ -35,3 +35,8 @@ variable "instance_type" {
   type    = string
   default = "t3a.medium"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}

--- a/terraform/eks/daemon/fluent/windows/2019/variables.tf
+++ b/terraform/eks/daemon/fluent/windows/2019/variables.tf
@@ -45,3 +45,8 @@ variable "windows_os_version" {
   type    = string
   default = "2019"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}

--- a/terraform/eks/daemon/fluent/windows/2022/variables.tf
+++ b/terraform/eks/daemon/fluent/windows/2022/variables.tf
@@ -45,3 +45,8 @@ variable "windows_os_version" {
   type    = string
   default = "2022"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}

--- a/terraform/eks/daemon/fluent/windows/variables.tf
+++ b/terraform/eks/daemon/fluent/windows/variables.tf
@@ -45,3 +45,9 @@ variable "windows_os_version" {
   type    = string
   default = "2022"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}
+

--- a/terraform/eks/daemon/gpu/variables.tf
+++ b/terraform/eks/daemon/gpu/variables.tf
@@ -35,3 +35,8 @@ variable "instance_type" {
   type    = string
   default = "g4dn.xlarge"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}

--- a/terraform/eks/daemon/modify_hop_limit/modify_hop_limit.go
+++ b/terraform/eks/daemon/modify_hop_limit/modify_hop_limit.go
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+func main() {
+	args := os.Args
+	cluster := args[1]
+	hopLimit, err := strconv.Atoi(args[2])
+	if err != nil {
+		log.Fatalf("could not parse hop limit %s", args[2])
+	}
+	cxt := context.Background()
+	defaultConfig, err := config.LoadDefaultConfig(cxt)
+	if err != nil {
+		log.Fatal("could not create aws sdk v2 config")
+	}
+	ec2client := ec2.NewFromConfig(defaultConfig)
+	clusterNameFilter := types.Filter{Name: aws.String("tag:eks:cluster-name"), Values: []string{
+		cluster,
+	}}
+	instanceInput := ec2.DescribeInstancesInput{
+		Filters: []types.Filter{
+			clusterNameFilter,
+			{Name: aws.String("instance-state-name"),
+				Values: []string{"running"}}}}
+	instanceOutput, err := ec2client.DescribeInstances(cxt, &instanceInput)
+	if err != nil {
+		log.Fatalf("could not get instances for input %v %v", instanceInput, err)
+	}
+	for _, reservation := range instanceOutput.Reservations {
+		for _, instance := range reservation.Instances {
+			modifyInstanceMetadataOptionsInput := ec2.ModifyInstanceMetadataOptionsInput{
+				InstanceId:              instance.InstanceId,
+				HttpPutResponseHopLimit: aws.Int32(int32(hopLimit)),
+			}
+			_, err := ec2client.ModifyInstanceMetadataOptions(cxt, &modifyInstanceMetadataOptionsInput)
+			if err != nil {
+				log.Fatalf("could not modify hop limit for instance %v %v", *instance.InstanceId, err)
+			}
+		}
+	}
+}

--- a/terraform/eks/daemon/statsd/variables.tf
+++ b/terraform/eks/daemon/statsd/variables.tf
@@ -35,3 +35,8 @@ variable "instance_type" {
   type    = string
   default = "t3a.medium"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}

--- a/terraform/eks/daemon/variables.tf
+++ b/terraform/eks/daemon/variables.tf
@@ -35,3 +35,8 @@ variable "instance_type" {
   type    = string
   default = "t3a.medium"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}

--- a/terraform/eks/daemon/windows/2019/variables.tf
+++ b/terraform/eks/daemon/windows/2019/variables.tf
@@ -45,3 +45,8 @@ variable "windows_os_version" {
   type    = string
   default = "2019"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}

--- a/terraform/eks/daemon/windows/2022/variables.tf
+++ b/terraform/eks/daemon/windows/2022/variables.tf
@@ -45,3 +45,8 @@ variable "windows_os_version" {
   type    = string
   default = "2022"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}

--- a/terraform/eks/daemon/windows/variables.tf
+++ b/terraform/eks/daemon/windows/variables.tf
@@ -45,3 +45,8 @@ variable "windows_os_version" {
   type    = string
   default = "2022"
 }
+
+variable "hop_limit" {
+  type    = number
+  default = 2
+}


### PR DESCRIPTION
# Description of the issue
There is no way to test what happens when hop limit is 1 for EKS

# Description of changes
Add hop limit 1 EKS test

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/8726746471/job/23943412898
