### PR TITLE
Changing data type of appsignals integ test

### DIFF
--- a/test/app_signals/resources/metrics/client_producer.json
+++ b/test/app_signals/resources/metrics/client_producer.json
@@ -34,8 +34,8 @@
           "metrics": [
             {
               "name": "Error",
-              "unit": "Milliseconds",
-              "sum": {
+              "unit": "",
+              "exponential_histogram": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -87,8 +87,8 @@
             },
             {
               "name": "Fault",
-              "unit": "Milliseconds",
-              "sum": {
+              "unit": "",
+              "exponential_histogram": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -141,7 +141,7 @@
             {
               "name": "Latency",
               "unit": "Milliseconds",
-              "sum": {
+              "exponential_histogram": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -197,3 +197,4 @@
     }
   ]
 }
+

--- a/test/app_signals/resources/metrics/server_consumer.json
+++ b/test/app_signals/resources/metrics/server_consumer.json
@@ -34,8 +34,8 @@
           "metrics": [
             {
               "name": "Error",
-              "unit": "Milliseconds",
-              "sum": {
+              "unit": "",
+              "exponential_histogram": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -93,8 +93,8 @@
             },
             {
               "name": "Fault",
-              "unit": "Milliseconds",
-              "sum": {
+              "unit": "",
+              "exponential_histogram": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -153,7 +153,7 @@
             {
               "name": "Latency",
               "unit": "Milliseconds",
-              "sum": {
+              "exponential_histogram": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -212,7 +212,7 @@
             {
               "name": "Latency",
               "unit": "Milliseconds",
-              "sum": {
+              "exponential_histogram": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -271,7 +271,7 @@
             {
               "name": "Latency",
               "unit": "Milliseconds",
-              "sum": {
+              "exponential_histogram": {
                 "dataPoints": [
                   {
                     "attributes": [
@@ -333,3 +333,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
# Description of the issue
Current server_consumer.json and client_producer.json generates invalid app signal metrics. The metrics Latency, Error, and Fault should be an object but instead the request sent to the agent generated the metrics to just be zero.

### Metrics are not objects
<img width="1728" alt="Screenshot 2024-04-09 at 3 13 50 PM" src="https://github.com/aws/amazon-cloudwatch-agent-test/assets/50599809/47d7dadb-7823-4a5d-8ce1-07d8b4fc35cf">




# Description of changes
It is a really small change, the data type of each metric is sum but instead it should be the type exponential_histogram. This is the correct type and it generates correct app signal metrics.

### Verifying correct metrics were generated
<img width="1728" alt="Screenshot 2024-04-09 at 3 11 54 PM" src="https://github.com/aws/amazon-cloudwatch-agent-test/assets/50599809/0ec6e157-d4e1-4e1a-aef7-8cdd7b4bde13">


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Sent json's to the agent and checked the console which had the correct format of the metrics.
