### PR TITLE
EKS Nvidia Test Use A GPU Instance Type

### DIFF
--- a/generator/resources/eks_daemon_test_matrix.json
+++ b/generator/resources/eks_daemon_test_matrix.json
@@ -2,7 +2,7 @@
   {
     "k8s_version": "1.24",
     "ami": "AL2_x86_64",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3.medium",
     "arc": "amd64"
   },
   {

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -41,6 +41,7 @@ type testConfig struct {
 	// e.g. statsd can have a multiple terraform module sets for difference test scenarios (ecs, eks or ec2)
 	testDir       string
 	terraformDir  string
+	instanceType  string
 	runMockServer bool
 	// define target matrix field as set(s)
 	// empty map means a testConfig will be created with a test entry for each entry from *_test_matrix.json
@@ -216,7 +217,8 @@ var testTypeToTestConfig = map[string][]testConfig{
 		{testDir: "./test/fluent", terraformDir: "terraform/eks/daemon/fluent/windows/2022"},
 		{
 			testDir: "./test/gpu", terraformDir: "terraform/eks/daemon/gpu",
-			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
+			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
+			instanceType: "g4dn.xlarge",
 		},
 	},
 	"eks_deployment": {
@@ -302,6 +304,10 @@ func genMatrix(testType string, testConfigs []testConfig, ami []string) []matrix
 			err = mapstructure.Decode(test, &row)
 			if err != nil {
 				log.Panicf("can't decode map test %v to metric line struct with error %v", testConfig, err)
+			}
+
+			if testConfig.instanceType != "" {
+				row.InstanceType = testConfig.instanceType
 			}
 
 			if len(ami) != 0 && !slices.Contains(ami, row.Ami) {

--- a/terraform/eks/daemon/gpu/main.tf
+++ b/terraform/eks/daemon/gpu/main.tf
@@ -47,10 +47,10 @@ resource "aws_eks_node_group" "this" {
     min_size     = 1
   }
 
-  ami_type       = "AL2_x86_64"
+  ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
   disk_size      = 20
-  instance_types = ["t3.medium"]
+  instance_types = [var.instance_type]
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,


### PR DESCRIPTION
# Description of the issue
EKS GPU test was not using a gpu instance type

# Description of changes
Use GPU instance type for EKS GPU test

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/8913045939/job/24478223654
