### PR TITLE
Fix panic when metrics not yet ready in a cluster

### DIFF
--- a/test/metric/container_insights_util.go
+++ b/test/metric/container_insights_util.go
@@ -58,6 +58,15 @@ func ValidateMetrics(env *environment.MetaData, metricFilter string, expectedDim
 		}
 		results = append(results, validateMetricsAvailability(dims, metrics, actual))
 		for _, m := range metrics {
+			// this is to prevent panic with rand.Intn when metrics are not yet ready in a cluster
+			if _, ok := actual[m]; !ok {
+				results = append(results, status.TestResult{
+					Name:   dims,
+					Status: status.FAILED,
+				})
+				log.Printf("ValidateMetrics failed with missing metric: %s", m)
+				continue
+			}
 			// pick a random dimension set to test metric data OR test all dimension sets which might be overkill
 			randIdx := rand.Intn(len(actual[m]))
 			results = append(results, validateMetricValue(m, actual[m][randIdx]))


### PR DESCRIPTION
# Description of the issue
Container Insights integration test fails with a panic when a cluster is not ready with target metrics

# Description of changes
- Add a precheck before calling `rand.Intn`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

