### PR TITLE
Disable application signals testing in favor of end-to-end tests

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -110,10 +110,6 @@ var testTypeToTestConfig = map[string][]testConfig{
 			terraformDir: "terraform/ec2/creds",
 			targets:      map[string]map[string]struct{}{"os": {"al2": {}}},
 		},
-		{
-			testDir: "./test/app_signals",
-			targets: map[string]map[string]struct{}{"os": {"al2": {}}, "arc": {"amd64": {}}},
-		},
 	},
 	/*
 		You can only place 1 mac instance on a dedicate host a single time.
@@ -211,9 +207,6 @@ var testTypeToTestConfig = map[string][]testConfig{
 			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
 		},
 		{testDir: "./test/fluent", terraformDir: "terraform/eks/daemon/fluent/bit"},
-		{testDir: "./test/app_signals", terraformDir: "terraform/eks/daemon/app_signals",
-			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
-		},
 		{testDir: "./test/fluent", terraformDir: "terraform/eks/daemon/fluent/windows/2022"},
 		{
 			testDir: "./test/gpu", terraformDir: "terraform/eks/daemon/gpu",


### PR DESCRIPTION
# Description of the issue
The tests covered in this test repo are also covered in the end-to-end tests: https://github.com/aws/amazon-cloudwatch-agent/blob/main/.github/workflows/application-signals-java-e2e-ec2-asg-test.yml

These tests are more robust, as they use the adot sdks to send elemetry to the agent. The tests in this repo are also stale as a result of the schema changes introduced in https://github.com/aws/amazon-cloudwatch-agent/commit/4193fa17b3759581753480cd378f0c6ef47043bb

# Description of changes
This PR disables testing for application signals. These tests are wasting resources to test features covered in the workflow linked above.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A
