### PR TITLE
Removing end-of-life OSes.

### DIFF
--- a/generator/resources/ec2_mac_test_matrix.json
+++ b/generator/resources/ec2_mac_test_matrix.json
@@ -1,17 +1,5 @@
 [
       {
-        "os": "macOS Big Sur Arm64",
-        "instanceType":"mac2.metal",
-        "ami": "cloudwatch-agent-integration-test-mac-bigsur-arm64",
-        "arc": "arm64"
-      },
-      {
-        "os": "macOS Big Sur Amd64",
-        "instanceType":"mac1.metal",
-        "ami": "cloudwatch-agent-integration-test-mac-bigsur-x86",
-        "arc": "amd64"
-      },
-      {
         "os": "macOS Ventura Arm64",
         "instanceType":"mac2.metal",
         "ami": "cloudwatch-agent-integration-test-mac-ventura-arm64",

--- a/generator/resources/ec2_windows_test_matrix.json
+++ b/generator/resources/ec2_windows_test_matrix.json
@@ -6,12 +6,6 @@
     "useSSM": false
   },
   {
-    "os": "win-2012",
-    "instanceType":"t3a.medium",
-    "ami": "cloudwatch-agent-integration-test-win-2012*",
-    "useSSM": false
-  },
-  {
     "os": "win-2016",
     "instanceType":"t3a.medium",
     "ami": "cloudwatch-agent-integration-test-win-2016*",

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -82,9 +82,7 @@ resource "aws_ec2_host" "dedicated_host" {
   for_each = {
     "Ventura_x86_64" : "mac1.metal"
     "Sonoma_x86_64" : "mac1.metal"
-    "Big_Sur_x86_64" : "mac1.metal"
     "Ventura_arm64" : "mac2.metal"
-    "Big_Sur_arm64" : "mac2.metal"
     "Sonoma_arm64" : "mac2.metal"
   }
 


### PR DESCRIPTION
# Description of the issue
We want to remove end-of-life OSes code as they're end-of-life.

# Description of changes
Removed references for end-of-life OSes in this package.

## Testing
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/9369085049
- EC2WinIntegrationTest for win-2012 and EC2DarwinIntegrationTest for macOS Big Sur are no longer present.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
