### PR TITLE
Update metrics_collection_interval for Kafka to 10 seconds

### DIFF
--- a/test/metric_value_benchmark/agent_configs/jmx_kafka_config.json
+++ b/test/metric_value_benchmark/agent_configs/jmx_kafka_config.json
@@ -1,6 +1,7 @@
 {
   "agent": {
-    "debug": true
+    "debug": true,
+    "metrics_collection_interval": 10
   },
   "metrics": {
     "namespace": "MetricValueBenchmarkJMXTest",


### PR DESCRIPTION
# Description of the issue
Currently the `metric_value_benchmark` test is failing due to the increase in Kafka metrics to 60 seconds. 

# Description of changes
Modified test agent config to include `"metrics_collection_interval": 10`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
It passed with 10 seconds interval in this integration test: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/9681807856/job/26713593403 
And it started failing when we update to 60 seconds seen in this integration test: 
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/9717891459/job/26825009743