### PR TITLE
Add logic to restart the windows event log service for the windows event log tests

### DIFF
--- a/util/common/logs.go
+++ b/util/common/logs.go
@@ -22,13 +22,13 @@ import (
 const logLine = "# %d - This is a log line. \n"
 
 func KillEventLogService() error {
-	eventLogPid, err := RunShellScript("gcim", "-ClassName Win32_Service -Filter \\\"name like 'EventLog' or displayname like 'EventLog'\\\"")
+	out, err := RunShellScript("gcim", "-ClassName Win32_Service -Filter \\\"name like 'EventLog' or displayname like 'EventLog'\\\"")
 	if err != nil {
-		log.Printf("Error getting Windows event log service PID: %v", err)
+		log.Printf("Error getting Windows event log service PID: %v; the output is %s", err, out)
 		return err
 	}
 
-	_, err = RunShellScript("Stop-Process " + string(eventLogPid) + " -Force")
+	_, err = RunShellScript("Stop-Process " + string(out) + " -Force")
 	if err != nil {
 		log.Printf("Error killing Windows event log service: %v", err)
 		return err
@@ -38,9 +38,9 @@ func KillEventLogService() error {
 }
 
 func StartEventLogService() error {
-	_, err := RunCommand("Start-Service EventLog")
+	out, err := RunCommand("Start-Service EventLog")
 	if err != nil {
-		log.Printf("Error starting Windows event log service: %v", err)
+		log.Printf("Error starting Windows event log service: %v; the output is %s", err, string(out))
 		return err
 	}
 

--- a/util/common/logs.go
+++ b/util/common/logs.go
@@ -22,13 +22,13 @@ import (
 const logLine = "# %d - This is a log line. \n"
 
 func KillEventLogService() error {
-	eventLogPid, err := exec.Command("powershell.exe", "-Command", "\"gcim -ClassName Win32_Service -Filter \\\"name like 'EventLog' or displayname like 'EventLog'\\\"").Output()
+	eventLogPid, err := RunShellScript("gcim",  "-ClassName Win32_Service -Filter \\\"name like 'EventLog' or displayname like 'EventLog'\\\"")
 	if err != nil {
 		log.Printf("Error getting Windows event log service PID: %v", err)
 		return err
 	}
 
-	_, err = exec.Command("powershell.exe", "-Command", "\"Stop-Process "+string(eventLogPid)+" -Force\"").Output()
+	_, err = RunShellScript("Stop-Process " + string(eventLogPid) + " -Force")
 	if err != nil {
 		log.Printf("Error killing Windows event log service: %v", err)
 		return err
@@ -38,7 +38,7 @@ func KillEventLogService() error {
 }
 
 func StartEventLogService() error {
-	_, err := exec.Command("powershell.exe", "-Command", "\"Start-Service EventLog\"").Output()
+	_, err := RunCommand("Start-Service EventLog"
 	if err != nil {
 		log.Printf("Error starting Windows event log service: %v", err)
 		return err

--- a/util/common/logs.go
+++ b/util/common/logs.go
@@ -21,28 +21,30 @@ import (
 
 const logLine = "# %d - This is a log line. \n"
 
+func GetEventLogServicePid() (string, error) {
+	out, err := RunShellScript("gcim -ClassName Win32_Service -Filter \"name like 'EventLog' or displayname like 'EventLog'\" | Select-Object -ExpandProperty 'ProcessId'")
+	return out, err
+}
+
 func KillEventLogService() error {
-	out, err := RunShellScript("gcim", "-ClassName Win32_Service -Filter \\\"name like 'EventLog' or displayname like 'EventLog'\\\"")
+	out, err := GetEventLogServicePid()
 	if err != nil {
 		log.Printf("Error getting Windows event log service PID: %v; the output is %s", err, out)
-		return err
 	}
-
-	_, err = RunShellScript("Stop-Process " + string(out) + " -Force")
-	if err != nil {
-		log.Printf("Error killing Windows event log service: %v", err)
-		return err
-	}
+	log.Printf("Windows EventLog Service PID: %s", out)
+	_, _ = RunShellScript("Stop-Process -Force " + out)
 
 	return nil
 }
 
 func StartEventLogService() error {
-	out, err := RunCommand("Start-Service EventLog")
+	out, err := RunShellScript("Start-Service EventLog")
 	if err != nil {
 		log.Printf("Error starting Windows event log service: %v; the output is %s", err, string(out))
 		return err
 	}
+	pid, _ := GetEventLogServicePid()
+	log.Printf("Windows EventLog Service PID: %s", pid)
 
 	return nil
 }

--- a/util/common/logs.go
+++ b/util/common/logs.go
@@ -22,7 +22,7 @@ import (
 const logLine = "# %d - This is a log line. \n"
 
 func KillEventLogService() error {
-	eventLogPid, err := exec.Command("powershell.exe", "-Command", "\"gcim -ClassName Win32_Service -Filter name like \\\"EventLog\\\" or displayname like \\\"EventLog\\\"\"").Output()
+	eventLogPid, err := exec.Command("powershell.exe", "-Command", "\"gcim -ClassName Win32_Service -Filter \\\"name like 'EventLog' or displayname like 'EventLog'\\\"").Output()
 	if err != nil {
 		log.Printf("Error getting Windows event log service PID: %v", err)
 		return err

--- a/util/common/logs.go
+++ b/util/common/logs.go
@@ -22,13 +22,13 @@ import (
 const logLine = "# %d - This is a log line. \n"
 
 func KillEventLogService() error {
-	eventLogPid, err := exec.Command("gcim", "-ClassName", "Win32_Service", "-Filter", "name like \"EventLog\" or displayname like \"EventLog\"").Output()
+	eventLogPid, err := exec.Command("powershell.exe", "-Command", "\"gcim -ClassName Win32_Service -Filter name like \\\"EventLog\\\" or displayname like \\\"EventLog\\\"\"").Output()
 	if err != nil {
 		log.Printf("Error getting Windows event log service PID: %v", err)
 		return err
 	}
 
-	_, err = exec.Command("Stop-Process", string(eventLogPid), "-Force").Output()
+	_, err = exec.Command("powershell.exe", "-Command", "\"Stop-Process "+string(eventLogPid)+" -Force\"").Output()
 	if err != nil {
 		log.Printf("Error killing Windows event log service: %v", err)
 		return err
@@ -38,7 +38,7 @@ func KillEventLogService() error {
 }
 
 func StartEventLogService() error {
-	_, err := exec.Command("Start-Service", "EventLog").Output()
+	_, err := exec.Command("powershell.exe", "-Command", "\"Start-Service EventLog\"").Output()
 	if err != nil {
 		log.Printf("Error starting Windows event log service: %v", err)
 		return err

--- a/util/common/logs.go
+++ b/util/common/logs.go
@@ -47,6 +47,15 @@ func StartEventLogService() error {
 	return nil
 }
 
+func ContainsWindowsEventLog(validationLog []models.LogValidation) bool {
+	for _, vLog := range validationLog {
+		if isWindowsEventLog(vLog) {
+			return true
+		}
+	}
+	return false
+}
+
 func GenerateLogs(configFilePath string, duration time.Duration, sendingInterval time.Duration, logLinesPerMinute int, validationLog []models.LogValidation) error {
 	var multiErr error
 	if err := StartLogWrite(configFilePath, duration, sendingInterval, logLinesPerMinute); err != nil {
@@ -61,7 +70,7 @@ func GenerateLogs(configFilePath string, duration time.Duration, sendingInterval
 func GenerateWindowsEvents(validationLog []models.LogValidation) error {
 	var multiErr error
 	for _, vLog := range validationLog {
-		if vLog.LogSource == "WindowsEvents" && vLog.LogLevel != "" {
+		if isWindowsEventLog(vLog) {
 			err := CreateWindowsEvent(vLog.LogStream, vLog.LogLevel, vLog.LogValue)
 			if err != nil {
 				multiErr = multierr.Append(multiErr, err)
@@ -102,6 +111,10 @@ func StartLogWrite(configFilePath string, duration time.Duration, sendingInterva
 	}
 
 	return multiErr
+}
+
+func isWindowsEventLog(vLog models.LogValidation) bool {
+	return vLog.LogSource == "WindowsEvents" && vLog.LogLevel != ""
 }
 
 // writeToLogs opens a file at the specified file path and writes the specified number of lines per second (tps)

--- a/util/common/logs.go
+++ b/util/common/logs.go
@@ -22,7 +22,7 @@ import (
 const logLine = "# %d - This is a log line. \n"
 
 func KillEventLogService() error {
-	eventLogPid, err := RunShellScript("gcim",  "-ClassName Win32_Service -Filter \\\"name like 'EventLog' or displayname like 'EventLog'\\\"")
+	eventLogPid, err := RunShellScript("gcim", "-ClassName Win32_Service -Filter \\\"name like 'EventLog' or displayname like 'EventLog'\\\"")
 	if err != nil {
 		log.Printf("Error getting Windows event log service PID: %v", err)
 		return err
@@ -38,7 +38,7 @@ func KillEventLogService() error {
 }
 
 func StartEventLogService() error {
-	_, err := RunCommand("Start-Service EventLog"
+	_, err := RunCommand("Start-Service EventLog")
 	if err != nil {
 		log.Printf("Error starting Windows event log service: %v", err)
 		return err

--- a/util/common/logs.go
+++ b/util/common/logs.go
@@ -21,6 +21,32 @@ import (
 
 const logLine = "# %d - This is a log line. \n"
 
+func KillEventLogService() error {
+	eventLogPid, err := exec.Command("gcim", "-ClassName", "Win32_Service", "-Filter", "name like \"EventLog\" or displayname like \"EventLog\"").Output()
+	if err != nil {
+		log.Printf("Error getting Windows event log service PID: %v", err)
+		return err
+	}
+
+	_, err = exec.Command("Stop-Process", string(eventLogPid), "-Force").Output()
+	if err != nil {
+		log.Printf("Error killing Windows event log service: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+func StartEventLogService() error {
+	_, err := exec.Command("Start-Service", "EventLog").Output()
+	if err != nil {
+		log.Printf("Error starting Windows event log service: %v", err)
+		return err
+	}
+
+	return nil
+}
+
 func GenerateLogs(configFilePath string, duration time.Duration, sendingInterval time.Duration, logLinesPerMinute int, validationLog []models.LogValidation) error {
 	var multiErr error
 	if err := StartLogWrite(configFilePath, duration, sendingInterval, logLinesPerMinute); err != nil {

--- a/util/common/logs.go
+++ b/util/common/logs.go
@@ -30,8 +30,9 @@ func KillEventLogService() error {
 	out, err := GetEventLogServicePid()
 	if err != nil {
 		log.Printf("Error getting Windows event log service PID: %v; the output is %s", err, out)
+		return err
 	}
-	log.Printf("Windows EventLog Service PID: %s", out)
+	log.Printf("Killing Windows EventLog Service PID: %s", out)
 	_, _ = RunShellScript("Stop-Process -Force " + out)
 
 	return nil
@@ -40,11 +41,11 @@ func KillEventLogService() error {
 func StartEventLogService() error {
 	out, err := RunShellScript("Start-Service EventLog")
 	if err != nil {
-		log.Printf("Error starting Windows event log service: %v; the output is %s", err, string(out))
+		log.Printf("Error starting Windows event log service: %v; the output is %s", err, out)
 		return err
 	}
 	pid, _ := GetEventLogServicePid()
-	log.Printf("Windows EventLog Service PID: %s", pid)
+	log.Printf("Started Windows EventLog Service PID: %s", pid)
 
 	return nil
 }

--- a/validator/validators/feature/feature_validator.go
+++ b/validator/validators/feature/feature_validator.go
@@ -41,6 +41,15 @@ func (s *FeatureValidator) GenerateLoad() error {
 		validationLog         = s.vConfig.GetLogValidation()
 	)
 
+	// Kill event log service and wait a bit to restart to ensure the agent can resubscribe
+	if err := common.KillEventLogService(); err != nil {
+		multiErr = multierr.Append(multiErr, err)
+	}
+	time.Sleep(20 * time.Second)
+	if err := common.StartEventLogService(); err != nil {
+		multiErr = multierr.Append(multiErr, err)
+	}
+
 	if err := common.GenerateLogs(agentConfigFilePath, agentCollectionPeriod, metricSendingInterval, dataRate, validationLog); err != nil {
 		multiErr = multierr.Append(multiErr, err)
 	}

--- a/validator/validators/feature/feature_validator.go
+++ b/validator/validators/feature/feature_validator.go
@@ -46,7 +46,7 @@ func (s *FeatureValidator) GenerateLoad() error {
 		if err := common.KillEventLogService(); err != nil {
 			multiErr = multierr.Append(multiErr, err)
 		}
-		time.Sleep(20 * time.Second)
+		time.Sleep(5 * time.Second)
 		if err := common.StartEventLogService(); err != nil {
 			multiErr = multierr.Append(multiErr, err)
 		}

--- a/validator/validators/feature/feature_validator.go
+++ b/validator/validators/feature/feature_validator.go
@@ -41,13 +41,15 @@ func (s *FeatureValidator) GenerateLoad() error {
 		validationLog         = s.vConfig.GetLogValidation()
 	)
 
-	// Kill event log service and wait a bit to restart to ensure the agent can resubscribe
-	if err := common.KillEventLogService(); err != nil {
-		multiErr = multierr.Append(multiErr, err)
-	}
-	time.Sleep(20 * time.Second)
-	if err := common.StartEventLogService(); err != nil {
-		multiErr = multierr.Append(multiErr, err)
+	// If we are validating windows event logs, kill event log service so the agent can resubscribe
+	if common.ContainsWindowsEventLog(validationLog) {
+		if err := common.KillEventLogService(); err != nil {
+			multiErr = multierr.Append(multiErr, err)
+		}
+		time.Sleep(20 * time.Second)
+		if err := common.StartEventLogService(); err != nil {
+			multiErr = multierr.Append(multiErr, err)
+		}
 	}
 
 	if err := common.GenerateLogs(agentConfigFilePath, agentCollectionPeriod, metricSendingInterval, dataRate, validationLog); err != nil {


### PR DESCRIPTION
# Description of the issue
We need to ensure the agent is able to publish windows event logs even when the event log service restarts or crashes

# Description of changes
Adds steps to kill the event log service pid, and then start the service before publishing event logs. Used a variation of the following powershell script:

```
Function Get-EventLogPid {
	$ServiceName = 'EventLog'
	$filter = "name like ""$ServiceName"" or displayname like ""$ServiceName"""
	$Service = gcim -ClassName Win32_Service -Filter $filter
	return $Service.ProcessId
}


# 1. Get the EvenLogPid
$EventLogPid = Get-EventLogPid

# 2. Kill EventLog service by PID
Stop-Process $EventLogPid -Force
sleep 20


# 3. Start the eventlog service
Start-Service EventLog
```

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran a test with a version of the agent that did not have the event log fix:
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/10205915443

Ran a test with latest changes of the agent with the event log fix:
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/10205917120
