### PR TITLE
Removed End of Life OSes (debian-10,centos-7,rhel7)

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -33,17 +33,6 @@
     "family": "linux"
   },
   {
-    "os": "debian-10",
-    "username": "admin",
-    "instanceType": "c6g.large",
-    "installAgentCommand": "/snap/bin/go run ./install/install_agent.go deb",
-    "ami": "cloudwatch-agent-integration-test-debian-10-arm64*",
-    "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
-    "arc": "arm64",
-    "binaryName": "amazon-cloudwatch-agent.deb",
-    "family": "linux"
-  },
-  {
     "os": "debian-11",
     "username": "admin",
     "instanceType": "c6g.large",
@@ -110,17 +99,6 @@
     "family": "linux"
   },
   {
-    "os": "rhel7",
-    "username": "ec2-user",
-    "instanceType":"t3a.medium",
-    "installAgentCommand": "go run ./install/install_agent.go rpm",
-    "ami": "cloudwatch-agent-integration-test-rhel7*",
-    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
-    "arc": "amd64",
-    "binaryName": "amazon-cloudwatch-agent.rpm",
-    "family": "linux"
-  },
-  {
     "os": "rhel8",
     "username": "ec2-user",
     "instanceType":"t3a.medium",
@@ -159,17 +137,6 @@
     "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-ol9*",
-    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
-    "arc": "amd64",
-    "binaryName": "amazon-cloudwatch-agent.rpm",
-    "family": "linux"
-  },
-  {
-    "os": "centos-7",
-    "username": "centos",
-    "instanceType":"t3a.medium",
-    "installAgentCommand": "go run ./install/install_agent.go rpm",
-    "ami": "cloudwatch-agent-integration-test-centos-7*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",


### PR DESCRIPTION
# Description of the issue
We want to remove end-of-life OSes code as they're end-of-life.

| OS Name   | End Of Life   | Source                                                                                                                                                                                                 |
|-----------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| debian-10 | June 30, 2024 | [link](https://www.debian.org/News/2024/20240615)                                                                                                                                                      |
| centos-7  | June 30, 2024 | [link](https://www.redhat.com/en/topics/linux/centos-linux-eol#:~:text=On%20June%2030%2C%202024%2C%20CentOS,for%20Third%20Party%20Linux%20Migration.)                                                  |
| rhel-7    | June 30, 2024 | [link](https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/rhel-7-end-of-maintenance#:~:text=Although%20Red%20Hat%20Enterprise%20Linux,%2C%20updates%2C%20and%20security%20fixes.) |
# Description of changes
Removed them from test matrix

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Integration Test: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/10377633957
You can see that debian-10, centos-7, rhel-7 tests are missing, which is wanted behavior. 
