### PR TITLE
Updating integration tests for newly added metrics

### DIFF
--- a/test/metric_value_benchmark/eks_resources/util.go
+++ b/test/metric_value_benchmark/eks_resources/util.go
@@ -258,6 +258,8 @@ func GetExpectedDimsToMetrics(env *environment.MetaData) map[string][]string {
 			"pod_memory_utilization",
 			"pod_number_of_running_containers",
 			"pod_status_scheduled",
+			"pod_cpu_usage_total",
+			"pod_memory_working_set",
 		},
 		"ClusterName-Namespace": {
 			"pod_interface_network_rx_dropped",
@@ -269,6 +271,8 @@ func GetExpectedDimsToMetrics(env *environment.MetaData) map[string][]string {
 			"pod_interface_network_tx_dropped",
 			"pod_cpu_utilization",
 			"pod_network_tx_bytes",
+			"pod_cpu_usage_total",
+			"pod_memory_working_set",
 		},
 	}
 

--- a/test/metric_value_benchmark/eks_resources/util.go
+++ b/test/metric_value_benchmark/eks_resources/util.go
@@ -139,6 +139,8 @@ func GetExpectedDimsToMetrics(env *environment.MetaData) map[string][]string {
 			"node_cpu_reserved_capacity",
 			"container_memory_utilization_over_container_limit",
 			"container_cpu_request",
+			"pod_cpu_usage_total",
+			"pod_memory_working_set",
 		},
 		"ClusterName-FullPodName-Namespace-PodName": {
 			"pod_network_tx_bytes",
@@ -168,6 +170,8 @@ func GetExpectedDimsToMetrics(env *environment.MetaData) map[string][]string {
 			"pod_memory_request",
 			"pod_cpu_reserved_capacity",
 			"pod_cpu_utilization_over_pod_limit",
+			"pod_cpu_usage_total",
+			"pod_memory_working_set",
 		},
 		"ClusterName-Namespace-PodName": {
 			"pod_interface_network_rx_dropped",
@@ -197,6 +201,8 @@ func GetExpectedDimsToMetrics(env *environment.MetaData) map[string][]string {
 			"pod_cpu_utilization_over_pod_limit",
 			"pod_status_scheduled",
 			"pod_memory_limit",
+			"pod_cpu_usage_total",
+			"pod_memory_working_set",
 		},
 
 		"ClusterName-InstanceId-NodeName": {


### PR DESCRIPTION
# Description of the issue
We are adding 2 new metrics per pod `pod_cpu_usage_total` & `pod_memory_working_set`

PR: https://github.com/aws/amazon-cloudwatch-agent/pull/1294

Updating integrationTests for the newly added metrics.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
<img width="776" alt="Screenshot 2024-08-16 at 12 16 27" src="https://github.com/user-attachments/assets/9896de62-7491-4ab6-a215-808a755cc9a6">

There is an issue with fetching other metrics in integration Tests, so the complete workflow is not successful: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/10408457860/job/28826102473

