### PR TITLE
add removed variables for ami_type and instance_type

### DIFF
--- a/terraform/eks/daemon/awsneuron/variables.tf
+++ b/terraform/eks/daemon/awsneuron/variables.tf
@@ -26,3 +26,12 @@ variable "k8s_version" {
   default = "1.28"
 }
 
+variable "ami_type" {
+  type    = string
+  default = "AL2_x86_64"
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3.medium"
+}


### PR DESCRIPTION
# Description of the issue
We had removed the ami_type and instance_type variables from the variables.tf file since they were not used but the terraform apply in the agent needs these variables, adding them back so that the terraform apply doesn't fail

agent code : 
```
terraform init
            if terraform apply --auto-approve \
              -var="test_dir=${{ matrix.arrays.test_dir }}"\
              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
              -var="cwagent_image_tag=${{ github.sha }}" \
              -var="ami_type=${{ matrix.arrays.ami }}" \
              -var="instance_type=${{ matrix.arrays.instanceType }}" \
              -var="k8s_version=${{ matrix.arrays.k8s_version }}"; then
              terraform destroy -auto-approve
            else
              terraform destroy -auto-approve && exit 1
            fi
```

# Description of changes
- adding back ami_type and instance_type in neuron integ test

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- make fmt
- terraform apply working using test agent, workflow where terraform apply is initialised properly : https://github.com/aws/amazon-cloudwatch-agent/actions/runs/10508871596/job/29119854059
