### PR TITLE
Add ubuntu24 to ec2 linux test suite

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -33,6 +33,17 @@
     "family": "linux"
   },
   {
+    "os": "ubuntu-24",
+    "username": "ubuntu",
+    "instanceType":"t3.medium",
+    "installAgentCommand": "go run ./install/install_agent.go deb",
+    "ami": "cloudwatch-agent-integration-test-ubuntu-24*",
+    "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.deb",
+    "family": "linux"
+  },
+  {
     "os": "debian-11",
     "username": "admin",
     "instanceType": "c6g.large",


### PR DESCRIPTION
# Description of changes
Add Ubuntu 24.04 support

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Test run in the agent repo: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/10964690286

The test was targeting only ubuntu 23 and 24 for comparison. 
