### PR TITLE
Adding integ test for agent otel config merging

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -217,8 +217,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 		{testDir: "./test/fluent", terraformDir: "terraform/eks/daemon/fluent/windows/2022"},
 		{
 			testDir: "./test/gpu", terraformDir: "terraform/eks/daemon/gpu",
-			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
-			instanceType: "g4dn.xlarge",
+			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
 		},
 	},
 	"eks_deployment": {

--- a/terraform/eks/daemon/gpu/main.tf
+++ b/terraform/eks/daemon/gpu/main.tf
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 module "common" {
-  source             = "../../../common"
+  source             = "../common"
   cwagent_image_repo = var.cwagent_image_repo
   cwagent_image_tag  = var.cwagent_image_tag
 }
 
 module "basic_components" {
-  source = "../../../basic_components"
+  source = "../basic_components"
 
   region = var.region
 }

--- a/terraform/gpu/main.tf
+++ b/terraform/gpu/main.tf
@@ -1,0 +1,146 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "common" {
+  source             = "../common"
+  cwagent_image_repo = var.cwagent_image_repo
+  cwagent_image_tag  = var.cwagent_image_tag
+}
+
+module "basic_components" {
+  source = "../basic_components"
+
+  region = var.region
+}
+
+
+data "aws_eks_cluster_auth" "this" {
+  name = aws_eks_cluster.this.name
+}
+
+locals {
+  role_arn = format("%s%s", module.basic_components.role_arn, var.beta ? "-eks-beta" : "")
+  aws_eks  = format("%s%s", "aws eks --region ${var.region}", var.beta ? " --endpoint ${var.beta_endpoint}" : "")
+}
+
+resource "aws_eks_cluster" "this" {
+  name     = "cwagent-operator-eks-integ-${module.common.testing_id}"
+  role_arn = local.role_arn
+  version  = var.k8s_version
+  vpc_config {
+    subnet_ids         = module.basic_components.public_subnet_ids
+    security_group_ids = [module.basic_components.security_group]
+  }
+}
+
+# EKS Node Groups
+resource "aws_eks_node_group" "this" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_group_name = "cwagent-operator-eks-integ-node"
+  node_role_arn   = aws_iam_role.node_role.arn
+  subnet_ids      = module.basic_components.public_subnet_ids
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  ami_type       = "AL2_x86_64_GPU"
+  capacity_type  = "ON_DEMAND"
+  disk_size      = 20
+  instance_types = ["g4dn.xlarge"]
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.node_AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.node_AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.node_CloudWatchAgentServerPolicy
+  ]
+}
+
+# EKS Node IAM Role
+resource "aws_iam_role" "node_role" {
+  name = "cwagent-operator-eks-Worker-Role-${module.common.testing_id}"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_CloudWatchAgentServerPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+  role       = aws_iam_role.node_role.name
+}
+
+
+resource "null_resource" "kubectl" {
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_eks_node_group.this
+  ]
+  provisioner "local-exec" {
+    command = <<-EOT
+      ${local.aws_eks} update-kubeconfig --name ${aws_eks_cluster.this.name}
+      ${local.aws_eks} list-clusters --output text
+      ${local.aws_eks} describe-cluster --name ${aws_eks_cluster.this.name} --output text
+    EOT
+  }
+}
+
+resource "aws_eks_addon" "this" {
+  depends_on = [
+    null_resource.kubectl
+  ]
+  addon_name   = var.addon_name
+  cluster_name = aws_eks_cluster.this.name
+  addon_version = var.addon_version
+}
+
+resource "null_resource" "validator" {
+  depends_on = [
+      aws_eks_node_group.this,
+      aws_eks_addon.this
+  ]
+
+  provisioner "local-exec" {
+    command = <<EOT
+      go test ${var.test_dir} -eksClusterName ${aws_eks_cluster.this.name} -computeType=EKS -v -eksDeploymentStrategy=DAEMON -eksGpuType=nvidia
+
+      # Get all pods and describe them
+      kubectl get pods --all-namespaces -o wide > pods.txt
+      kubectl describe pods --all-namespaces > pods_describe.txt
+
+      # Log the contents of the files
+      cat pods.txt
+      cat pods_describe.txt
+    EOT
+  }
+}
+

--- a/terraform/gpu/providers.tf
+++ b/terraform/gpu/providers.tf
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+provider "aws" {
+  region = var.region
+  endpoints {
+    eks = var.beta ? var.beta_endpoint : null
+  }
+}
+
+provider "kubernetes" {
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.this.name]
+  }
+  host                   = aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}

--- a/terraform/gpu/variables.tf
+++ b/terraform/gpu/variables.tf
@@ -8,8 +8,19 @@ variable "region" {
 
 variable "test_dir" {
   type    = string
-  default = "../test/gpu"
+  default = "../../test/gpu"
 }
+
+variable "addon_name" {
+  type    = string
+  default = "amazon-cloudwatch-observability"
+}
+
+variable "addon_version" {
+  type = string
+  default = "v1.6.0-eksbuild.1"
+}
+
 
 variable "cwagent_image_repo" {
   type    = string
@@ -28,10 +39,20 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2_x86_64_GPU"
 }
 
 variable "instance_type" {
   type    = string
   default = "g4dn.xlarge"
+}
+
+variable "beta" {
+  type    = bool
+  default = true
+}
+
+variable "beta_endpoint" {
+  type    = string
+  default = "https://api.beta.us-west-2.wesley.amazonaws.com"
 }

--- a/test/metric/container_insights_util.go
+++ b/test/metric/container_insights_util.go
@@ -58,6 +58,15 @@ func ValidateMetrics(env *environment.MetaData, metricFilter string, expectedDim
 		}
 		results = append(results, validateMetricsAvailability(dims, metrics, actual))
 		for _, m := range metrics {
+			// this is to prevent panic with rand.Intn when metrics are not yet ready in a cluster
+			if _, ok := actual[m]; !ok {
+				results = append(results, status.TestResult{
+					Name:   dims,
+					Status: status.FAILED,
+				})
+				log.Printf("ValidateMetrics failed with missing metric: %s", m)
+				continue
+			}
 			// pick a random dimension set to test metric data OR test all dimension sets which might be overkill
 			randIdx := rand.Intn(len(actual[m]))
 			results = append(results, validateMetricValue(m, actual[m][randIdx]))
@@ -123,7 +132,7 @@ func validateMetricsAvailability(dims string, expected []string, actual map[stri
 		Name:   dims,
 		Status: status.FAILED,
 	}
-	log.Printf("expected metrics: %d, actual metrics: %d", len(expected), len(actual))
+	log.Printf("expected metrics: %d, actual metrics: %d", len(expected), 3*len(actual))
 	if compareMetrics(expected, actual) {
 		testResult.Status = status.SUCCESSFUL
 	} else {


### PR DESCRIPTION
# Description of the issue
This pr adds otel yaml merging integ test. We want to make sure that no regression happens in the agent where the yaml merging for the agent stops working.  Passing test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/11353738985/job/31579557585
#### Passing test
<img width="761" alt="Screenshot 2024-10-15 at 5 43 13 PM" src="https://github.com/user-attachments/assets/c3bbba15-a98d-47e2-8cdf-7dffa9bffe6f">
s/11353738985/job/31579557585

Amazon-cloudwatch-agent repo pr: https://github.com/aws/amazon-cloudwatch-agent/pull/1391


# Description of changes

### Test workflow
1. Starts the agent with the given config.json below using StartAgent() function
2. Calls `sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -s -m ec2 -c file:./resources/otel.yaml` 
3. Then we do a `curl -X POST -H "Content-Type: application/json" -d @metrics.json -i localhost:4318/v1/metrics`
where otlp reciever listens to this and sends it over to cloudwatch using the awsemf exporter. 
4. Then confirm the metric is in the console.



#### Agent configuration (have one metric being collected in order to generate agent yaml to be merged):
```
{
  "metrics": {
    "metrics_collected": {
      "cpu": {
        "measurement": [
          "cpu_usage_idle"
        ]
      }
    }
  }
}
```
#### Agent Yaml:
```
exporters:
    awscloudwatch:
        force_flush_interval: 1m0s
        max_datums_per_call: 1000
        max_values_per_datum: 150
        middleware: agenthealth/metrics
        namespace: CWAgent
        region: us-west-2
        resource_to_telemetry_conversion:
            enabled: true
extensions:
    agenthealth/metrics:
        is_usage_data_enabled: true
        stats:
            operations:
                - PutMetricData
            usage_flags:
                mode: EC2
                region_type: EC2M
receivers:
    telegraf_cpu:
        collection_interval: 1m0s
        initial_delay: 1s
        timeout: 0s
service:
    extensions:
        - agenthealth/metrics
    pipelines:
        metrics/host:
            exporters:
                - awscloudwatch
            processors: []
            receivers:
                - telegraf_cpu
    telemetry:
        logs:
            development: false
            disable_caller: false
            disable_stacktrace: false
            encoding: console
            level: info
            output_paths:
                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
            sampling:
                enabled: true
                initial: 2
                thereafter: 500
                tick: 10s
        metrics:
            address: ""
            level: None
        traces: {}
```

#### Otel Yaml

```
receivers:
  otlp:
    protocols:
      grpc:
      http:

exporters:
  awsemf/otel-merging:
    namespace: "CWAgent-testing-otel"
    log_group_name: "CWA"
    dimension_rollup_option: "NoDimensionRollup"
    log_stream_name: "Testing-otel"
    resource_to_telemetry_conversion:
      enabled: true
    version: "0"

service:
  pipelines:
    metrics:
      receivers: [otlp]
      exporters: [awsemf/otel-merging]
```

#### Merged OTEL configuration:
``` 
exporters:
    awscloudwatch:
        force_flush_interval: 1m0s
        max_datums_per_call: 1000
        max_values_per_datum: 150
        middleware: agenthealth/metrics
        namespace: CWAgent
        region: us-west-2
        resource_to_telemetry_conversion:
            enabled: true
    awsemf/otel-merging:
        certificate_file_path: ""
        detailed_metrics: false
        dimension_rollup_option: NoDimensionRollup
        disable_metric_extraction: false
        eks_fargate_container_insights_enabled: false
        endpoint: ""
        enhanced_container_insights: false
        imds_retries: 0
        local_mode: false
        log_group_name: CWA
        log_retention: 0
        log_stream_name: Testing-otel
        max_retries: 2
        namespace: CWAgent-testing-otel
        no_verify_ssl: false
        num_workers: 8
        output_destination: cloudwatch
        profile: ""
        proxy_address: ""
        region: ""
        request_timeout_seconds: 30
        resource_arn: ""
        resource_to_telemetry_conversion:
            enabled: true
        retain_initial_value_of_delta_metric: false
        role_arn: ""
        version: "0"
extensions:
    agenthealth/metrics:
        is_usage_data_enabled: true
        stats:
            operations:
                - PutMetricData
            usage_flags:
                mode: EC2
                region_type: EC2M
receivers:
    otlp:
        protocols:
            grpc:
                dialer:
                    timeout: 0s
                endpoint: 0.0.0.0:4317
                include_metadata: false
                max_concurrent_streams: 0
                max_recv_msg_size_mib: 0
                read_buffer_size: 524288
                transport: tcp
                write_buffer_size: 0
            http:
                endpoint: 0.0.0.0:4318
                include_metadata: false
                logs_url_path: /v1/logs
                max_request_body_size: 0
                metrics_url_path: /v1/metrics
                traces_url_path: /v1/traces
    telegraf_cpu:
        collection_interval: 1m0s
        initial_delay: 1s
        timeout: 0s
service:
    extensions:
        - agenthealth/metrics
    pipelines:
        metrics:
            exporters:
                - awsemf/otel-merging
            receivers:
                - otlp
        metrics/host:
            exporters:
                - awscloudwatch
            processors: []
            receivers:
                - telegraf_cpu
    telemetry:
        logs:
            development: false
            disable_caller: false
            disable_stacktrace: false
            encoding: console
            error_output_paths:
                - stderr
            level: info
            output_paths:
                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
            sampling:
                enabled: true
                initial: 2
                thereafter: 500
                tick: 10s
        metrics:
            address: ""
            level: None
        traces: {}

```


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manually tested this on ec2 instance by running these command with the above configurations:
```
sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a stop=
sudo rm /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.yaml 
sudo rm /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log 
sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -s -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json
sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -s -m ec2 -c file:/home/ec2-user/test.yaml
sleep 5
cat /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log 
go run goScript.go //which simply just does a curl to otlp reciever to add metrics
```




