### PR TITLE
Add EKS integration test for FluentBit log emission with Entity field

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -231,6 +231,10 @@ var testTypeToTestConfig = map[string][]testConfig{
 			testDir: "./test/awsneuron", terraformDir: "terraform/eks/daemon/awsneuron",
 			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
 		},
+		{
+			testDir: "./test/entity", terraformDir: "terraform/eks/daemon/entity",
+			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
+		},
 	},
 	"eks_deployment": {
 		{testDir: "./test/metric_value_benchmark"},

--- a/terraform/eks/daemon/entity/main.tf
+++ b/terraform/eks/daemon/entity/main.tf
@@ -19,13 +19,6 @@ resource "aws_eks_cluster" "this" {
   name     = "cwagent-eks-integ-${module.common.testing_id}"
   role_arn = module.basic_components.role_arn
   version  = var.k8s_version
-  enabled_cluster_log_types = [
-    "api",
-    "audit",
-    "authenticator",
-    "controllerManager",
-    "scheduler"
-  ]
   vpc_config {
     subnet_ids         = module.basic_components.public_subnet_ids
     security_group_ids = [module.basic_components.security_group]

--- a/terraform/eks/daemon/entity/main.tf
+++ b/terraform/eks/daemon/entity/main.tf
@@ -182,7 +182,6 @@ resource "helm_release" "aws_observability" {
   namespace  = "amazon-cloudwatch"
   create_namespace = true
 
-  # Specify any necessary values here
   set {
     name  = "clusterName"
     value = aws_eks_cluster.this.name
@@ -251,7 +250,7 @@ resource "null_resource" "validator" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      echo "Validating EKS metrics/traces for AppSignals"
+      echo "Validating EKS logs for entity fields"
       cd ../../../..
       go test ${var.test_dir} -timeout 1h -eksClusterName=${aws_eks_cluster.this.name} -computeType=EKS -v -eksDeploymentStrategy=DAEMON -instanceId=${data.aws_instance.eks_node_detail.instance_id}
     EOT

--- a/terraform/eks/daemon/entity/main.tf
+++ b/terraform/eks/daemon/entity/main.tf
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 module "common" {
-  source             = "../../../common"
+  source = "../../../common"
 }
 
 module "basic_components" {
@@ -177,9 +177,9 @@ resource "null_resource" "clone_helm_chart" {
 }
 
 resource "helm_release" "aws_observability" {
-  name       = "amazon-cloudwatch-observability"
-  chart      = "./helm-charts/charts/amazon-cloudwatch-observability"
-  namespace  = "amazon-cloudwatch"
+  name             = "amazon-cloudwatch-observability"
+  chart            = "./helm-charts/charts/amazon-cloudwatch-observability"
+  namespace        = "amazon-cloudwatch"
   create_namespace = true
 
   set {
@@ -194,7 +194,7 @@ resource "helm_release" "aws_observability" {
   depends_on = [
     aws_eks_cluster.this,
     aws_eks_node_group.this,
-    null_resource.clone_helm_chart]
+  null_resource.clone_helm_chart]
 }
 
 resource "kubernetes_pod" "log_generator" {

--- a/terraform/eks/daemon/entity/main.tf
+++ b/terraform/eks/daemon/entity/main.tf
@@ -1,0 +1,260 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "common" {
+  source             = "../../../common"
+}
+
+module "basic_components" {
+  source = "../../../basic_components"
+
+  region = var.region
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = aws_eks_cluster.this.name
+}
+
+resource "aws_eks_cluster" "this" {
+  name     = "cwagent-eks-integ-${module.common.testing_id}"
+  role_arn = module.basic_components.role_arn
+  version  = var.k8s_version
+  enabled_cluster_log_types = [
+    "api",
+    "audit",
+    "authenticator",
+    "controllerManager",
+    "scheduler"
+  ]
+  vpc_config {
+    subnet_ids         = module.basic_components.public_subnet_ids
+    security_group_ids = [module.basic_components.security_group]
+  }
+}
+
+# EKS Node Groups
+resource "aws_eks_node_group" "this" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_group_name = "cwagent-eks-integ-node-${module.common.testing_id}"
+  node_role_arn   = aws_iam_role.node_role.arn
+  subnet_ids      = module.basic_components.public_subnet_ids
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  ami_type       = var.ami_type
+  capacity_type  = "ON_DEMAND"
+  disk_size      = 20
+  instance_types = [var.instance_type]
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.node_AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.node_AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.node_CloudWatchAgentServerPolicy,
+    aws_iam_role_policy_attachment.node_AWSXRayDaemonWriteAccess
+  ]
+}
+
+# EKS Node IAM Role
+resource "aws_iam_role" "node_role" {
+  name = "cwagent-eks-Worker-Role-${module.common.testing_id}"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_CloudWatchAgentServerPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+  role       = aws_iam_role.node_role.name
+}
+resource "aws_iam_role_policy_attachment" "node_AWSXRayDaemonWriteAccess" {
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.node_role.name
+}
+
+# TODO: these security groups be created once and then reused
+# EKS Cluster Security Group
+resource "aws_security_group" "eks_cluster_sg" {
+  name        = "cwagent-eks-cluster-sg-${module.common.testing_id}"
+  description = "Cluster communication with worker nodes"
+  vpc_id      = module.basic_components.vpc_id
+}
+
+resource "aws_security_group_rule" "cluster_inbound" {
+  description              = "Allow worker nodes to communicate with the cluster API Server"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_cluster_sg.id
+  source_security_group_id = aws_security_group.eks_nodes_sg.id
+  to_port                  = 443
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "cluster_outbound" {
+  description              = "Allow cluster API Server to communicate with the worker nodes"
+  from_port                = 1024
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_cluster_sg.id
+  source_security_group_id = aws_security_group.eks_nodes_sg.id
+  to_port                  = 65535
+  type                     = "egress"
+}
+
+
+# EKS Node Security Group
+resource "aws_security_group" "eks_nodes_sg" {
+  name        = "cwagent-eks-node-sg-${module.common.testing_id}"
+  description = "Security group for all nodes in the cluster"
+  vpc_id      = module.basic_components.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "nodes_internal" {
+  description              = "Allow nodes to communicate with each other"
+  from_port                = 0
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.eks_nodes_sg.id
+  source_security_group_id = aws_security_group.eks_nodes_sg.id
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "nodes_cluster_inbound" {
+  description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
+  from_port                = 1025
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_nodes_sg.id
+  source_security_group_id = aws_security_group.eks_cluster_sg.id
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "null_resource" "clone_helm_chart" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      if [ ! -d "./helm-charts" ]; then
+        git clone -b ${var.helm_chart_branch} https://github.com/aws-observability/helm-charts.git ./helm-charts
+      fi
+    EOT
+  }
+}
+
+resource "helm_release" "aws_observability" {
+  name       = "amazon-cloudwatch-observability"
+  chart      = "./helm-charts/charts/amazon-cloudwatch-observability"
+  namespace  = "amazon-cloudwatch"
+  create_namespace = true
+
+  # Specify any necessary values here
+  set {
+    name  = "clusterName"
+    value = aws_eks_cluster.this.name
+  }
+
+  set {
+    name  = "region"
+    value = "us-west-2"
+  }
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_eks_node_group.this,
+    null_resource.clone_helm_chart]
+}
+
+resource "kubernetes_pod" "log_generator" {
+  depends_on = [aws_eks_node_group.this]
+  metadata {
+    name      = "log-generator"
+    namespace = "default"
+  }
+
+  spec {
+    container {
+      name  = "log-generator"
+      image = "busybox"
+
+      # Run shell script that generate a log line every second
+      command = ["/bin/sh", "-c"]
+      args    = ["while true; do echo \"Log entry at $(date)\"; sleep 1; done"]
+    }
+    restart_policy = "Always"
+  }
+}
+
+
+# Get the single instance ID of the node in the node group
+data "aws_instances" "eks_node" {
+  depends_on = [
+    aws_eks_node_group.this
+  ]
+  filter {
+    name   = "tag:eks:nodegroup-name"
+    values = [aws_eks_node_group.this.node_group_name]
+  }
+}
+
+# Retrieve details of the single instance to get private DNS
+data "aws_instance" "eks_node_detail" {
+  depends_on = [
+    data.aws_instances.eks_node
+  ]
+  instance_id = data.aws_instances.eks_node.ids[0]
+}
+
+resource "null_resource" "validator" {
+  depends_on = [
+    aws_eks_node_group.this,
+    helm_release.aws_observability,
+    kubernetes_pod.log_generator
+  ]
+
+  triggers = {
+    always_run = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "Validating EKS metrics/traces for AppSignals"
+      cd ../../../..
+      go test ${var.test_dir} -timeout 1h -eksClusterName=${aws_eks_cluster.this.name} -computeType=EKS -v -eksDeploymentStrategy=DAEMON -instanceId=${data.aws_instance.eks_node_detail.instance_id}
+    EOT
+  }
+}
+

--- a/terraform/eks/daemon/entity/providers.tf
+++ b/terraform/eks/daemon/entity/providers.tf
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+provider "aws" {
+  region = var.region
+}
+
+provider "kubernetes" {
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.this.name]
+  }
+  host                   = aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = aws_eks_cluster.this.endpoint
+    cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority.0.data)
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.this.name]
+      command     = "aws"
+    }
+  }
+}

--- a/terraform/eks/daemon/entity/variables.tf
+++ b/terraform/eks/daemon/entity/variables.tf
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "test_dir" {
+  type    = string
+  default = "./test/entity"
+}
+
+variable "k8s_version" {
+  type    = string
+  default = "1.30"
+}
+
+variable "ami_type" {
+  type    = string
+  default = "AL2_x86_64"
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3a.medium"
+}
+
+variable "helm_chart_branch" {
+  type    = string
+  default = "main"
+}
+
+variable "cwagent_image_repo" {
+  type    = string
+  default = "public.ecr.aws/cloudwatch-agent/cloudwatch-agent"
+}
+
+variable "cwagent_image_tag" {
+  type    = string
+  default = "latest"
+}

--- a/test/entity/entity_test.go
+++ b/test/entity/entity_test.go
@@ -1,0 +1,214 @@
+package entity
+
+import (
+	"fmt"
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	"log"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	sleepForFlush = 180 * time.Second
+
+	entityType        = "@entity.KeyAttributes.Type"
+	entityName        = "@entity.KeyAttributes.Name"
+	entityEnvironment = "@entity.KeyAttributes.Environment"
+
+	entityPlatform          = "@entity.Attributes.PlatformType"
+	entityInstanceId        = "@entity.Attributes.EC2.InstanceId"
+	entityEKSCluster        = "@entity.Attributes.EKS.Cluster"
+	entityK8sNode           = "@entity.Attributes.K8s.Node"
+	entityK8sNamespace      = "@entity.Attributes.K8s.Namespace"
+	entityK8sWorkload       = "@entity.Attributes.K8s.Workload"
+	entityServiceNameSource = "@entity.Attributes.AWS.ServiceNameSource"
+)
+
+type expectedEntity struct {
+	entityType        string
+	name              string
+	environment       string
+	platformType      string
+	k8sWorkload       string
+	k8sNode           string
+	k8sNamespace      string
+	eksCluster        string
+	serviceNameSource string
+	instanceId        string
+}
+
+func init() {
+	environment.RegisterEnvironmentMetaDataFlags()
+}
+
+// TestPutLogEventEntityEKS checks if entity is emitted correctly in EKS
+// through FluentBit
+func TestPutLogEventEntityEKS(t *testing.T) {
+	var instancePrivateDNS *string
+
+	env := environment.GetEnvironmentMetaData()
+	assert.NotEmpty(t, env.InstanceId)
+	assert.NotEmpty(t, env.EKSClusterName)
+	assert.NotEmpty(t, env.ComputeType)
+	if env.InstanceId != "" {
+		var err error
+		instancePrivateDNS, err = awsservice.GetInstancePrivateIpDns(env.InstanceId)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, instancePrivateDNS)
+	}
+
+	// ensure that there is enough time from the "start" time and the first log line,
+	// so we don't miss it in the StartQuery call
+	log.Printf("Sleeping for %f seconds to ensure log group is ready for query", sleepForFlush.Seconds())
+	time.Sleep(sleepForFlush)
+	end := time.Now()
+
+	testCases := map[string]struct {
+		agentConfigPath string
+		podName         string
+		useEC2Tag       bool
+		expectedEntity  expectedEntity
+	}{
+		"Entity/K8sWorkloadServiceNameSource": {
+			agentConfigPath: filepath.Join("resources", "compass_default_log.json"),
+			podName:         "log-generator",
+			expectedEntity: expectedEntity{
+				entityType:        "Service",
+				name:              "log-generator",
+				environment:       "eks:" + env.EKSClusterName + "/" + "default",
+				platformType:      "AWS::EKS",
+				k8sWorkload:       "log-generator",
+				k8sNode:           *instancePrivateDNS,
+				k8sNamespace:      "default",
+				eksCluster:        env.EKSClusterName,
+				instanceId:        env.InstanceId,
+				serviceNameSource: "K8sWorkload",
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var podApplicationLogStream string
+
+			appLogGroup := fmt.Sprintf("/aws/containerinsights/%s/%s", env.EKSClusterName, "application")
+			logStreamNames := awsservice.GetLogStreamNames(appLogGroup)
+			assert.NotZero(t, len(logStreamNames))
+			for _, streamName := range logStreamNames {
+				if strings.Contains(streamName, testCase.podName) {
+					podApplicationLogStream = streamName
+					log.Printf("Found log stream %s that matches pattern %s", streamName, testCase.podName)
+				}
+			}
+			assert.NotEmpty(t, podApplicationLogStream)
+			// check CWL to ensure we got the expected entities in the log group
+			queryString := fmt.Sprintf("fields @message, @entity.KeyAttributes.Type, @entity.KeyAttributes.Name, @entity.KeyAttributes.Environment, @entity.Attributes.PlatformType, @entity.Attributes.EKS.Cluster, @entity.Attributes.K8s.Node, @entity.Attributes.K8s.Namespace, @entity.Attributes.K8s.Workload, @entity.Attributes.AWS.ServiceNameSource, @entity.Attributes.EC2.InstanceId | filter @logStream == \"%s\"", podApplicationLogStream)
+			ValidateEntity(t, appLogGroup, podApplicationLogStream, &end, queryString, testCase.expectedEntity, string(env.ComputeType))
+		})
+	}
+}
+
+// ValidateEntity queries a given LogGroup/LogStream combination given the start and end times, and executes an
+// log query for entity attributes to ensure the entity values are correct
+func ValidateEntity(t *testing.T, logGroup, logStream string, end *time.Time, queryString string, expectedEntity expectedEntity, entityPlatformType string) {
+	var requiredEntityFields map[string]bool
+
+	log.Printf("Checking log group/stream: %s/%s", logGroup, logStream)
+
+	if !awsservice.IsLogGroupExists(logGroup) {
+		t.Fatalf("application log group used for entity validation doesn't exsit: %s", logGroup)
+	}
+	begin := end.Add(-sleepForFlush * 2)
+	log.Printf("Start time is " + begin.String() + " and end time is " + end.String())
+
+	result, err := awsservice.GetLogQueryResults(logGroup, begin.Unix(), end.Unix(), queryString)
+	assert.NoError(t, err)
+	if !assert.NotZero(t, len(result)) {
+		return
+	}
+	if entityPlatformType == "EC2" {
+		requiredEntityFields = map[string]bool{
+			entityType:        false,
+			entityName:        false,
+			entityEnvironment: false,
+			entityPlatform:    false,
+			entityInstanceId:  false,
+		}
+	} else if entityPlatformType == "EKS" {
+		requiredEntityFields = map[string]bool{
+			entityType:              false,
+			entityName:              false,
+			entityEnvironment:       false,
+			entityPlatform:          false,
+			entityEKSCluster:        false,
+			entityK8sNode:           false,
+			entityK8sNamespace:      false,
+			entityK8sWorkload:       false,
+			entityServiceNameSource: false,
+		}
+	}
+	for _, field := range result[0] {
+		if entityPlatformType == "EC2" {
+			switch aws.ToString(field.Field) {
+			case entityType:
+				requiredEntityFields[entityType] = true
+				assert.Equal(t, expectedEntity.entityType, aws.ToString(field.Value))
+			case entityName:
+				requiredEntityFields[entityName] = true
+				assert.Equal(t, expectedEntity.name, aws.ToString(field.Value))
+			case entityEnvironment:
+				requiredEntityFields[entityEnvironment] = true
+				assert.Equal(t, expectedEntity.environment, aws.ToString(field.Value))
+			case entityPlatform:
+				requiredEntityFields[entityPlatform] = true
+				assert.Equal(t, expectedEntity.platformType, aws.ToString(field.Value))
+			case entityInstanceId:
+				requiredEntityFields[entityInstanceId] = true
+				assert.Equal(t, expectedEntity.instanceId, aws.ToString(field.Value))
+			}
+		} else {
+			switch aws.ToString(field.Field) {
+			case entityType:
+				requiredEntityFields[entityType] = true
+				assert.Equal(t, expectedEntity.entityType, aws.ToString(field.Value))
+			case entityName:
+				requiredEntityFields[entityName] = true
+				assert.Equal(t, expectedEntity.name, aws.ToString(field.Value))
+			case entityEnvironment:
+				requiredEntityFields[entityEnvironment] = true
+				assert.Equal(t, expectedEntity.environment, aws.ToString(field.Value))
+			case entityPlatform:
+				requiredEntityFields[entityPlatform] = true
+				assert.Equal(t, expectedEntity.platformType, aws.ToString(field.Value))
+			case entityEKSCluster:
+				requiredEntityFields[entityEKSCluster] = true
+				assert.Equal(t, expectedEntity.eksCluster, aws.ToString(field.Value))
+			case entityK8sNode:
+				requiredEntityFields[entityK8sNode] = true
+				assert.Equal(t, expectedEntity.k8sNode, aws.ToString(field.Value))
+			case entityK8sNamespace:
+				requiredEntityFields[entityK8sNamespace] = true
+				assert.Equal(t, expectedEntity.k8sNamespace, aws.ToString(field.Value))
+			case entityK8sWorkload:
+				requiredEntityFields[entityK8sWorkload] = true
+				assert.Equal(t, expectedEntity.k8sWorkload, aws.ToString(field.Value))
+			case entityServiceNameSource:
+				requiredEntityFields[entityServiceNameSource] = true
+				assert.Equal(t, expectedEntity.serviceNameSource, aws.ToString(field.Value))
+			}
+		}
+
+		fmt.Printf("%s: %s\n", aws.ToString(field.Field), aws.ToString(field.Value))
+	}
+	allEntityFieldsFound := true
+	for _, value := range requiredEntityFields {
+		if !value {
+			allEntityFieldsFound = false
+		}
+	}
+	assert.True(t, allEntityFieldsFound)
+}

--- a/test/entity/entity_test.go
+++ b/test/entity/entity_test.go
@@ -1,16 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package entity
 
 import (
 	"fmt"
-	"github.com/aws/amazon-cloudwatch-agent-test/environment"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/stretchr/testify/assert"
 	"log"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 )
 
 const (


### PR DESCRIPTION
# Description of the issue
FluentBit has a new feature to emit CloudWatch logs with entity field which helps users navigate between their telemetry in the CloudWatch console. We want to add an integration test which helps us validate this behavior.

This PR focuses on the test scenario where FluentBit falls back to using K8sWorkload as the service name and uses default environment name. 

# Description of changes
- Add new terraform that uses helm chart to set up the cluster
- Create a worker pod that output log every second
- Add test code to validate the entity fields contain the necessary values.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/11790939699/job/32939527206 (Ran after commit [861e08b](https://github.com/aws/amazon-cloudwatch-agent-test/pull/427/commits/861e08bfff6c58eaeb71df2b72459ae1c4e0588a))
