### PR TITLE
Add EKS integration test for FluentBit log emission with custom envir…

### DIFF
--- a/test/entity/entity_test.go
+++ b/test/entity/entity_test.go
@@ -197,6 +197,24 @@ func TestPutLogEventEntityEKS(t *testing.T) {
 				serviceNameSource: entityServiceNameSourceInstrumentation,
 			},
 		},
+		"Entity/InstrumentationServiceNameSourceCustomEnvironment": {
+			agentConfigPath: filepath.Join("resources", "compass_default_log.json"),
+			podName:         "petclinic-instrumentation-custom-env",
+			expectedEntity: expectedEntity{
+				entityType: eksServiceEntityType,
+				// This service name comes from OTEL_SERVICE_NAME which is
+				// customized in the terraform code when creating the pod
+				name:              "petclinic-custom-service-name",
+				environment:       "petclinic-custom-environment",
+				platformType:      entityEKSPlatform,
+				k8sWorkload:       "petclinic-instrumentation-custom-env",
+				k8sNode:           *instancePrivateDNS,
+				k8sNamespace:      k8sDefaultNamespace,
+				eksCluster:        env.EKSClusterName,
+				instanceId:        env.InstanceId,
+				serviceNameSource: entityServiceNameSourceInstrumentation,
+			},
+		},
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
# Description of the issue
FluentBit has a new feature to emit CloudWatch logs with entity field which helps users navigate between their telemetry in the CloudWatch console. We want to add an integration test which helps us validate this behavior.

This PR focuses on the test scenario where FluentBit uses Instrumentation service name source from AppSignal and uses custom environment name.

# Description of changes
- Add EKS integration test for FluentBit emitting service name with source Instrumentation and custom environment name from `deployment.environment`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/11842220241/job/33000595192
