### PR TITLE
Remove EOL centos-stream-8 and rhel8 configurations from matrix

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -110,17 +110,6 @@
     "family": "linux"
   },
   {
-    "os": "rhel8",
-    "username": "ec2-user",
-    "instanceType":"t3a.medium",
-    "installAgentCommand": "go run ./install/install_agent.go rpm",
-    "ami": "cloudwatch-agent-integration-test-rhel8-base*",
-    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
-    "arc": "amd64",
-    "binaryName": "amazon-cloudwatch-agent.rpm",
-    "family": "linux"
-  },
-  {
     "os": "ol7",
     "username": "ec2-user",
     "instanceType":"t3a.medium",
@@ -148,17 +137,6 @@
     "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-ol9*",
-    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
-    "arc": "amd64",
-    "binaryName": "amazon-cloudwatch-agent.rpm",
-    "family": "linux"
-  },
-  {
-    "os": "centos-stream-8",
-    "username": "cloud-user",
-    "instanceType":"t3a.medium",
-    "installAgentCommand": "go run ./install/install_agent.go rpm",
-    "ami": "cloudwatch-agent-integration-test-centos-stream-8*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",


### PR DESCRIPTION
# Description of the issue

Rhel8 and centos-8 are End of Life so ami is missing, remove them from our test suite This is blocking thre following tests:

EC2 Linux CA Bundle Test &
EC2 Linux Metric Dimension Test & 

EC2 Linux OpenTelemetry Protocol (OTLP) Test *

EC2 Linux Run as User Test
EC2 Linux X-Ray Test

# Description of changes

Remove centos 8 and rhel8

I confirmed by looking at a recent test run that all other tests were fine
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/11918099514

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A