### PR TITLE
update list of ContainerInsights metrics used for validations

### DIFF
--- a/test/metric_value_benchmark/eks_resources/util.go
+++ b/test/metric_value_benchmark/eks_resources/util.go
@@ -171,6 +171,7 @@ func GetExpectedDimsToMetrics(env *environment.MetaData) map[string][]string {
 			"container_cpu_request",
 			"pod_cpu_usage_total",
 			"pod_memory_working_set",
+			"pod_container_status_waiting_reason_crash_loop_back_off",
 		},
 		"ClusterName-FullPodName-Namespace-PodName": {
 			"pod_network_tx_bytes",
@@ -202,6 +203,7 @@ func GetExpectedDimsToMetrics(env *environment.MetaData) map[string][]string {
 			"pod_cpu_utilization_over_pod_limit",
 			"pod_cpu_usage_total",
 			"pod_memory_working_set",
+			"pod_container_status_waiting_reason_crash_loop_back_off",
 		},
 		"ClusterName-Namespace-PodName": {
 			"pod_interface_network_rx_dropped",
@@ -233,6 +235,7 @@ func GetExpectedDimsToMetrics(env *environment.MetaData) map[string][]string {
 			"pod_memory_limit",
 			"pod_cpu_usage_total",
 			"pod_memory_working_set",
+			"pod_container_status_waiting_reason_crash_loop_back_off",
 		},
 
 		"ClusterName-InstanceId-NodeName": {
@@ -301,8 +304,6 @@ func GetExpectedDimsToMetrics(env *environment.MetaData) map[string][]string {
 			"pod_interface_network_tx_dropped",
 			"pod_cpu_utilization",
 			"pod_network_tx_bytes",
-			"pod_cpu_usage_total",
-			"pod_memory_working_set",
 		},
 	}
 


### PR DESCRIPTION
# Description of the issue
Metrics benchmark integ tests are failing example: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/11959277199/job/33340769914

# Description of changes
Update the list of metrics used for validations and the dimension sets they get validates with

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
```
2024/12/03 13:24:17 >>>>>>>>>>>>>><<<<<<<<<<<<<<
2024/12/03 13:24:17 >>>>>>>>>>>>>>Successful<<<<<<<<<<<<<<
2024/12/03 13:24:17 ==============EKSContainerInstance==============
2024/12/03 13:24:17 ==============Successful==============
ClusterName-InstanceId-NodeName                           Successful  
node_status_allocatable_pods                              Successful  
node_network_total_bytes                                  Successful  
node_status_condition_unknown                             Successful  
node_interface_network_rx_dropped                         Successful  
node_number_of_running_containers                         Successful  
node_interface_network_tx_dropped                         Successful  
node_memory_utilization                                   Successful  
node_cpu_limit                                            Successful  
node_status_condition_disk_pressure                       Successful  
node_memory_working_set                                   Successful  
node_cpu_reserved_capacity                                Successful  
node_status_condition_ready                               Successful  
node_filesystem_utilization                               Successful  
node_status_condition_memory_pressure                     Successful  
node_memory_limit                                         Successful  
node_memory_reserved_capacity                             Successful  
node_diskio_io_serviced_total                             Successful  
node_status_condition_pid_pressure                        Successful  
node_filesystem_inodes                                    Successful  
node_cpu_usage_total                                      Successful  
node_number_of_running_pods                               Successful  
node_diskio_io_service_bytes_total                        Successful  
node_status_capacity_pods                                 Successful  
node_filesystem_inodes_free                               Successful  
node_cpu_utilization                                      Successful  
ClusterName-Namespace-Service                             Successful  
pod_status_unknown                                        Successful  
pod_memory_limit                                          Successful  
pod_container_status_terminated                           Successful  
pod_status_ready                                          Successful  
pod_number_of_container_restarts                          Successful  
pod_status_pending                                        Successful  
pod_status_succeeded                                      Successful  
pod_network_rx_bytes                                      Successful  
pod_status_failed                                         Successful  
pod_number_of_containers                                  Successful  
pod_cpu_request                                           Successful  
service_number_of_running_pods                            Successful  
pod_memory_reserved_capacity                              Successful  
pod_network_tx_bytes                                      Successful  
pod_container_status_waiting                              Successful  
pod_memory_request                                        Successful  
pod_status_running                                        Successful  
pod_container_status_running                              Successful  
pod_cpu_reserved_capacity                                 Successful  
pod_memory_utilization_over_pod_limit                     Successful  
pod_cpu_utilization                                       Successful  
pod_memory_utilization                                    Successful  
pod_number_of_running_containers                          Successful  
pod_status_scheduled                                      Successful  
pod_cpu_usage_total                                       Successful  
pod_memory_working_set                                    Successful  
ClusterName-Namespace                                     Successful  
pod_interface_network_rx_dropped                          Successful  
pod_network_rx_bytes                                      Successful  
pod_cpu_utilization_over_pod_limit                        Successful  
pod_memory_utilization_over_pod_limit                     Successful  
namespace_number_of_running_pods                          Successful  
pod_memory_utilization                                    Successful  
pod_interface_network_tx_dropped                          Successful  
pod_cpu_utilization                                       Successful  
pod_network_tx_bytes                                      Successful  
ClusterName                                               Successful  
pod_number_of_containers                                  Successful  
node_status_allocatable_pods                              Successful  
pod_number_of_container_restarts                          Successful  
node_status_condition_unknown                             Successful  
node_number_of_running_pods                               Successful  
pod_container_status_running                              Successful  
node_status_condition_ready                               Successful  
pod_status_running                                        Successful  
node_filesystem_utilization                               Successful  
pod_container_status_terminated                           Successful  
pod_status_pending                                        Successful  
pod_cpu_utilization                                       Successful  
node_filesystem_inodes                                    Successful  
node_diskio_io_service_bytes_total                        Successful  
node_status_condition_memory_pressure                     Successful  
container_cpu_utilization                                 Successful  
service_number_of_running_pods                            Successful  
pod_memory_utilization_over_pod_limit                     Successful  
node_memory_limit                                         Successful  
pod_cpu_request                                           Successful  
pod_interface_network_tx_dropped                          Successful  
pod_status_succeeded                                      Successful  
namespace_number_of_running_pods                          Successful  
pod_memory_reserved_capacity                              Successful  
node_diskio_io_serviced_total                             Successful  
pod_network_rx_bytes                                      Successful  
node_status_capacity_pods                                 Successful  
pod_status_unknown                                        Successful  
cluster_failed_node_count                                 Successful  
container_memory_utilization                              Successful  
node_memory_utilization                                   Successful  
node_filesystem_inodes_free                               Successful  
container_memory_request                                  Successful  
container_cpu_limit                                       Successful  
node_memory_reserved_capacity                             Successful  
node_interface_network_tx_dropped                         Successful  
pod_cpu_utilization_over_pod_limit                        Successful  
container_memory_failures_total                           Successful  
pod_status_ready                                          Successful  
pod_number_of_running_containers                          Successful  
cluster_node_count                                        Successful  
pod_memory_request                                        Successful  
node_cpu_utilization                                      Successful  
cluster_number_of_running_pods                            Successful  
node_memory_working_set                                   Successful  
pod_status_failed                                         Successful  
node_status_condition_pid_pressure                        Successful  
pod_status_scheduled                                      Successful  
node_number_of_running_containers                         Successful  
node_cpu_limit                                            Successful  
node_status_condition_disk_pressure                       Successful  
pod_cpu_limit                                             Successful  
pod_memory_limit                                          Successful  
node_cpu_usage_total                                      Successful  
pod_cpu_reserved_capacity                                 Successful  
pod_network_tx_bytes                                      Successful  
container_memory_limit                                    Successful  
pod_memory_utilization                                    Successful  
node_interface_network_rx_dropped                         Successful  
node_network_total_bytes                                  Successful  
container_cpu_utilization_over_container_limit            Successful  
pod_interface_network_rx_dropped                          Successful  
pod_container_status_waiting                              Successful  
node_cpu_reserved_capacity                                Successful  
container_memory_utilization_over_container_limit         Successful  
container_cpu_request                                     Successful  
pod_cpu_usage_total                                       Successful  
pod_memory_working_set                                    Successful  
pod_container_status_waiting_reason_crash_loop_back_off   Successful  
ClusterName-FullPodName-Namespace-PodName                 Successful  
pod_network_tx_bytes                                      Successful  
pod_interface_network_rx_dropped                          Successful  
pod_cpu_limit                                             Successful  
pod_status_succeeded                                      Successful  
pod_container_status_waiting                              Successful  
pod_number_of_running_containers                          Successful  
pod_number_of_container_restarts                          Successful  
pod_status_pending                                        Successful  
pod_status_running                                        Successful  
pod_container_status_running                              Successful  
pod_memory_limit                                          Successful  
pod_status_unknown                                        Successful  
pod_memory_utilization_over_pod_limit                     Successful  
pod_cpu_request                                           Successful  
pod_status_scheduled                                      Successful  
pod_memory_utilization                                    Successful  
pod_status_failed                                         Successful  
pod_network_rx_bytes                                      Successful  
pod_number_of_containers                                  Successful  
pod_cpu_utilization                                       Successful  
pod_memory_reserved_capacity                              Successful  
pod_status_ready                                          Successful  
pod_container_status_terminated                           Successful  
pod_interface_network_tx_dropped                          Successful  
pod_memory_request                                        Successful  
pod_cpu_reserved_capacity                                 Successful  
pod_cpu_utilization_over_pod_limit                        Successful  
pod_cpu_usage_total                                       Successful  
pod_memory_working_set                                    Successful  
pod_container_status_waiting_reason_crash_loop_back_off   Successful  
ClusterName-Namespace-PodName                             Successful  
pod_interface_network_rx_dropped                          Successful  
pod_status_succeeded                                      Successful  
pod_container_status_running                              Successful  
pod_network_rx_bytes                                      Successful  
pod_cpu_utilization                                       Successful  
pod_memory_utilization                                    Successful  
pod_interface_network_tx_dropped                          Successful  
pod_status_ready                                          Successful  
pod_container_status_terminated                           Successful  
pod_cpu_reserved_capacity                                 Successful  
pod_memory_request                                        Successful  
pod_status_running                                        Successful  
pod_status_pending                                        Successful  
pod_number_of_containers                                  Successful  
pod_memory_utilization_over_pod_limit                     Successful  
pod_status_unknown                                        Successful  
pod_cpu_limit                                             Successful  
pod_container_status_waiting                              Successful  
pod_memory_reserved_capacity                              Successful  
pod_network_tx_bytes                                      Successful  
pod_status_failed                                         Successful  
pod_number_of_running_containers                          Successful  
pod_number_of_container_restarts                          Successful  
pod_cpu_request                                           Successful  
pod_cpu_utilization_over_pod_limit                        Successful  
pod_status_scheduled                                      Successful  
pod_memory_limit                                          Successful  
pod_cpu_usage_total                                       Successful  
pod_memory_working_set                                    Successful  
pod_container_status_waiting_reason_crash_loop_back_off   Successful  
cluster_failed_node_count                                 Successful  
cluster_node_count                                        Successful  
namespace_number_of_running_pods                          Successful  
node_cpu_limit                                            Successful  
node_cpu_reserved_capacity                                Successful  
node_cpu_usage_total                                      Successful  
node_cpu_utilization                                      Successful  
node_filesystem_utilization                               Successful  
node_memory_limit                                         Successful  
node_memory_reserved_capacity                             Successful  
node_memory_utilization                                   Successful  
node_memory_working_set                                   Successful  
node_network_total_bytes                                  Successful  
node_number_of_running_containers                         Successful  
node_number_of_running_pods                               Successful  
pod_cpu_reserved_capacity                                 Successful  
pod_cpu_utilization                                       Successful  
pod_cpu_utilization_over_pod_limit                        Successful  
pod_memory_reserved_capacity                              Successful  
pod_memory_utilization                                    Successful  
pod_memory_utilization_over_pod_limit                     Successful  
pod_network_rx_bytes                                      Successful  
pod_network_tx_bytes                                      Successful  
service_number_of_running_pods                            Successful  
emf-logs                                                  Successful  
2024/12/03 13:24:17 ==============================
2024/12/03 13:24:17 >>>>>>>>>>>>>>><<<<<<<<<<<<<<<
>>>> Finished MetricBenchmarkTestSuite
--- PASS: TestMetricValueBenchmarkSuite (25.01s)
    --- PASS: TestMetricValueBenchmarkSuite/TestAllInSuite (25.00s)
PASS
ok  	github.com/aws/amazon-cloudwatch-agent-test/test/metric_value_benchmark	25.837s
```
