### PR TITLE
Fix flaky sanity test for TestAgentStatus

### DIFF
--- a/test/sanity/resources/verifyUnixCtlScript.sh
+++ b/test/sanity/resources/verifyUnixCtlScript.sh
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 assertStatus() {
+     sleep 3
      keyToCheck="${1:-}"
      expectedVal="${2:-}"
 


### PR DESCRIPTION
# Description of the issue
We have a flaky sanity check in our integration tests when `verifyUnixCtlScript.sh.

```
2024-09-05T17:17:50.0818601Z [0m[1mnull_resource.integration_test_run (remote-exec):[0m [0m****** processing amazon-cloudwatch-agent ******
2024-09-05T17:17:50.0820072Z [0m[1mnull_resource.integration_test_run (remote-exec):[0m [0mall amazon-cloudwatch-agent configurations have been removed
2024-09-05T17:17:50.0821670Z [0m[1mnull_resource.integration_test_run (remote-exec):[0m [0mIn step 7, cwa_running_status is NOT expected. (actual=stopped; expected=running)
2024-09-05T17:17:50.0823223Z [0m[1mnull_resource.integration_test_run (remote-exec):[0m [0m    sanity_unix.go:17: Running sanity check failed
2024-09-05T17:17:50.0824572Z [0m[1mnull_resource.integration_test_run (remote-exec):[0m [0m--- FAIL: TestAgentStatus (98.56s)
2024-09-05T17:17:50.0825686Z [0m[1mnull_resource.integration_test_run (remote-exec):[0m [0mFAIL
2024-09-05T17:17:50.0827097Z [0m[1mnull_resource.integration_test_run (remote-exec):[0m [0mFAIL	github.com/aws/amazon-cloudwatch-agent-test/test/sanity	98.569s
2024-09-05T17:17:50.0828418Z [0m[1mnull_resource.integration_test_run (remote-exec):[0m [0mFAIL
```

This is caused by a race condition between the agent ctl commands finishing and the status properties.

# Description of changes
- Add a `sleep` function to prevent the race condition between the agent ctl commands finishing and the status properties.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran script locally with agent installed.

Ran workflow: TBD