### PR TITLE
drop addon version to pick the latest

### DIFF
--- a/generator/resources/eks_addon_test_matrix.json
+++ b/generator/resources/eks_addon_test_matrix.json
@@ -1,8 +1,6 @@
 [
   {
     "k8sVersion": "1.31",
-    "addon_name":"amazon-cloudwatch-observability",
-    "addon_version":"v2.5.0-eksbuild.1",
     "ami": "AL2_x86_64_GPU",
     "terraform_dir": "terraform/eks/addon/gpu",
     "test_dir": "../../../../test/gpu",

--- a/terraform/eks/addon/gpu/main.tf
+++ b/terraform/eks/addon/gpu/main.tf
@@ -124,7 +124,6 @@ resource "aws_eks_addon" "this" {
   ]
   addon_name    = var.addon_name
   cluster_name  = aws_eks_cluster.this.name
-  addon_version = var.addon_version
 }
 output "eks_cluster_name" {
   value = aws_eks_cluster.this.name

--- a/terraform/eks/addon/gpu/main.tf
+++ b/terraform/eks/addon/gpu/main.tf
@@ -122,8 +122,8 @@ resource "aws_eks_addon" "this" {
   depends_on = [
     null_resource.kubectl
   ]
-  addon_name    = var.addon_name
-  cluster_name  = aws_eks_cluster.this.name
+  addon_name   = var.addon_name
+  cluster_name = aws_eks_cluster.this.name
 }
 output "eks_cluster_name" {
   value = aws_eks_cluster.this.name

--- a/terraform/eks/addon/gpu/variables.tf
+++ b/terraform/eks/addon/gpu/variables.tf
@@ -16,11 +16,6 @@ variable "addon_name" {
   default = "amazon-cloudwatch-observability"
 }
 
-variable "addon_version" {
-  type    = string
-  default = "v2.5.0-eksbuild.1"
-}
-
 variable "k8s_version" {
   type    = string
   default = "1.31"


### PR DESCRIPTION
# Description of changes
drop `addon_version` variable to let the addon module to install the latest

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

