### PR TITLE
[Enhancement] Enhance CloudWatch Agent Startup on Windows AMIs via Dependency Updates

### DIFF
--- a/msi/tools/amazon-cloudwatch-agent.wxs
+++ b/msi/tools/amazon-cloudwatch-agent.wxs
@@ -7,7 +7,7 @@
     UpgradeCode='c537c936-91b3-4270-94d7-e128acfc3e86'
     Language='1033'
     Codepage='1252'
-    Version='<version>'
+    Version='1.4.37902'
     Manufacturer='Amazon.com, Inc.'>
 
     <Package Id='*'
@@ -90,16 +90,23 @@
                 ErrorControl="normal"
                 Vital="yes"
             >
-                <ServiceDependency Id="LanmanServer"/>
-                <ServiceConfig FirstFailureActionType="restart" SecondFailureActionType="restart" ThirdFailureActionType="restart" ResetPeriodInDays="1" RestartServiceDelayInSeconds="2" xmlns="http://schemas.microsoft.com/wix/UtilExtension"/>
-                <ServiceConfig OnInstall="yes" OnReinstall="yes" FailureActionsWhen="failedToStopOrReturnedError"/>
+                <ServiceDependency Id="Tcpip"/>
+                <ServiceDependency Id="Dhcp"/>
+                <ServiceDependency Id="Dnscache"/>
+                <ServiceConfig 
+                FirstFailureActionType="restart" 
+                SecondFailureActionType="restart" 
+                ThirdFailureActionType="restart" 
+                ResetPeriodInDays="1" 
+                RestartServiceDelayInSeconds="2" 
+                xmlns="http://schemas.microsoft.com/wix/UtilExtension"/>
             </ServiceInstall>
             <ServiceControl
                 Id="StartService"
+                Start="install"
                 Stop="both"
                 Remove="uninstall"
                 Name="AmazonCloudWatchAgent"
-                Wait="yes"
             />
         </Component>
         <Component Id='AgentEXE' Guid='d98c86be-b6c8-4f24-84a5-03b08bd6e7f2' Win64='yes'>

--- a/msi/tools/amazon-cloudwatch-agent.wxs
+++ b/msi/tools/amazon-cloudwatch-agent.wxs
@@ -7,7 +7,7 @@
     UpgradeCode='c537c936-91b3-4270-94d7-e128acfc3e86'
     Language='1033'
     Codepage='1252'
-    Version='1.4.37902'
+    Version='<version>'
     Manufacturer='Amazon.com, Inc.'>
 
     <Package Id='*'


### PR DESCRIPTION
### Description of the Issue
The CloudWatch Agent service on Windows fails to start automatically on certain custom AMIs created using Windows sysprep. This issue occurs due to a race condition between the agent's startup and the initialization of network drivers during system boot.

### Description of Changes
This PR modifies the CloudWatch Agent's service configuration to improve its startup reliability:

1. Removed the dependency on the "LanmanServer" service.
2. Added new service dependencies: "Tcpip" and "Dnscache".
3. Implemented more detailed failure action settings in the service configuration.
4. Added `Start='install'` to the `ServiceControl` element.

**Rationale:**
- **Removed "LanmanServer" dependency:** Eliminates a non-critical wait during startup, reducing potential delays.
- **Added "Tcpip" and "Dnscache" dependencies:** Ensures that the network stack is fully initialized before the CloudWatch Agent starts, addressing the race condition with network drivers.
- **Failure action settings:** Provides specific instructions for Windows to handle potential startup failures, improving service recovery.
- **`Start='install'` addition:** Ensures proper service management during installation, streamlining the setup process.

### License
By submitting this pull request, I confirm that you are permitted to use, modify, copy, and redistribute this contribution under the terms of your choice.

### Tests
Testing was performed on a Windows 2016 instance using the latest AMI in US-East-1:

- Installed MSI and used the default configuration for the `.json` file.
- Verified that when pushing the JSON config via parameter, the agent service started immediately after the `AmazonCloudWatch-ManageAgent` document completed.
- Confirmed that CloudWatch metrics were successfully streamed from the Agent to the service.
- Created an image from the working instance and launched it.
- Launched an initial instance and 10 additional instances for testing.
- Used SSM Run Command to execute the following PowerShell script on all instances:  
  `Get-Service -Name "Amazon CloudWatch*"`
- All executions returned success, confirming that the CloudWatch Agent was running on instances launched from the AMI.
![Screenshot 2024-12-11 at 3 42 29 PM](https://github.com/user-attachments/assets/4c7961e4-31a3-4b68-8856-777200be9fcd)
