### PR TITLE
Remove starting Agent Service on Installation on Windows

### DIFF
--- a/msi/tools/amazon-cloudwatch-agent.wxs
+++ b/msi/tools/amazon-cloudwatch-agent.wxs
@@ -103,7 +103,6 @@
             </ServiceInstall>
             <ServiceControl
                 Id="StartService"
-                Start="install"
                 Stop="both"
                 Remove="uninstall"
                 Name="AmazonCloudWatchAgent"


### PR DESCRIPTION
## Description of the Issue
We encountered an issue with Docker on Windows where the automatic starting of the agent service during installation was interfering with the Docker environment.

## Description of Changes
- Removed the build flag responsible for auto-starting the agent service from the WXS file.
- This change prevents the agent service from starting automatically upon installation with msi on Windows systems.

## Rationale
By removing the automatic start of the agent service, we aim to resolve conflicts with Docker environments on Windows, allowing for a smoother installation process.

## Testing
- Ran integration tests and compared results to the main branch:
  - Main branch test: [Run #12323241718](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12323241718)
  - This change: [Run #12658779476](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12658779476)
- Verified Docker build success: [Run #12658507798](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12658507798)


## License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.