### PR TITLE
Remove End of Life OS: ubuntu-23

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -22,17 +22,6 @@
     "family": "linux"
   },
   {
-    "os": "ubuntu-23",
-    "username": "ubuntu",
-    "instanceType":"t3.medium",
-    "installAgentCommand": "go run ./install/install_agent.go deb",
-    "ami": "cloudwatch-agent-integration-test-ubuntu-23*",
-    "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
-    "arc": "amd64",
-    "binaryName": "amazon-cloudwatch-agent.deb",
-    "family": "linux"
-  },
-  {
     "os": "ubuntu-24",
     "username": "ubuntu",
     "instanceType":"t3.medium",


### PR DESCRIPTION
# Description of the issue
Ubuntu-23 is End of Life starting since 11 Jul 2024. We no longer support this Operating System; thus, we are removing it from our test suite.
# Description of changes
Remove Ubuntu-23 from our test matrix

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Test run:https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12680590830 
In the test run you can see ubuntu-23 no longer exists.
<img width="1281" alt="Screenshot 2025-01-09 at 3 14 36 PM" src="https://github.com/user-attachments/assets/8badef31-bcf1-460c-b718-5c9f67401ce5" />
