### PR TITLE
Add pod identity credential integration test

### DIFF
--- a/environment/eksdeploymenttype/eks_deployment_type.go
+++ b/environment/eksdeploymenttype/eks_deployment_type.go
@@ -8,18 +8,20 @@ import "strings"
 type EKSDeploymentType string
 
 const (
-	DAEMON   EKSDeploymentType = "DAEMON"
-	REPLICA  EKSDeploymentType = "REPLICA"
-	SIDECAR  EKSDeploymentType = "SIDECAR"
-	STATEFUL EKSDeploymentType = "STATEFUL"
+	DAEMON      EKSDeploymentType = "DAEMON"
+	REPLICA     EKSDeploymentType = "REPLICA"
+	SIDECAR     EKSDeploymentType = "SIDECAR"
+	STATEFUL    EKSDeploymentType = "STATEFUL"
+	PODIDENTITY EKSDeploymentType = "PODIDENTITY"
 )
 
 var (
 	eksDeploymentTypes = map[string]EKSDeploymentType{
-		"DAEMON":   DAEMON,
-		"REPLICA":  REPLICA,
-		"SIDECAR":  SIDECAR,
-		"STATEFUL": STATEFUL,
+		"DAEMON":      DAEMON,
+		"REPLICA":     REPLICA,
+		"SIDECAR":     SIDECAR,
+		"STATEFUL":    STATEFUL,
+		"PODIDENTITY": PODIDENTITY,
 	}
 )
 

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -242,6 +242,10 @@ var testTypeToTestConfig = map[string][]testConfig{
 			testDir: "./test/efa", terraformDir: "terraform/eks/daemon/efa",
 			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
 		},
+		{
+			testDir: "./test/metric_value_benchmark", terraformDir: "terraform/eks/daemon/credentials/pod_identity",
+			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
+		},
 	},
 	"eks_deployment": {
 		{testDir: "./test/metric_value_benchmark"},

--- a/terraform/eks/daemon/credentials/pod_identity/main.tf
+++ b/terraform/eks/daemon/credentials/pod_identity/main.tf
@@ -1,0 +1,324 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "common" {
+  source = "../../../../common"
+}
+
+module "basic_components" {
+  source = "../../../../basic_components"
+
+  region = var.region
+}
+
+locals {
+  aws_eks = "aws eks --region ${var.region}"
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = aws_eks_cluster.this.name
+}
+
+resource "aws_eks_cluster" "this" {
+  name     = "cwagent-eks-integ-${module.common.testing_id}"
+  role_arn = module.basic_components.role_arn
+  version  = var.k8s_version
+  vpc_config {
+    subnet_ids         = module.basic_components.public_subnet_ids
+    security_group_ids = [module.basic_components.security_group]
+  }
+}
+
+# EKS Node Groups
+resource "aws_eks_node_group" "this" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_group_name = "cwagent-eks-integ-node-${module.common.testing_id}"
+  node_role_arn   = aws_iam_role.node_role.arn
+  subnet_ids      = module.basic_components.public_subnet_ids
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  ami_type       = var.ami_type
+  capacity_type  = "ON_DEMAND"
+  disk_size      = 20
+  instance_types = [var.instance_type]
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.node_AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.node_AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.pod_CloudWatchAgentServerPolicy
+  ]
+}
+
+resource "aws_eks_addon" "pod_identity_addon" {
+  cluster_name = aws_eks_cluster.this.name
+  addon_name   = "eks-pod-identity-agent"
+  depends_on = [aws_eks_node_group.this]
+}
+
+# EKS Node IAM Role
+resource "aws_iam_role" "node_role" {
+  name = "cwagent-eks-Worker-Role-${module.common.testing_id}"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+data "aws_iam_policy_document" "pod-identity-policy" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession"
+    ]
+  }
+}
+
+
+resource "aws_iam_role" "pod-identity-role" {
+  name               = "cwagent-eks-pod-identity-role-${module.common.testing_id}"
+  assume_role_policy = data.aws_iam_policy_document.pod-identity-policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "pod_CloudWatchAgentServerPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+  role       = aws_iam_role.pod-identity-role.name
+}
+
+resource "aws_eks_pod_identity_association" "association" {
+  cluster_name = aws_eks_cluster.this.name
+  namespace = "amazon-cloudwatch"
+  service_account = "cloudwatch-agent"
+  role_arn = aws_iam_role.pod-identity-role.arn
+  depends_on = [aws_eks_cluster.this]
+}
+
+# TODO: these security groups be created once and then reused
+# EKS Cluster Security Group
+resource "aws_security_group" "eks_cluster_sg" {
+  name        = "cwagent-eks-cluster-sg-${module.common.testing_id}"
+  description = "Cluster communication with worker nodes"
+  vpc_id      = module.basic_components.vpc_id
+}
+
+resource "aws_security_group_rule" "cluster_inbound" {
+  description              = "Allow worker nodes to communicate with the cluster API Server"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_cluster_sg.id
+  source_security_group_id = aws_security_group.eks_nodes_sg.id
+  to_port                  = 443
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "cluster_outbound" {
+  description              = "Allow cluster API Server to communicate with the worker nodes"
+  from_port                = 1024
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_cluster_sg.id
+  source_security_group_id = aws_security_group.eks_nodes_sg.id
+  to_port                  = 65535
+  type                     = "egress"
+}
+
+
+# EKS Node Security Group
+resource "aws_security_group" "eks_nodes_sg" {
+  name        = "cwagent-eks-node-sg-${module.common.testing_id}"
+  description = "Security group for all nodes in the cluster"
+  vpc_id      = module.basic_components.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "nodes_internal" {
+  description              = "Allow nodes to communicate with each other"
+  from_port                = 0
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.eks_nodes_sg.id
+  source_security_group_id = aws_security_group.eks_nodes_sg.id
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "nodes_cluster_inbound" {
+  description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
+  from_port                = 1025
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_nodes_sg.id
+  source_security_group_id = aws_security_group.eks_cluster_sg.id
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "null_resource" "clone_helm_chart" {
+  triggers = {
+    timestamp = "${timestamp()}" # Forces re-run on every apply
+  }
+  provisioner "local-exec" {
+    command = <<-EOT
+      if [ ! -d "./helm-charts" ]; then
+        git clone -b ${var.helm_chart_branch} https://github.com/aws-observability/helm-charts.git ./helm-charts
+      fi
+    EOT
+  }
+}
+
+resource "helm_release" "aws_observability" {
+  name             = "amazon-cloudwatch-observability"
+  chart            = "./helm-charts/charts/amazon-cloudwatch-observability"
+  namespace        = "amazon-cloudwatch"
+  create_namespace = true
+
+  set {
+    name  = "clusterName"
+    value = aws_eks_cluster.this.name
+  }
+
+  set {
+    name  = "region"
+    value = "us-west-2"
+  }
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_eks_node_group.this,
+    null_resource.clone_helm_chart,
+    aws_eks_addon.pod_identity_addon,
+    aws_eks_pod_identity_association.association,
+  ]
+}
+
+resource "null_resource" "kubectl" {
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_eks_node_group.this,
+  ]
+  provisioner "local-exec" {
+    command = <<-EOT
+      ${local.aws_eks} update-kubeconfig --name ${aws_eks_cluster.this.name}
+      ${local.aws_eks} list-clusters --output text
+      ${local.aws_eks} describe-cluster --name ${aws_eks_cluster.this.name} --output text
+    EOT
+  }
+}
+
+resource "null_resource" "update_image" {
+  depends_on = [helm_release.aws_observability, null_resource.kubectl]
+  triggers = {
+    timestamp = "${timestamp()}" # Forces re-run on every apply
+  }
+  provisioner "local-exec" {
+    command = <<-EOT
+      kubectl -n amazon-cloudwatch patch AmazonCloudWatchAgent cloudwatch-agent --type='json' -p='[{"op": "replace", "path": "/spec/image", "value": "${var.cwagent_image_repo}:${var.cwagent_image_tag}"}]'
+      kubectl set image deployment/amazon-cloudwatch-observability-controller-manager -n amazon-cloudwatch manager=public.ecr.aws/cloudwatch-agent/cloudwatch-agent-operator:latest
+      kubectl set image daemonset/fluent-bit -n amazon-cloudwatch fluent-bit=506463145083.dkr.ecr.us-west-2.amazonaws.com/fluent-bit-test:latest
+      sleep 10
+    EOT
+  }
+}
+
+resource "kubernetes_pod" "log_generator" {
+  depends_on = [aws_eks_node_group.this]
+  metadata {
+    name      = "log-generator"
+    namespace = "default"
+  }
+
+  spec {
+    container {
+      name  = "log-generator"
+      image = "busybox"
+
+      # Run shell script that generate a log line every second
+      command = ["/bin/sh", "-c"]
+      args    = ["while true; do echo \"Log entry at $(date)\"; sleep 1; done"]
+    }
+    restart_policy = "Always"
+  }
+}
+
+# Get the single instance ID of the node in the node group
+data "aws_instances" "eks_node" {
+  depends_on = [
+    aws_eks_node_group.this
+  ]
+  filter {
+    name   = "tag:eks:nodegroup-name"
+    values = [aws_eks_node_group.this.node_group_name]
+  }
+}
+
+# Retrieve details of the single instance to get private DNS
+data "aws_instance" "eks_node_detail" {
+  depends_on = [
+    data.aws_instances.eks_node
+  ]
+  instance_id = data.aws_instances.eks_node.ids[0]
+}
+
+resource "null_resource" "validator" {
+  depends_on = [
+    aws_eks_node_group.this,
+    aws_eks_addon.pod_identity_addon,
+    helm_release.aws_observability,
+    null_resource.update_image,
+    kubernetes_pod.log_generator,
+  ]
+
+  triggers = {
+    always_run = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "Validating CloudWatch Agent and FluentBit with pod identity credential"
+      cd ../../../../..
+      go test ./test/metric_value_benchmark -timeout 1h -eksClusterName=${aws_eks_cluster.this.name} -computeType=EKS -v -eksDeploymentStrategy=PODIDENTITY -instanceId=${data.aws_instance.eks_node_detail.instance_id} &&
+      go test ./test/fluent -eksClusterName=${aws_eks_cluster.this.name} -computeType=EKS -v -eksDeploymentStrategy=DAEMON
+    EOT
+  }
+}
+

--- a/terraform/eks/daemon/credentials/pod_identity/main.tf
+++ b/terraform/eks/daemon/credentials/pod_identity/main.tf
@@ -58,7 +58,7 @@ resource "aws_eks_node_group" "this" {
 resource "aws_eks_addon" "pod_identity_addon" {
   cluster_name = aws_eks_cluster.this.name
   addon_name   = "eks-pod-identity-agent"
-  depends_on = [aws_eks_node_group.this]
+  depends_on   = [aws_eks_node_group.this]
 }
 
 # EKS Node IAM Role
@@ -124,11 +124,11 @@ resource "aws_iam_role_policy_attachment" "pod_CloudWatchAgentServerPolicy" {
 }
 
 resource "aws_eks_pod_identity_association" "association" {
-  cluster_name = aws_eks_cluster.this.name
-  namespace = "amazon-cloudwatch"
+  cluster_name    = aws_eks_cluster.this.name
+  namespace       = "amazon-cloudwatch"
   service_account = "cloudwatch-agent"
-  role_arn = aws_iam_role.pod-identity-role.arn
-  depends_on = [aws_eks_cluster.this]
+  role_arn        = aws_iam_role.pod-identity-role.arn
+  depends_on      = [aws_eks_cluster.this]
 }
 
 # TODO: these security groups be created once and then reused

--- a/terraform/eks/daemon/credentials/pod_identity/main.tf
+++ b/terraform/eks/daemon/credentials/pod_identity/main.tf
@@ -254,7 +254,6 @@ resource "null_resource" "update_image" {
     command = <<-EOT
       kubectl -n amazon-cloudwatch patch AmazonCloudWatchAgent cloudwatch-agent --type='json' -p='[{"op": "replace", "path": "/spec/image", "value": "${var.cwagent_image_repo}:${var.cwagent_image_tag}"}]'
       kubectl set image deployment/amazon-cloudwatch-observability-controller-manager -n amazon-cloudwatch manager=public.ecr.aws/cloudwatch-agent/cloudwatch-agent-operator:latest
-      kubectl set image daemonset/fluent-bit -n amazon-cloudwatch fluent-bit=506463145083.dkr.ecr.us-west-2.amazonaws.com/fluent-bit-test:latest
       sleep 10
     EOT
   }
@@ -314,7 +313,7 @@ resource "null_resource" "validator" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      echo "Validating CloudWatch Agent and FluentBit with pod identity credential"
+      echo "Validating CloudWatch Agent with pod identity credential"
       cd ../../../../..
       go test ./test/metric_value_benchmark -timeout 1h -eksClusterName=${aws_eks_cluster.this.name} -computeType=EKS -v -eksDeploymentStrategy=PODIDENTITY -instanceId=${data.aws_instance.eks_node_detail.instance_id} &&
       go test ./test/fluent -eksClusterName=${aws_eks_cluster.this.name} -computeType=EKS -v -eksDeploymentStrategy=DAEMON

--- a/terraform/eks/daemon/credentials/pod_identity/providers.tf
+++ b/terraform/eks/daemon/credentials/pod_identity/providers.tf
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+provider "aws" {
+  region = var.region
+}
+
+provider "kubernetes" {
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.this.name]
+  }
+  host                   = aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = aws_eks_cluster.this.endpoint
+    cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority.0.data)
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.this.name]
+      command     = "aws"
+    }
+  }
+}

--- a/terraform/eks/daemon/credentials/pod_identity/variables.tf
+++ b/terraform/eks/daemon/credentials/pod_identity/variables.tf
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "test_dir" {
+  type    = string
+  default = "./test/metric_value_benchmark"
+}
+
+variable "k8s_version" {
+  type    = string
+  default = "1.30"
+}
+
+variable "ami_type" {
+  type    = string
+  default = "AL2_x86_64"
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3a.medium"
+}
+
+variable "helm_chart_branch" {
+  type    = string
+  default = "main"
+}
+
+variable "cwagent_image_repo" {
+  type    = string
+  default = "public.ecr.aws/cloudwatch-agent/cloudwatch-agent"
+}
+
+variable "cwagent_image_tag" {
+  type    = string
+  default = "latest"
+}

--- a/test/metric/container_insights_util.go
+++ b/test/metric/container_insights_util.go
@@ -145,11 +145,30 @@ func validateMetricsAvailability(dims string, expected []string, actual map[stri
 func compareMetrics(expected []string, actual map[string][][]types.Dimension) bool {
 	if len(expected) != len(actual) {
 		log.Printf("the count of fetched metrics do not match with expected count: expected-%v, actual-%v\n", len(expected), len(actual))
+
+		expectedSet := make(map[string]struct{})
+		for _, key := range expected {
+			expectedSet[key] = struct{}{}
+		}
+
+		for key := range actual {
+			if _, exists := expectedSet[key]; !exists {
+				log.Printf("Unexpected metric in actual output : %s\n", key)
+			}
+		}
+
+		// Find missing metrics in expected output
+		for _, key := range expected {
+			if _, exists := actual[key]; !exists {
+				log.Printf("Missing metric in actual output: %s\n", key)
+			}
+		}
 		return false
 	}
 
 	for _, key := range expected {
 		if _, ok := actual[key]; !ok {
+			log.Printf("Missing metric in actual: %s\n", key)
 			return false
 		}
 	}

--- a/test/metric_value_benchmark/eks_daemonset_test.go
+++ b/test/metric_value_benchmark/eks_daemonset_test.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/environment/eksdeploymenttype"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric_value_benchmark/eks_resources"
@@ -31,7 +32,9 @@ type EKSDaemonTestRunner struct {
 
 func (e *EKSDaemonTestRunner) Validate() status.TestGroupResult {
 	var testResults []status.TestResult
-	testResults = append(testResults, metric.ValidateMetrics(e.env, "", eks_resources.GetExpectedDimsToMetrics(e.env))...)
+	if e.env.EksDeploymentStrategy != eksdeploymenttype.PODIDENTITY {
+		testResults = append(testResults, metric.ValidateMetrics(e.env, "", eks_resources.GetExpectedDimsToMetrics(e.env))...)
+	}
 	metrics := e.GetMeasuredMetrics()
 	for _, name := range metrics {
 		testResults = append(testResults, e.validateInstanceMetrics(name))

--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -89,6 +89,16 @@ func getEksTestRunners(env *environment.MetaData) []*test_runner.EKSTestRunner {
 				Env: *env,
 			}
 			eksTestRunners = append(eksTestRunners, &eksDeploymentTestRunner)
+		case eksdeploymenttype.PODIDENTITY:
+			eksDaemonTestRunner := test_runner.EKSTestRunner{
+				Runner: &EKSDaemonTestRunner{BaseTestRunner: test_runner.BaseTestRunner{
+					DimensionFactory: factory,
+				},
+					env: env,
+				},
+				Env: *env,
+			}
+			eksTestRunners = append(eksTestRunners, &eksDaemonTestRunner)
 		}
 	}
 	return eksTestRunners


### PR DESCRIPTION
# Description of the issue
Pod identity credential support is added to CloudWatch Agent and FluentBit, however we lack integration test.

# Description of changes
- Add new terraform folder for credential related testing
- Add new test case when deployment strategy is pod identity. This mode only checks for basic Container Insight metrics that are present on any EKS cluster.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- Integration test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12797706927/job/35689119613. Note that other test failures were there before this change and it is not in scope for fixing as part of this PR.
- integ test run rev2: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12952146544
