### PR TITLE
Fix EKS integration test by removing unnecessary metric

### DIFF
--- a/test/metric_value_benchmark/eks_resources/util.go
+++ b/test/metric_value_benchmark/eks_resources/util.go
@@ -171,7 +171,6 @@ func GetExpectedDimsToMetrics(env *environment.MetaData) map[string][]string {
 			"container_cpu_request",
 			"pod_cpu_usage_total",
 			"pod_memory_working_set",
-			"pod_container_status_waiting_reason_crash_loop_back_off",
 		},
 		"ClusterName-FullPodName-Namespace-PodName": {
 			"pod_network_tx_bytes",
@@ -203,7 +202,6 @@ func GetExpectedDimsToMetrics(env *environment.MetaData) map[string][]string {
 			"pod_cpu_utilization_over_pod_limit",
 			"pod_cpu_usage_total",
 			"pod_memory_working_set",
-			"pod_container_status_waiting_reason_crash_loop_back_off",
 		},
 		"ClusterName-Namespace-PodName": {
 			"pod_interface_network_rx_dropped",
@@ -235,7 +233,6 @@ func GetExpectedDimsToMetrics(env *environment.MetaData) map[string][]string {
 			"pod_memory_limit",
 			"pod_cpu_usage_total",
 			"pod_memory_working_set",
-			"pod_container_status_waiting_reason_crash_loop_back_off",
 		},
 
 		"ClusterName-InstanceId-NodeName": {


### PR DESCRIPTION
# Description of the issue
Our EKS integration test is failing for metric value benchmark.

# Description of changes
We are tracking metric that is not published. Since this is a positive test we won't have crash loop back off status in any of pods so tracking this metric isn't necessary.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Integration test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12813906231
