### PR TITLE
Update EKS 1.24 -> 1.32

### DIFF
--- a/terraform/eks/daemon/app_signals/variables.tf
+++ b/terraform/eks/daemon/app_signals/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/fluent/bit/variables.tf
+++ b/terraform/eks/daemon/fluent/bit/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/fluent/common/variables.tf
+++ b/terraform/eks/daemon/fluent/common/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.32"
 }
 
 // ami_type and instance_type can be used to test ARM node group

--- a/terraform/eks/daemon/fluent/d/variables.tf
+++ b/terraform/eks/daemon/fluent/d/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/fluent/windows/2019/variables.tf
+++ b/terraform/eks/daemon/fluent/windows/2019/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/fluent/windows/2022/variables.tf
+++ b/terraform/eks/daemon/fluent/windows/2022/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/fluent/windows/variables.tf
+++ b/terraform/eks/daemon/fluent/windows/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/statsd/variables.tf
+++ b/terraform/eks/daemon/statsd/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/variables.tf
+++ b/terraform/eks/daemon/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/windows/2019/variables.tf
+++ b/terraform/eks/daemon/windows/2019/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/windows/2022/variables.tf
+++ b/terraform/eks/daemon/windows/2022/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/windows/variables.tf
+++ b/terraform/eks/daemon/windows/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/deployment/variables.tf
+++ b/terraform/eks/deployment/variables.tf
@@ -23,5 +23,5 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.32"
 }


### PR DESCRIPTION
# Description of the issue
EKS 1.24 is on extended support until 1/31/2025. We can no longer create clusters past this date.
Also, EKS 1.32 is now GA.

# Description of changes
Update EKS versions used for our test suite.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A
