### PR TITLE
Fix ECS EMF integration tests

### DIFF
--- a/test/emf/ecs_resources/ec2_launch/daemon/ecs_taskdef.tpl
+++ b/test/emf/ecs_resources/ec2_launch/daemon/ecs_taskdef.tpl
@@ -74,7 +74,7 @@
         "entryPoint": [
             "/bin/sh",
             "-c",
-            "while true; do CURRENT_TIME=\"$(date +%s%3N)\";  CLUSTER_NAME=\"$(curl $${ECS_CONTAINER_METADATA_URI_V4}/task | sed -n 's|.*\\\"Cluster\\\": *\\\"\\([^\\\"]*\\)\\\".*|\\1|p')\"; echo '{\"_aws\":{\"Timestamp\":'\"$${CURRENT_TIME}\"',\"LogGroupName\":\"EMFECSLogGroup\",\"CloudWatchMetrics\":[{\"Namespace\":\"EMFECSNameSpace\",\"Dimensions\":[[\"Type\",\"ClusterName\"]],\"Metrics\":[{\"Name\":\"EMFCounter\",\"Unit\":\"Count\"}]}]},\"Type\":\"Counter\",\"EMFCounter\":5, \"ClusterName\": \"'$${CLUSTER_NAME}'\"}' | nc -u -v -w 0 cloudwatch_agent 25888; sleep 60; done"
+            "while true; do CURRENT_TIME=\"$(date +%s%3N)\";  CLUSTER_NAME=\"$(wget -vO- $${ECS_CONTAINER_METADATA_URI_V4}/task | sed -n 's|.*\\\"Cluster\\\": *\\\"\\([^\\\"]*\\)\\\".*|\\1|p')\"; echo '{\"_aws\":{\"Timestamp\":'\"$${CURRENT_TIME}\"',\"LogGroupName\":\"EMFECSLogGroup\",\"CloudWatchMetrics\":[{\"Namespace\":\"EMFECSNameSpace\",\"Dimensions\":[[\"Type\",\"ClusterName\"]],\"Metrics\":[{\"Name\":\"EMFCounter\",\"Unit\":\"Count\"}]}]},\"Type\":\"Counter\",\"EMFCounter\":5, \"ClusterName\": \"'$${CLUSTER_NAME}'\"}' | nc -u -v -w 0 cloudwatch_agent 25888; sleep 60; done"
         ]
     }
 ]

--- a/test/emf/ecs_resources/ec2_launch/daemon/ecs_taskdef.tpl
+++ b/test/emf/ecs_resources/ec2_launch/daemon/ecs_taskdef.tpl
@@ -74,7 +74,7 @@
         "entryPoint": [
             "/bin/bash",
             "-c",
-            "while true; do CURRENT_TIME=\"$(date +%s%3N)\";  CLUSTER_NAME=\"$(wget -vO- $${ECS_CONTAINER_METADATA_URI_V4}/task | sed -n 's|.*\\\"Cluster\\\": *\\\"\\([^\\\"]*\\)\\\".*|\\1|p')\"; echo '{\"_aws\":{\"Timestamp\":'\"$${CURRENT_TIME}\"',\"LogGroupName\":\"EMFECSLogGroup\",\"CloudWatchMetrics\":[{\"Namespace\":\"EMFECSNameSpace\",\"Dimensions\":[[\"Type\",\"ClusterName\"]],\"Metrics\":[{\"Name\":\"EMFCounter\",\"Unit\":\"Count\"}]}]},\"Type\":\"Counter\",\"EMFCounter\":5, \"ClusterName\": \"'$${CLUSTER_NAME}'\"}' | nc -u -v -w 0 cloudwatch_agent 25888; sleep 60; done"
+            "while true; do CURRENT_TIME=\"$(date +%s%3N)\";  CLUSTER_NAME=\"$(curl $${ECS_CONTAINER_METADATA_URI_V4}/task | sed -n 's|.*\\\"Cluster\\\": *\\\"\\([^\\\"]*\\)\\\".*|\\1|p')\"; echo '{\"_aws\":{\"Timestamp\":'\"$${CURRENT_TIME}\"',\"LogGroupName\":\"EMFECSLogGroup\",\"CloudWatchMetrics\":[{\"Namespace\":\"EMFECSNameSpace\",\"Dimensions\":[[\"Type\",\"ClusterName\"]],\"Metrics\":[{\"Name\":\"EMFCounter\",\"Unit\":\"Count\"}]}]},\"Type\":\"Counter\",\"EMFCounter\":5, \"ClusterName\": \"'$${CLUSTER_NAME}'\"}' | nc -u -v -w 0 cloudwatch_agent 25888; sleep 60; done"
         ]
     }
 ]

--- a/test/emf/ecs_resources/ec2_launch/daemon/ecs_taskdef.tpl
+++ b/test/emf/ecs_resources/ec2_launch/daemon/ecs_taskdef.tpl
@@ -61,7 +61,7 @@
     {
         "name": "emf_container",
         "links":  ["cloudwatch_agent"],
-        "image": "506463145083.dkr.ecr.us-west-2.amazonaws.com/cwagent-integration-test:ubuntu-socat-2.0.0-2",
+        "image": "506463145083.dkr.ecr.us-west-2.amazonaws.com/cwagent-integration-test:linux-amd64",
         "logConfiguration": {
             "logDriver": "awslogs",
             "options": {

--- a/test/emf/ecs_resources/ec2_launch/daemon/ecs_taskdef.tpl
+++ b/test/emf/ecs_resources/ec2_launch/daemon/ecs_taskdef.tpl
@@ -61,7 +61,7 @@
     {
         "name": "emf_container",
         "links":  ["cloudwatch_agent"],
-        "image": "506463145083.dkr.ecr.us-west-2.amazonaws.com/cwagent-integration-test:linux-amd64",
+        "image": "busybox:latest",
         "logConfiguration": {
             "logDriver": "awslogs",
             "options": {
@@ -74,7 +74,7 @@
         "entryPoint": [
             "/bin/sh",
             "-c",
-            "while true; do CURRENT_TIME=\"$(date +%s%3N)\";  CLUSTER_NAME=\"$(curl $${ECS_CONTAINER_METADATA_URI_V4}/task | sed -n 's|.*\\\"Cluster\\\": *\\\"\\([^\\\"]*\\)\\\".*|\\1|p')\"; echo '{\"_aws\":{\"Timestamp\":'\"$${CURRENT_TIME}\"',\"LogGroupName\":\"EMFECSLogGroup\",\"CloudWatchMetrics\":[{\"Namespace\":\"EMFECSNameSpace\",\"Dimensions\":[[\"Type\",\"ClusterName\"]],\"Metrics\":[{\"Name\":\"EMFCounter\",\"Unit\":\"Count\"}]}]},\"Type\":\"Counter\",\"EMFCounter\":5, \"ClusterName\": \"'$${CLUSTER_NAME}'\"}' | socat -v -t 0 - UDP:cloudwatch_agent:25888; sleep 60; done"
+            "while true; do CURRENT_TIME=\"$(date +%s%3N)\";  CLUSTER_NAME=\"$(curl $${ECS_CONTAINER_METADATA_URI_V4}/task | sed -n 's|.*\\\"Cluster\\\": *\\\"\\([^\\\"]*\\)\\\".*|\\1|p')\"; echo '{\"_aws\":{\"Timestamp\":'\"$${CURRENT_TIME}\"',\"LogGroupName\":\"EMFECSLogGroup\",\"CloudWatchMetrics\":[{\"Namespace\":\"EMFECSNameSpace\",\"Dimensions\":[[\"Type\",\"ClusterName\"]],\"Metrics\":[{\"Name\":\"EMFCounter\",\"Unit\":\"Count\"}]}]},\"Type\":\"Counter\",\"EMFCounter\":5, \"ClusterName\": \"'$${CLUSTER_NAME}'\"}' | nc -u -v -w 0 cloudwatch_agent 25888; sleep 60; done"
         ]
     }
 ]

--- a/test/emf/ecs_resources/ec2_launch/daemon/ecs_taskdef.tpl
+++ b/test/emf/ecs_resources/ec2_launch/daemon/ecs_taskdef.tpl
@@ -61,7 +61,7 @@
     {
         "name": "emf_container",
         "links":  ["cloudwatch_agent"],
-        "image": "busybox:latest",
+        "image": "mcr.microsoft.com/devcontainers/base:alpine",
         "logConfiguration": {
             "logDriver": "awslogs",
             "options": {
@@ -72,7 +72,7 @@
         },
         "essential": true,
         "entryPoint": [
-            "/bin/sh",
+            "/bin/bash",
             "-c",
             "while true; do CURRENT_TIME=\"$(date +%s%3N)\";  CLUSTER_NAME=\"$(wget -vO- $${ECS_CONTAINER_METADATA_URI_V4}/task | sed -n 's|.*\\\"Cluster\\\": *\\\"\\([^\\\"]*\\)\\\".*|\\1|p')\"; echo '{\"_aws\":{\"Timestamp\":'\"$${CURRENT_TIME}\"',\"LogGroupName\":\"EMFECSLogGroup\",\"CloudWatchMetrics\":[{\"Namespace\":\"EMFECSNameSpace\",\"Dimensions\":[[\"Type\",\"ClusterName\"]],\"Metrics\":[{\"Name\":\"EMFCounter\",\"Unit\":\"Count\"}]}]},\"Type\":\"Counter\",\"EMFCounter\":5, \"ClusterName\": \"'$${CLUSTER_NAME}'\"}' | nc -u -v -w 0 cloudwatch_agent 25888; sleep 60; done"
         ]


### PR DESCRIPTION
# Description of the issue
Our ECS EMF integration tests are currently failing. This is because the ubuntu socat image referenced in our code no longer exists.  

# Description of changes
The code now references a public alpine image that comes preinstalled with the necessary packages (curl, netcat, bash shell).  

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Integration Test: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13162186862
ECS EMF Test 1: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13162186862/job/36733536164
ECS EMF Test 2: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13162186862/job/36733551094