### PR TITLE
[temp fix] Add cancellation for rebooting instances during tests

### DIFF
--- a/terraform/ec2/common/linux/main.tf
+++ b/terraform/ec2/common/linux/main.tf
@@ -71,10 +71,6 @@ resource "aws_instance" "cwagent" {
     sudo systemctl restart sshd
   EOT
 
-  root_block_device {
-    volume_size = 64
-  }
-
   metadata_options {
     http_endpoint = "enabled"
     http_tokens   = "required"

--- a/terraform/ec2/common/linux/main.tf
+++ b/terraform/ec2/common/linux/main.tf
@@ -71,6 +71,10 @@ resource "aws_instance" "cwagent" {
     sudo systemctl restart sshd
   EOT
 
+  root_block_device {
+    volume_size = 64
+  }
+
   metadata_options {
     http_endpoint = "enabled"
     http_tokens   = "required"

--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -91,8 +91,8 @@ resource "null_resource" "integration_test_run" {
       "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
       "echo run integration test",
       "cd ~/amazon-cloudwatch-agent-test",
+      "nohup bash -c 'while true; do sudo shutdown -c; sleep 60; done' >/dev/null 2>&1 &",
       "echo run sanity test && go test ./test/sanity -p 1 -v",
-      "sudo shutdown -c",
       var.pre_test_setup,
       "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -excludedTests='${var.excluded_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.linux_common.proxy_instance_proxy_ip} -instanceId=${module.linux_common.cwagent_id} ${length(regexall("/amp", var.test_dir)) > 0 ? "-ampWorkspaceId=${module.amp[0].workspace_id} " : ""}-v",
     ]

--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -92,6 +92,7 @@ resource "null_resource" "integration_test_run" {
       "echo run integration test",
       "cd ~/amazon-cloudwatch-agent-test",
       "echo run sanity test && go test ./test/sanity -p 1 -v",
+      "ps -ef | grep reboot",
       var.pre_test_setup,
       "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -excludedTests='${var.excluded_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.linux_common.proxy_instance_proxy_ip} -instanceId=${module.linux_common.cwagent_id} ${length(regexall("/amp", var.test_dir)) > 0 ? "-ampWorkspaceId=${module.amp[0].workspace_id} " : ""}-v",
     ]

--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -92,7 +92,7 @@ resource "null_resource" "integration_test_run" {
       "echo run integration test",
       "cd ~/amazon-cloudwatch-agent-test",
       "echo run sanity test && go test ./test/sanity -p 1 -v",
-      "ps -ef | grep reboot",
+      "sudo shutdown -c",
       var.pre_test_setup,
       "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -excludedTests='${var.excluded_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.linux_common.proxy_instance_proxy_ip} -instanceId=${module.linux_common.cwagent_id} ${length(regexall("/amp", var.test_dir)) > 0 ? "-ampWorkspaceId=${module.amp[0].workspace_id} " : ""}-v",
     ]

--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -91,7 +91,7 @@ resource "null_resource" "integration_test_run" {
       "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
       "echo run integration test",
       "cd ~/amazon-cloudwatch-agent-test",
-      "nohup bash -c 'while true; do sudo shutdown -c; sleep 60; done' >/dev/null 2>&1 &",
+      "nohup bash -c 'while true; do sudo shutdown -c; sleep 30; done' >/dev/null 2>&1 &",
       "echo run sanity test && go test ./test/sanity -p 1 -v",
       var.pre_test_setup,
       "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -excludedTests='${var.excluded_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.linux_common.proxy_instance_proxy_ip} -instanceId=${module.linux_common.cwagent_id} ${length(regexall("/amp", var.test_dir)) > 0 ? "-ampWorkspaceId=${module.amp[0].workspace_id} " : ""}-v",


### PR DESCRIPTION
# Description of the issue
Multiple tests are failing because the instances are being rebooted in the middle of setup or while the test is running, which hides actual failures.

```
null_resource.integration_test_run (remote-exec): Broadcast message from root@ip-XXX-XX-XX-XX.us-west-2.compute.internal (Wed 2025-01-22 01:27:02 UTC):
null_resource.integration_test_run (remote-exec): The system is going down for reboot at Wed 2025-01-22 01:28:02 UTC!
```

# Description of changes
- Add cancellation for rebooting instances during tests (temporary fix that should be removed after root cause)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13212770564
