### PR TITLE
Remove EOL OSes from our test matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-## Amazon CloudWatch Agent Test
+# Amazon CloudWatch Agent Test
 
-Be sure to:
-
-* Edit your repository description on GitHub
+This repository contains related testing code for the [Amazon CloudWatch Agent](https://github.com/aws/amazon-cloudwatch-agent).
 
 ## Security
 

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -4,7 +4,7 @@
     "username": "ubuntu",
     "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go deb",
-    "ami": "cloudwatch-agent-integration-test-ubuntu",
+    "ami": "cloudwatch-agent-integration-test-ubuntu*",
     "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.deb",

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -33,17 +33,6 @@
     "family": "linux"
   },
   {
-    "os": "debian-11",
-    "username": "admin",
-    "instanceType": "c6g.large",
-    "installAgentCommand": "/snap/bin/go run ./install/install_agent.go deb",
-    "ami": "cloudwatch-agent-integration-test-debian-11-arm64*",
-    "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
-    "arc": "arm64",
-    "binaryName": "amazon-cloudwatch-agent.deb",
-    "family": "linux"
-  },
-  {
     "os": "debian-12",
     "username": "admin",
     "instanceType": "c6g.large",
@@ -95,17 +84,6 @@
     "ami": "cloudwatch-agent-integration-test-aarch64-al2023*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
     "arc": "arm64",
-    "binaryName": "amazon-cloudwatch-agent.rpm",
-    "family": "linux"
-  },
-  {
-    "os": "ol7",
-    "username": "ec2-user",
-    "instanceType":"t3a.medium",
-    "installAgentCommand": "go run ./install/install_agent.go rpm",
-    "ami": "cloudwatch-agent-integration-test-ol7*",
-    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
-    "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",
     "family": "linux"
   },

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -4,7 +4,7 @@
     "username": "ubuntu",
     "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go deb",
-    "ami": "cloudwatch-agent-integration-test-ubuntu*",
+    "ami": "cloudwatch-agent-integration-test-ubuntu",
     "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.deb",


### PR DESCRIPTION
# Description of the issue
We have EOL OSes that we no longer support in our integration test matrix

# Description of changes
This PR removes the EOL OSes that are no longer supported

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 

# Tests
_Describe what tests you have done._
