### PR TITLE
[Windows] Update validator install path to C:\\validator.exe

### DIFF
--- a/terraform/ec2/win/main.tf
+++ b/terraform/ec2/win/main.tf
@@ -120,7 +120,7 @@ resource "null_resource" "integration_test_setup_validator" {
   # Install agent binaries
   provisioner "remote-exec" {
     inline = [
-      "aws s3 cp s3://${var.s3_bucket}/integration-test/validator/${var.cwa_github_sha}/windows/${var.arc}/validator.exe .",
+      "aws s3 cp s3://${var.s3_bucket}/integration-test/validator/${var.cwa_github_sha}/windows/${var.arc}/validator.exe C:\\validator.exe",
     ]
   }
 }
@@ -186,7 +186,7 @@ resource "null_resource" "integration_test_run" {
   provisioner "remote-exec" {
     inline = [
       "set AWS_REGION=${var.region}",
-      "validator.exe --test-name=${var.test_dir}"
+      "C:\\validator.exe --test-name=${var.test_dir}"
     ]
   }
 }
@@ -234,9 +234,9 @@ resource "null_resource" "integration_test_run_validator" {
       "cd amazon-cloudwatch-agent-test",
       "go test ./test/sanity -p 1 -v",
       "cd ..",
-      "validator.exe --validator-config=${module.validator.instance_validator_config} --preparation-mode=true",
+      "C:\\validator.exe --validator-config=${module.validator.instance_validator_config} --preparation-mode=true",
       var.use_ssm ? "powershell \"& 'C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1' -a fetch-config -m ec2 -s -c ssm:${local.ssm_parameter_name}\"" : "powershell \"& 'C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1' -a fetch-config -m ec2 -s -c file:${module.validator.instance_agent_config}\"",
-      "validator.exe --validator-config=${module.validator.instance_validator_config} --preparation-mode=false"
+      "C:\\validator.exe --validator-config=${module.validator.instance_validator_config} --preparation-mode=false"
     ]
   }
 }
@@ -305,9 +305,9 @@ resource "null_resource" "integration_test_run_validator_custom_start" {
   provisioner "remote-exec" {
     inline = [
       "set AWS_REGION=${var.region}",
-      "validator.exe --validator-config=${module.validator.instance_validator_config} --preparation-mode=true",
+      "C:\\validator.exe --validator-config=${module.validator.instance_validator_config} --preparation-mode=true",
       "powershell.exe \"& 'C:ProgramFiles\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1' -m ec2 -a status\"",
-      "validator.exe --validator-config=${module.validator.instance_validator_config} --preparation-mode=false"
+      "C:\\validator.exe --validator-config=${module.validator.instance_validator_config} --preparation-mode=false"
     ]
   }
 }


### PR DESCRIPTION
# Description of the issue
Windows integration tests were failing due to being unable find `validator.exe`

# Description of changes
- Updated validator install path to explicit path of C:\\validator.exe
- Updated commands that call validator.exe as well.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Passing tests that are able to run validator.exe
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13461232545/job/37716968400

Previously failing test that could not find validator.exe
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13421207184/job/37494425152

## Screenshot:
<img width="1163" alt="Screenshot 2025-02-24 at 1 52 57 PM" src="https://github.com/user-attachments/assets/e26a2ca0-d285-4505-bbb9-32d800a91fa2" />
