### PR TITLE
[EOL OS] Remove SLES-12 from Test Matrix

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -110,18 +110,6 @@
     "family": "linux"
   },
   {
-    "os": "sles-12",
-    "username": "ec2-user",
-    "instanceType":"t3a.medium",
-    "installAgentCommand": "go run ./install/install_agent.go rpm",
-    "ami": "cloudwatch-agent-integration-test-sles-12*",
-    "caCertPath": "/etc/ssl/ca-bundle.pem",
-    "arc": "amd64",
-    "binaryName": "amazon-cloudwatch-agent.rpm",
-    "family": "linux",
-    "excludedTests": "CollectD"
-  },
-  {
     "os": "sles-15",
     "username": "ec2-user",
     "instanceType":"t3a.medium",


### PR DESCRIPTION
# Description of the issue
We have EOL OSes(sles-12) that we no longer support in our integration test matrix

# Description of changes
This PR removes the EOL OSes(sles-12) that are no longer supported

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._
