### PR TITLE
Add cancellation for rebooting instances during tests for all environments

### DIFF
--- a/terraform/ec2/assume_role/main.tf
+++ b/terraform/ec2/assume_role/main.tf
@@ -204,6 +204,7 @@ resource "null_resource" "integration_test_run" {
       "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
       "echo run integration test",
       "cd ~/amazon-cloudwatch-agent-test",
+      "nohup bash -c 'while true; do sudo shutdown -c; sleep 30; done' >/dev/null 2>&1 &",
       "echo run sanity test && go test ./test/sanity -p 1 -v",
       "echo base assume role arn is ${aws_iam_role.roles["no_context_keys"].arn}",
       "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -assumeRoleArn=${aws_iam_role.roles["no_context_keys"].arn} -instanceArn=${aws_instance.cwagent.arn} -accountId=${data.aws_caller_identity.account_id.account_id} -v"

--- a/terraform/ec2/creds/main.tf
+++ b/terraform/ec2/creds/main.tf
@@ -160,6 +160,7 @@ resource "null_resource" "integration_test_run" {
       "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
       "echo run integration test",
       "cd ~/amazon-cloudwatch-agent-test",
+      "nohup bash -c 'while true; do sudo shutdown -c; sleep 30; done' >/dev/null 2>&1 &",
       "echo run sanity test && go test ./test/sanity -p 1 -v",
       "echo assume role arn is ${aws_iam_role.assume_role.arn}",
       "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -assumeRoleArn=${aws_iam_role.assume_role.arn} -instanceId=${aws_instance.cwagent.id} -v"

--- a/terraform/ec2/linux_onprem/main.tf
+++ b/terraform/ec2/linux_onprem/main.tf
@@ -99,6 +99,7 @@ resource "null_resource" "integration_test_run" {
       "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
       "echo run integration test",
       "cd ~/amazon-cloudwatch-agent-test",
+      "nohup bash -c 'while true; do sudo shutdown -c; sleep 30; done' >/dev/null 2>&1 &",
       "echo run sanity test && go test ./test/sanity -p 1 -v",
       "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -proxyUrl=${module.linux_common.proxy_instance_proxy_ip} -instanceId=${module.linux_common.cwagent_id} -agentStartCommand='${var.agent_start}' -v",
     ]


### PR DESCRIPTION
# Description of the issue
Multiple tests are failing because the instances are being rebooted in the middle of setup or while the test is running, which hides actual failures.

```
null_resource.integration_test_run (remote-exec): Broadcast message from root@ip-XXX-XX-XX-XX.us-west-2.compute.internal (Wed 2025-01-22 01:27:02 UTC):
null_resource.integration_test_run (remote-exec): The system is going down for reboot at Wed 2025-01-22 01:28:02 UTC!
```

# Description of changes
- Add cancellation for rebooting instances during tests (temporary fix that should be removed after root cause)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13212770564
