### PR TITLE
Enhance Test Case Generator with Descriptive Test Names

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -373,7 +373,7 @@ func genMatrix(testType string, testConfigs []testConfig, ami []string) []matrix
 			if row.Os != "" {
 				row.TestName = row.Os + ":" + row.TestName
 			}
-			if row.TestType != "" {
+			if row.TestType != "" && row.Os == "" {
 				row.TestName = row.TestType + ":" + row.TestName
 			}
 			if testConfig.instanceType != "" {

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -10,12 +10,14 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/exp/slices"
 )
 
 type matrixRow struct {
+	TestName            string `json:"testName"`
 	TestDir             string `json:"test_dir"`
 	Os                  string `json:"os"`
 	Family              string `json:"family"`
@@ -319,7 +321,24 @@ func main() {
 		}
 	}
 }
+func generateTestName(test_directory string) string {
+	parts := strings.Split(test_directory, "/")
 
+	// Remove empty parts caused by leading `../`
+	var cleaned []string
+	for _, part := range parts {
+		if part != "" && part != "." && part != ".." {
+			cleaned = append(cleaned, part)
+		}
+	}
+
+	// Reorder: move the first element to the end
+	if len(cleaned) > 1 {
+		cleaned = append(cleaned[1:], cleaned[0])
+	}
+
+	return strings.Join(cleaned, "-")
+}
 func genMatrix(testType string, testConfigs []testConfig, ami []string) []matrixRow {
 	openTestMatrix, err := os.Open(fmt.Sprintf("generator/resources/%v_test_matrix.json", testType))
 
@@ -341,6 +360,7 @@ func genMatrix(testType string, testConfigs []testConfig, ami []string) []matrix
 	for _, test := range testMatrix {
 		for _, testConfig := range testConfigs {
 			row := matrixRow{
+				TestName:     generateTestName(testConfig.testDir),
 				TestDir:      testConfig.testDir,
 				TestType:     testType,
 				TerraformDir: testConfig.terraformDir,
@@ -350,7 +370,9 @@ func genMatrix(testType string, testConfigs []testConfig, ami []string) []matrix
 			if err != nil {
 				log.Panicf("can't decode map test %v to metric line struct with error %v", testConfig, err)
 			}
-
+			if row.Os != "" {
+				row.TestName = row.Os + ":" + row.TestName
+			}
 			if testConfig.instanceType != "" {
 				row.InstanceType = testConfig.instanceType
 			}

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -373,6 +373,9 @@ func genMatrix(testType string, testConfigs []testConfig, ami []string) []matrix
 			if row.Os != "" {
 				row.TestName = row.Os + ":" + row.TestName
 			}
+			if row.TestType != "" {
+				row.TestName = row.TestType + ":" + row.TestName
+			}
 			if testConfig.instanceType != "" {
 				row.InstanceType = testConfig.instanceType
 			}


### PR DESCRIPTION
# Description of the issue
The current implementation of the test case generator does not support generating a descriptive test name for each test case. This makes it difficult to quickly identify the purpose or category of a test from its name. 

# Description of changes
This change introduces a new field `TestName` to the `matrixRow` struct. The `generateTestName` function is added to generate descriptive test names based on the directory structure of the test cases. The test names are further enhanced by prefixing them with the OS and test type when available.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
The changes have been tested by running the `genMatrix` function with various test configurations. The generated test names were verified to ensure they accurately represent the directory structure and include the OS and test type when applicable. 
Test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13663515237