### PR TITLE
Fix the Unrecognized Client exception for China/ITAR tests

### DIFF
--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -131,6 +131,7 @@ func getEc2TestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 		if env.Region == "us-west-2" {
 			ec2TestRunners = append(ec2TestRunners, &test_runner.TestRunner{TestRunner: &EntityMetricsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}})
 		}
+	}
 	return ec2TestRunners
 }
 

--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -109,26 +109,28 @@ func getEc2TestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 		factory := dimension.GetDimensionFactory(*env)
 		ec2TestRunners = []*test_runner.TestRunner{
 			{TestRunner: &StatsdTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &DiskTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &NetStatTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &PrometheusTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &CPUTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &MemTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &ProcStatTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &DiskIOTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &NetTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &EthtoolTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &EMFTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &SwapTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &ProcessesTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &CollectDTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &RenameSSMTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &JMXTomcatJVMTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &JMXKafkaTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &DiskTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &NetStatTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &PrometheusTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &CPUTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &MemTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &ProcStatTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &DiskIOTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &NetTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &EthtoolTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &EMFTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &SwapTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &ProcessesTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &CollectDTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &RenameSSMTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &JMXTomcatJVMTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			// {TestRunner: &JMXKafkaTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 		}
 
 		// Only add EntityMetricsTestRunner if in us-west-2 (we don't have access to ListEntitiesForMetric in CN/ITAR)
+		log.Printf("Region: %v", env.Region)
 		if env.Region == "us-west-2" {
+			log.Printf("adding Entity metrics test runner")
 			ec2TestRunners = append(ec2TestRunners, &test_runner.TestRunner{TestRunner: &EntityMetricsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}})
 		}
 	}

--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -109,28 +109,26 @@ func getEc2TestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 		factory := dimension.GetDimensionFactory(*env)
 		ec2TestRunners = []*test_runner.TestRunner{
 			{TestRunner: &StatsdTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &DiskTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &NetStatTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &PrometheusTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &CPUTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &MemTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &ProcStatTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &DiskIOTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &NetTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &EthtoolTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &EMFTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &SwapTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &ProcessesTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &CollectDTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &RenameSSMTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &JMXTomcatJVMTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			// {TestRunner: &JMXKafkaTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &DiskTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &NetStatTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &PrometheusTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &CPUTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &MemTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &ProcStatTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &DiskIOTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &NetTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &EthtoolTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &EMFTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &SwapTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &ProcessesTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &CollectDTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &RenameSSMTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &JMXTomcatJVMTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			{TestRunner: &JMXKafkaTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 		}
 
 		// Only add EntityMetricsTestRunner if in us-west-2 (we don't have access to ListEntitiesForMetric in CN/ITAR)
-		log.Printf("Region: %v", env.Region)
 		if env.Region == "us-west-2" {
-			log.Printf("adding Entity metrics test runner")
 			ec2TestRunners = append(ec2TestRunners, &test_runner.TestRunner{TestRunner: &EntityMetricsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}})
 		}
 	}

--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -125,9 +125,12 @@ func getEc2TestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 			{TestRunner: &RenameSSMTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &JMXTomcatJVMTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 			{TestRunner: &JMXKafkaTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
-			{TestRunner: &EntityMetricsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
 		}
-	}
+
+		// Only add EntityMetricsTestRunner if in us-west-2 (we don't have access to ListEntitiesForMetric in CN/ITAR)
+		if env.Region == "us-west-2" {
+			ec2TestRunners = append(ec2TestRunners, &test_runner.TestRunner{TestRunner: &EntityMetricsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}})
+		}
 	return ec2TestRunners
 }
 

--- a/util/awsservice/constant.go
+++ b/util/awsservice/constant.go
@@ -6,6 +6,7 @@ package awsservice
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -59,7 +60,13 @@ var (
 func init() {
 	ctx = context.Background()
 
-	err := ConfigureAWSClients("us-west-2")
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		// default to us-west-2
+		region = "us-west-2"
+	}
+
+	err := ConfigureAWSClients(region)
 	if err != nil {
 		fmt.Println("There was an error trying to configure the AWS clients: ", err)
 	}


### PR DESCRIPTION
# Description of the issue
Multiple China/ITAR tests are failing due to an UnrecognizedClientException when calling AWS APIs.

China
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13507749182/job/37741584109#step:7:1326
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13507749182/job/37741587895#step:7:1253
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13507749182/job/37741587403#step:7:2236

ITAR
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13533128422/job/37819655349

# Description of changes
This change configures the AWS clients to use the actual region instead of always defaulting to `us-west-2`. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 

# Tests
Integration test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13725123440
