### PR TITLE
Add UltraServer field to Neuron integ tests

### DIFF
--- a/docs/resources/dummy-neuron-monitor/dummy_neuron_monitor.py
+++ b/docs/resources/dummy-neuron-monitor/dummy_neuron_monitor.py
@@ -18,6 +18,8 @@ def get_instance_labels(instance_info):
         'region': instance_info['instance_region'],
         'subnet_id': instance_info['subnet_id']
     }
+    if 'ultraserver_id' in instance_info:
+        instance_labels['ultraserver_id'] = instance_info['ultraserver_id']
     return instance_labels
 
 
@@ -845,8 +847,8 @@ def update_loop(certfile, keyfile):
                 '"instance_id":"i-09db9b55e0095612f","instance_type":"trn1n.32xlarge",'
                 '"instance_availability_zone":"us-east-1c","instance_availability_zone_id":"use1-az6",'
                 '"instance_region":"us-east-1","ami_id":"ami-030686a4e905e98d3",'
-                '"subnet_id":"subnet-06a7754948e8a000f","error":""},"neuron_hardware_info":{"neuron_device_count":16,'
-                '"neuroncore_per_device_count":2,"error":""}}')
+                '"subnet_id":"subnet-06a7754948e8a000f","ultraserver_id":"u-cafb07773a569a23","error":""},'
+                '"neuron_hardware_info":{"neuron_device_count":16,"neuroncore_per_device_count":2,"error":""}}')
         if len(line) == 0:
             continue
         if original_file_hash:

--- a/test/metric_value_benchmark/eks_resources/test_schemas/container_neuroncore.json
+++ b/test/metric_value_benchmark/eks_resources/test_schemas/container_neuroncore.json
@@ -18,6 +18,7 @@
     "Service": {},
     "Timestamp": {},
     "Type": {},
+    "UltraServer": {},
     "Version": {},
     "availability_zone": {},
     "kubernetes": {},
@@ -44,6 +45,7 @@
     "Service",
     "Timestamp",
     "Type",
+    "UltraServer",
     "Version",
     "CloudWatchMetrics"
   ]

--- a/test/metric_value_benchmark/eks_resources/test_schemas/node_neuron.json
+++ b/test/metric_value_benchmark/eks_resources/test_schemas/node_neuron.json
@@ -11,6 +11,7 @@
     "NodeName": {},
     "Timestamp": {},
     "Type": {},
+    "UltraServer": {},
     "Version": {},
     "availability_zone": {},
     "kubernetes": {},
@@ -27,6 +28,7 @@
     "NodeName",
     "Timestamp",
     "Type",
+    "UltraServer",
     "Version",
     "CloudWatchMetrics"
   ]

--- a/test/metric_value_benchmark/eks_resources/test_schemas/node_neuroncore.json
+++ b/test/metric_value_benchmark/eks_resources/test_schemas/node_neuroncore.json
@@ -14,6 +14,7 @@
     "NodeName": {},
     "Timestamp": {},
     "Type": {},
+    "UltraServer": {},
     "Version": {},
     "availability_zone": {},
     "kubernetes": {},
@@ -36,6 +37,7 @@
     "NodeName",
     "Timestamp",
     "Type",
+    "UltraServer",
     "Version",
     "CloudWatchMetrics"
   ]

--- a/test/metric_value_benchmark/eks_resources/test_schemas/node_neurondevice.json
+++ b/test/metric_value_benchmark/eks_resources/test_schemas/node_neurondevice.json
@@ -12,6 +12,7 @@
     "NodeName": {},
     "Timestamp": {},
     "Type": {},
+    "UltraServer": {},
     "Version": {},
     "availability_zone": {},
     "kubernetes": {},
@@ -28,6 +29,7 @@
     "NodeName",
     "Timestamp",
     "Type",
+    "UltraServer",
     "Version",
     "CloudWatchMetrics"
   ]

--- a/test/metric_value_benchmark/eks_resources/test_schemas/pod_neuroncore.json
+++ b/test/metric_value_benchmark/eks_resources/test_schemas/pod_neuroncore.json
@@ -17,6 +17,7 @@
     "Service": {},
     "Timestamp": {},
     "Type": {},
+    "UltraServer": {},
     "Version": {},
     "availability_zone": {},
     "kubernetes": {},
@@ -43,6 +44,7 @@
     "Service",
     "Timestamp",
     "Type",
+    "UltraServer",
     "Version",
     "CloudWatchMetrics"
   ]


### PR DESCRIPTION
# Description of changes
Updated AWSNeuron integration tests to test for UltraServer changes introduced to the Agent repo

Related Agent PR: https://github.com/aws/amazon-cloudwatch-agent/pull/1571
DO NOT MERGE BEFORE ABOVE PR IS MERGED

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested with [ultraserver-tupperware](https://github.com/aws/amazon-cloudwatch-agent/tree/refs/heads/ultraserver-tupperware) branch in agent repo: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13837935054/job/38718531509#step:7:4075
