### PR TITLE
Bumping time duration of eks integ test

### DIFF
--- a/test/metric_value_benchmark/eks_daemonset_test.go
+++ b/test/metric_value_benchmark/eks_daemonset_test.go
@@ -116,7 +116,7 @@ func (e *EKSDaemonTestRunner) GetAgentConfigFileName() string {
 }
 
 func (e *EKSDaemonTestRunner) GetAgentRunDuration() time.Duration {
-	return time.Minute * 3
+	return time.Minute * 5
 }
 
 func (e *EKSDaemonTestRunner) GetMeasuredMetrics() []string {


### PR DESCRIPTION
# Description of the issue
Test for metric_value_benchmark seems to be flaky because metrics pop up eventually on cloudwatch, increasing time duration from 3->5 minutes.


# Description of changes
Tested locally by running test 20 times, but since tests weren't isolated. Ran terraform apply 10 time in this run:
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13937761021 where test seems to pass and only fail because we have reach IAM role limit.

Test run (has 10 test running - all passing)
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13948719906/job/39042317798
![Screenshot 2025-03-19 at 10 56 34 AM](https://github.com/user-attachments/assets/3e873c0e-e82c-47c3-8360-bd6b4fa9a78c)


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._
