### PR TITLE
Adding endpoint slices permission to Cluster Role

### DIFF
--- a/terraform/eks/daemon/app_signals/main.tf
+++ b/terraform/eks/daemon/app_signals/main.tf
@@ -478,6 +478,11 @@ resource "kubernetes_cluster_role" "clusterrole" {
     resources      = ["configmaps"]
     api_groups     = [""]
   }
+  rule {
+    verbs      = ["list", "watch", "get"]
+    resources  = ["endpointslices"]
+    api_groups = ["discovery.k8s.io"]
+  }
 }
 
 resource "kubernetes_cluster_role_binding" "rolebinding" {

--- a/terraform/eks/daemon/awsneuron/main.tf
+++ b/terraform/eks/daemon/awsneuron/main.tf
@@ -790,6 +790,11 @@ resource "kubernetes_cluster_role" "clusterrole" {
     non_resource_urls = ["/metrics"]
     verbs             = ["get", "list", "watch"]
   }
+  rule {
+    verbs      = ["list", "watch", "get"]
+    resources  = ["endpointslices"]
+    api_groups = ["discovery.k8s.io"]
+  }
 }
 
 resource "kubernetes_cluster_role_binding" "rolebinding" {

--- a/terraform/eks/daemon/efa/main.tf
+++ b/terraform/eks/daemon/efa/main.tf
@@ -489,6 +489,11 @@ resource "kubernetes_cluster_role" "clusterrole" {
     non_resource_urls = ["/metrics"]
     verbs             = ["get", "list", "watch"]
   }
+  rule {
+    verbs      = ["list", "watch", "get"]
+    resources  = ["endpointslices"]
+    api_groups = ["discovery.k8s.io"]
+  }
 }
 
 resource "kubernetes_cluster_role_binding" "rolebinding" {

--- a/terraform/eks/daemon/emf/main.tf
+++ b/terraform/eks/daemon/emf/main.tf
@@ -444,6 +444,11 @@ resource "kubernetes_cluster_role" "clusterrole" {
     resources      = ["configmaps"]
     api_groups     = [""]
   }
+  rule {
+    verbs      = ["list", "watch", "get"]
+    resources  = ["endpointslices"]
+    api_groups = ["discovery.k8s.io"]
+  }
 }
 
 resource "kubernetes_cluster_role_binding" "rolebinding" {

--- a/terraform/eks/daemon/fluent/common/main.tf
+++ b/terraform/eks/daemon/fluent/common/main.tf
@@ -210,6 +210,11 @@ resource "kubernetes_cluster_role" "clusterrole" {
     resources      = ["configmaps"]
     api_groups     = [""]
   }
+  rule {
+    verbs      = ["list", "watch", "get"]
+    resources  = ["endpointslices"]
+    api_groups = ["discovery.k8s.io"]
+  }
 }
 
 resource "kubernetes_cluster_role_binding" "rolebinding" {

--- a/terraform/eks/daemon/fluent/windows/main.tf
+++ b/terraform/eks/daemon/fluent/windows/main.tf
@@ -297,6 +297,11 @@ resource "kubernetes_cluster_role" "clusterrole" {
     resources      = ["configmaps"]
     api_groups     = [""]
   }
+  rule {
+    verbs      = ["list", "watch", "get"]
+    resources  = ["endpointslices"]
+    api_groups = ["discovery.k8s.io"]
+  }
 }
 
 resource "kubernetes_cluster_role_binding" "rolebinding" {

--- a/terraform/eks/daemon/gpu/main.tf
+++ b/terraform/eks/daemon/gpu/main.tf
@@ -683,6 +683,11 @@ resource "kubernetes_cluster_role" "clusterrole" {
     non_resource_urls = ["/metrics"]
     verbs             = ["get", "list", "watch"]
   }
+  rule {
+    verbs      = ["list", "watch", "get"]
+    resources  = ["endpointslices"]
+    api_groups = ["discovery.k8s.io"]
+  }
 }
 
 resource "kubernetes_cluster_role_binding" "rolebinding" {

--- a/terraform/eks/daemon/main.tf
+++ b/terraform/eks/daemon/main.tf
@@ -390,9 +390,9 @@ resource "kubernetes_cluster_role" "clusterrole" {
     api_groups     = [""]
   }
   rule {
-    verbs          = ["list", "watch", "get"]
-    resources      = ["endpointslices"]
-    api_groups     = ["discovery.k8s.io"]
+    verbs      = ["list", "watch", "get"]
+    resources  = ["endpointslices"]
+    api_groups = ["discovery.k8s.io"]
   }
 }
 

--- a/terraform/eks/daemon/main.tf
+++ b/terraform/eks/daemon/main.tf
@@ -389,6 +389,11 @@ resource "kubernetes_cluster_role" "clusterrole" {
     resources      = ["configmaps"]
     api_groups     = [""]
   }
+  rule {
+    verbs          = ["list", "watch", "get"]
+    resources      = ["endpointslices"]
+    api_groups     = ["discovery.k8s.io"]
+  }
 }
 
 resource "kubernetes_cluster_role_binding" "rolebinding" {

--- a/terraform/eks/daemon/statsd/main.tf
+++ b/terraform/eks/daemon/statsd/main.tf
@@ -438,6 +438,11 @@ resource "kubernetes_cluster_role" "clusterrole" {
     resources      = ["configmaps"]
     api_groups     = [""]
   }
+  rule {
+    verbs      = ["list", "watch", "get"]
+    resources  = ["endpointslices"]
+    api_groups = ["discovery.k8s.io"]
+  }
 }
 
 resource "kubernetes_cluster_role_binding" "rolebinding" {

--- a/terraform/eks/daemon/windows/main.tf
+++ b/terraform/eks/daemon/windows/main.tf
@@ -523,6 +523,11 @@ resource "kubernetes_cluster_role" "clusterrole" {
     resources      = ["configmaps"]
     api_groups     = [""]
   }
+  rule {
+    verbs      = ["list", "watch", "get"]
+    resources  = ["endpointslices"]
+    api_groups = ["discovery.k8s.io"]
+  }
 }
 
 resource "kubernetes_cluster_role_binding" "rolebinding" {

--- a/terraform/eks/deployment/main.tf
+++ b/terraform/eks/deployment/main.tf
@@ -380,6 +380,11 @@ resource "kubernetes_cluster_role" "clusterrole" {
     verbs             = ["get"]
     non_resource_urls = ["/metrics"]
   }
+  rule {
+    verbs      = ["list", "watch", "get"]
+    resources  = ["endpointslices"]
+    api_groups = ["discovery.k8s.io"]
+  }
 }
 
 resource "kubernetes_cluster_role_binding" "rolebinding" {


### PR DESCRIPTION
# Description of the issue
We need these extra permissions for cloudwatch-agent-role in order to fix eks_daemon test:
Passing test: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13980738612/job/39145280460

This pr is where the permissions were take from: https://github.com/aws-samples/amazon-cloudwatch-container-insights/pull/188

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._
