### PR TITLE
Fix race condition for ol9 userdata test

### DIFF
--- a/terraform/ec2/userdata/main.tf
+++ b/terraform/ec2/userdata/main.tf
@@ -93,6 +93,7 @@ resource "null_resource" "integration_test" {
         "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
         "echo run integration test",
         "cd ~/amazon-cloudwatch-agent-test",
+        "timeout 60 bash -c 'until [ -f /home/ec2-user/amazon-cloudwatch-agent-test/test/sanity/resources/verifyUnixCtlScript.sh ]; do echo \"Waiting for verifyUnixCtlScript.sh...\"; sleep 2; done'",
         "sudo chmod 777 ~/amazon-cloudwatch-agent-test/test/sanity/resources/verifyUnixCtlScript.sh",
         "echo run sanity test && go test ./test/sanity -p 1 -v",
         "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -v"


### PR DESCRIPTION
# Description of the issue
The ol9-userdata integration test is failing: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13975282090/job/39127808918.

The reason is that it is trying to access the `verifyUnixCtlScript.sh` file before its parent repository, `amazon-cloudwatch-agent-test`, is properly cloned.

The git clone occurs in [template_file.init](https://github.com/aws/amazon-cloudwatch-agent-test/pull/488/files#diff-a7be248a9b77a41abd209a2cf32cc4a4f3fd20974a91c76434a28dad80a90279R121-R131) with the [install_and_start_agent.sh](https://github.com/aws/amazon-cloudwatch-agent-test/blob/6b0a1a77338247831622d0ebe99c339864c7acf1/terraform/ec2/userdata/install_and_start_agent.sh) script.

# Description of changes
- Make sure `null_resource.integration_test` depends on `template_file.init`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
![Workflow Status](https://github.com/aws/amazon-cloudwatch-agent/actions/workflows/integration-test.yml/badge.svg?run_id=14028573129)
[View Workflow Run #14028573129](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14028573129)
