### PR TITLE
Increase timeout for daemon and fluent deployments for Windows

### DIFF
--- a/terraform/eks/daemon/fluent/windows/main.tf
+++ b/terraform/eks/daemon/fluent/windows/main.tf
@@ -580,9 +580,9 @@ resource "null_resource" "fluentbit-windows" {
       chmod +x kubectl
       ./kubectl apply -f ./../../../default_resources/fluenbit-windows-configmap.yaml
       ./kubectl apply -f ./../../../default_resources/fluenbit-windows-daemonset.yaml
-      ./kubectl rollout status daemonset fluent-bit-windows -n amazon-cloudwatch --timeout 600s
+      ./kubectl rollout status daemonset fluent-bit-windows -n amazon-cloudwatch --timeout 1200s
       sed -e 's+WINDOWS_SERVER_VERSION+${var.windows_os_version}+' -e 's+REPLICAS+1+' ./../../../default_resources/test-sample-windows.yaml | ./kubectl apply -f -
-      ./kubectl rollout status deployment windows-test-deployment --timeout 600s
+      ./kubectl rollout status deployment windows-test-deployment --timeout 1200s
       sleep 120
     EOT
   }

--- a/terraform/eks/daemon/windows/main.tf
+++ b/terraform/eks/daemon/windows/main.tf
@@ -445,8 +445,8 @@ resource "null_resource" "windows-cwagent" {
       chmod +x kubectl
       sed 's+CW_TEST_IMAGE+${var.cwagent_image_repo}:${var.cwagent_image_tag}+' ./../../default_resources/cwagent-windows-daemonset.yaml | ./kubectl apply -f -
       sed -e 's+WINDOWS_SERVER_VERSION+${var.windows_os_version}+' -e 's+REPLICAS+1+' ./../../default_resources/test-sample-windows.yaml | ./kubectl apply -f -
-      ./kubectl rollout status daemonset cloudwatch-agent-windows -n amazon-cloudwatch --timeout 600s
-      ./kubectl rollout status deployment windows-test-deployment --timeout 600s
+      ./kubectl rollout status daemonset cloudwatch-agent-windows -n amazon-cloudwatch --timeout 1200s
+      ./kubectl rollout status deployment windows-test-deployment --timeout 1200s
     EOT
   }
 


### PR DESCRIPTION
# Description of the issue
There is a common error for daemon (https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13932872602/job/38994139853) and fluent (https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13980566448/job/39144772679) tests for Windows.
```
error: deployment "windows-test-deployment" exceeded its progress deadline
```

# Description of changes
- Increase the timeout for deployments.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
![Workflow Status](https://github.com/aws/amazon-cloudwatch-agent/actions/workflows/integration-test.yml/badge.svg?run_id=14029002987)
[View Workflow Run #14029002987](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14029002987)
