### PR TITLE
Fix region check for entity metric_value_benchmark test

### DIFF
--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -8,6 +8,7 @@ package metric_value_benchmark
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"testing"
 
@@ -128,7 +129,7 @@ func getEc2TestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 		}
 
 		// Only add EntityMetricsTestRunner if in us-west-2 (we don't have access to ListEntitiesForMetric in CN/ITAR)
-		if env.Region == "us-west-2" {
+		if os.Getenv("AWS_REGION") == "us-west-2" {
 			ec2TestRunners = append(ec2TestRunners, &test_runner.TestRunner{TestRunner: &EntityMetricsTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}})
 		}
 	}


### PR DESCRIPTION
# Description of the issue
The check to see if the region is `us-west-2` does not work as intended.

# Description of changes
This PR fixes the region check.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 

# Tests
Integration test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14043851158/job/39320336163#step:7:3288
