### PR TITLE
Refactor e2e Tests Traffic Generation and Generic Helm Management

### DIFF
--- a/test/e2e/envutils.go
+++ b/test/e2e/envutils.go
@@ -75,7 +75,7 @@ func ApplyResources(k8ctl *utils.K8CtlManager, helm *utils.HelmManager, env *env
 		return err
 	}
 	fmt.Println("Waiting for CloudWatch Agent Operator to initialize...")
-	err := k8ctl.ConditionalWait("--for=condition=available", 60*time.Second, "deployment/amazon-cloudwatch-observability-controller-manager", "amazon-cloudwatch")
+	err := k8ctl.ConditionalWait("--for=condition=available", 2*time.Minute, "deployment/amazon-cloudwatch-observability-controller-manager", "amazon-cloudwatch")
 	if err != nil {
 		return err
 	}

--- a/test/e2e/envutils.go
+++ b/test/e2e/envutils.go
@@ -1,14 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package e2e
 
 import (
 	"fmt"
-	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 	"os"
 	"time"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/e2e/utils"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 )
 
 func InitializeEnvironment(env *environment.MetaData) error {

--- a/test/e2e/envutils.go
+++ b/test/e2e/envutils.go
@@ -1,140 +1,107 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
-
 package e2e
 
 import (
 	"fmt"
+	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
+	"time"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/e2e/utils"
 )
 
-//------------------------------------------------------------------------------
-// Environment Setup
-//------------------------------------------------------------------------------
-
 func InitializeEnvironment(env *environment.MetaData) error {
+	k8ctl := utils.NewK8CtlManager(env)
+	helm := utils.NewHelmManager()
+
+	if env.ComputeType == computetype.EKS {
+		k8ctl.UpdateKubeConfig(env.EKSClusterName)
+	}
+
 	if env.Region != "us-west-2" {
+		// Assume awsservice.ConfigureAWSClients remains unchanged
 		if err := awsservice.ConfigureAWSClients(env.Region); err != nil {
 			return fmt.Errorf("failed to reconfigure AWS clients: %v", err)
 		}
 		fmt.Printf("AWS clients reconfigured to use region: %s\n", env.Region)
 	} else {
-		fmt.Printf("Using default testing region: us-west-2\n")
+		fmt.Println("Using default testing region: us-west-2")
 	}
 
 	fmt.Println("Applying K8s resources...")
-	if err := ApplyResources(env); err != nil {
+	if err := ApplyResources(k8ctl, helm, env); err != nil {
 		return fmt.Errorf("failed to apply K8s resources: %v", err)
 	}
 
 	return nil
 }
 
-//------------------------------------------------------------------------------
-// K8s Resource Management Functions
-//------------------------------------------------------------------------------
-
-func ApplyResources(env *environment.MetaData) error {
-	updateKubeconfig := exec.Command("aws", "eks", "update-kubeconfig", "--name", env.EKSClusterName)
-	output, err := updateKubeconfig.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to update kubeconfig: %w\nOutput: %s", err, output)
+func ApplyResources(k8ctl *utils.K8CtlManager, helm *utils.HelmManager, env *environment.MetaData) error {
+	// Update kubeconfig
+	if err := k8ctl.UpdateKubeConfig(env.EKSClusterName); err != nil {
+		return err
 	}
 
-	fmt.Println("Installing Helm release...")
-	helm := []string{
-		"helm", "upgrade", "--install", "amazon-cloudwatch-observability",
-		filepath.Join("..", "..", "..", "terraform", "eks", "e2e", "helm-charts", "charts", "amazon-cloudwatch-observability"),
-		"--set", fmt.Sprintf("clusterName=%s", env.EKSClusterName),
-		"--set", fmt.Sprintf("region=%s", env.Region),
-		"--set", fmt.Sprintf("agent.image.repository=%s", env.CloudwatchAgentRepository),
-		"--set", fmt.Sprintf("agent.image.tag=%s", env.CloudwatchAgentTag),
-		"--set", fmt.Sprintf("agent.image.repositoryDomainMap.public=%s", env.CloudwatchAgentRepositoryURL),
-		"--set", fmt.Sprintf("manager.image.repository=%s", env.CloudwatchAgentOperatorRepository),
-		"--set", fmt.Sprintf("manager.image.tag=%s", env.CloudwatchAgentOperatorTag),
-		"--set", fmt.Sprintf("manager.image.repositoryDomainMap.public=%s", env.CloudwatchAgentOperatorRepositoryURL),
-		"--namespace", "amazon-cloudwatch",
-		"--create-namespace",
+	// Install Helm chart
+	values := map[string]utils.HelmValue{
+		"clusterName":                              utils.NewHelmValue(env.EKSClusterName),
+		"region":                                   utils.NewHelmValue(env.Region),
+		"agent.image.repository":                   utils.NewHelmValue(env.CloudwatchAgentRepository),
+		"agent.image.tag":                          utils.NewHelmValue(env.CloudwatchAgentTag),
+		"agent.image.repositoryDomainMap.public":   utils.NewHelmValue(env.CloudwatchAgentRepositoryURL),
+		"manager.image.repository":                 utils.NewHelmValue(env.CloudwatchAgentOperatorRepository),
+		"manager.image.tag":                        utils.NewHelmValue(env.CloudwatchAgentOperatorTag),
+		"manager.image.repositoryDomainMap.public": utils.NewHelmValue(env.CloudwatchAgentOperatorRepositoryURL),
 	}
 
 	if env.AgentConfig != "" {
-		agentConfigContent, err := os.ReadFile(env.AgentConfig)
-		if err != nil {
+		if agentConfigContent, err := os.ReadFile(env.AgentConfig); err == nil {
+			values["agent.config"] = utils.HelmValue{
+				Value: string(agentConfigContent),
+				Type:  utils.HelmValueJSON,
+			}
+		} else {
 			return fmt.Errorf("failed to read agent config file: %w", err)
 		}
-		helm = append(helm, "--set-json", fmt.Sprintf("agent.config=%s", string(agentConfigContent)))
 	}
 
-	helmUpgrade := exec.Command(helm[0], helm[1:]...)
-	helmUpgrade.Stdout = os.Stdout
-	helmUpgrade.Stderr = os.Stderr
-	if err := helmUpgrade.Run(); err != nil {
-		return fmt.Errorf("failed to install Helm release: %w", err)
+	if err := helm.InstallOrUpdate("amazon-cloudwatch-observability",
+		"../../../terraform/eks/e2e/helm-charts/charts/amazon-cloudwatch-observability",
+		values, "amazon-cloudwatch"); err != nil {
+		return err
 	}
-
 	fmt.Println("Waiting for CloudWatch Agent Operator to initialize...")
-	wait := exec.Command("kubectl", "wait", "--for=condition=available", "--timeout=60s", "deployment/amazon-cloudwatch-observability-controller-manager", "-n", "amazon-cloudwatch")
-	output, err = wait.CombinedOutput()
+	err := k8ctl.ConditionalWait("--for=condition=available", 60*time.Second, "deployment/amazon-cloudwatch-observability-controller-manager", "amazon-cloudwatch")
 	if err != nil {
-		return fmt.Errorf("failed to wait for operator deployment: %w\nOutput: %s", err, output)
+		return err
 	}
-
-	deploymentName := strings.TrimSuffix(filepath.Base(env.SampleApp), ".yaml")
-
-	apply := exec.Command("kubectl", "apply", "-f", env.SampleApp)
-	output, err = apply.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to apply sample app: %w\nOutput: %s", err, output)
-	}
-
-	fmt.Println("Waiting for Sample Application to initialize...")
-	wait = exec.Command("kubectl", "wait", "--for=condition=available", "--timeout=300s", fmt.Sprintf("deployment/%s", deploymentName), "-n", "test")
-	output, err = wait.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to wait for deployment %s: %w\nOutput: %s", deploymentName, err, output)
+	// Apply sample app
+	if env.SampleApp != "" {
+		if err := k8ctl.ApplyResource(env.SampleApp); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
 func DestroyResources(env *environment.MetaData) error {
-	updateKubeconfig := exec.Command("aws", "eks", "update-kubeconfig", "--name", env.EKSClusterName)
-	output, err := updateKubeconfig.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to update kubeconfig: %w\nOutput: %s", err, output)
+	k8ctl := utils.NewK8CtlManager(env)
+	helm := utils.NewHelmManager()
+	if err := k8ctl.UpdateKubeConfig(env.EKSClusterName); err != nil {
+		return err
 	}
 
-	var errors []error
-
-	fmt.Println("Deleting test namespace...")
-	deleteCmd := exec.Command("kubectl", "delete", "namespace", "test", "--timeout=60s")
-	output, err = deleteCmd.CombinedOutput()
-
-	// We don't want to consider not finding the namespace to be an error since that's the outcome we want
-	if err != nil && !strings.Contains(string(output), "not found") {
-		errors = append(errors, fmt.Errorf("failed to delete test namespace: %w\nOutput: %s", err, output))
+	if env.SampleApp != "" {
+		if err := k8ctl.DeleteResource(env.SampleApp); err != nil {
+			return err
+		}
 	}
 
-	fmt.Println("Uninstalling Helm release...")
-	helm := []string{
-		"helm", "uninstall", "amazon-cloudwatch-observability", "--namespace", "amazon-cloudwatch",
-	}
-
-	helmUninstall := exec.Command(helm[0], helm[1:]...)
-	helmUninstall.Stdout = os.Stdout
-	helmUninstall.Stderr = os.Stderr
-	if err := helmUninstall.Run(); err != nil {
-		errors = append(errors, fmt.Errorf("failed to uninstall Helm release: %w", err))
-	}
-
-	if len(errors) > 0 {
-		return fmt.Errorf("cleanup errors: %v", errors)
+	// Uninstall Helm release
+	if err := helm.Uninstall("amazon-cloudwatch-observability", "amazon-cloudwatch"); err != nil {
+		return err
 	}
 
 	return nil

--- a/test/e2e/jmx/jmx_test.go
+++ b/test/e2e/jmx/jmx_test.go
@@ -200,7 +200,6 @@ func testTomcatMetrics(t *testing.T) {
 
 func testTomcatSessions(t *testing.T) {
 	t.Run("verify_tomcat_sessions", func(t *testing.T) {
-		e2e.GenerateTraffic(t)
 		time.Sleep(e2e.Wait)
 		e2e.VerifyMetricAboveZero(t, "tomcat.sessions", "JVM_TOMCAT_E2E")
 	})
@@ -253,7 +252,6 @@ func testContainerInsightsMetrics(t *testing.T) {
 
 func testTomcatRejectedSessions(t *testing.T) {
 	t.Run("verify_catalina_manager_rejectedsessions", func(t *testing.T) {
-		e2e.GenerateTraffic(t)
 		time.Sleep(e2e.Wait)
 		e2e.VerifyMetricAboveZero(t, "catalina_manager_rejectedsessions", "ContainerInsights/Prometheus")
 	})

--- a/test/e2e/jmx/jmx_test.go
+++ b/test/e2e/jmx/jmx_test.go
@@ -141,6 +141,7 @@ func testAgentResources(t *testing.T, clientset *kubernetes.Clientset) {
 func testJMXResources(t *testing.T, clientset *kubernetes.Clientset) {
 	t.Run("verify_jmx_resources", func(t *testing.T) {
 		deploymentName := strings.TrimSuffix(filepath.Base(env.SampleApp), ".yaml")
+		time.Sleep(e2e.WaitForResourceCreation)
 
 		var jmxTargetSystem string
 		switch filepath.Base(env.AgentConfig) {

--- a/test/e2e/jmx/resources/cwagent_configs/jvm_tomcat.json
+++ b/test/e2e/jmx/resources/cwagent_configs/jvm_tomcat.json
@@ -1,4 +1,7 @@
 {
+  "agent": {
+    "region": "us-west-2"
+  },
   "metrics": {
     "namespace": "JVM_TOMCAT_E2E",
     "metrics_collected": {

--- a/test/e2e/jmx/resources/sample_apps/tomcat.yaml
+++ b/test/e2e/jmx/resources/sample_apps/tomcat.yaml
@@ -9,13 +9,12 @@ metadata:
   name: tomcat-service
   namespace: test
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: tomcat
   ports:
     - port: 80
       targetPort: 8080
-      nodePort: 30080
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -41,3 +40,59 @@ spec:
           image: public.ecr.aws/l9b8e0i6/tomcat:latest
           ports:
             - containerPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: load-generator
+  namespace: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: load-generator
+  template:
+    metadata:
+      labels:
+        app: load-generator
+    spec:
+      containers:
+        - name: load-generator
+          image: grafana/k6
+          command:
+            ["k6", "run", "--duration", "5m", "--vus", "50", "/scripts/test.js"]
+          volumeMounts:
+            - name: k6-scripts
+              mountPath: /scripts
+      volumes:
+        - name: k6-scripts
+          configMap:
+            name: k6-test-scripts
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k6-test-scripts
+  namespace: test
+data:
+  test.js: |
+    import http from 'k6/http';
+    import { check, sleep } from 'k6';
+
+    export const options = {
+        stages: [
+            { duration: '10m', target: 1 } // 1 user for 10 mins
+        ],
+    };
+
+    export default function () {
+        const res = http.get('http://tomcat-service:80/webapp/index.jsp');
+        
+        check(res, {
+            'status is 200': (r) => r.status === 200,
+            'response time < 500ms': (r) => r.timings.duration < 500,
+        });
+        
+        sleep(1); // Pause between iterations
+    }

--- a/test/e2e/testutils.go
+++ b/test/e2e/testutils.go
@@ -6,9 +6,7 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"os/exec"
-	"strings"
+	v1 "k8s.io/api/core/v1"
 	"testing"
 	"time"
 
@@ -24,8 +22,9 @@ import (
 //------------------------------------------------------------------------------
 
 const (
-	Wait     = 5 * time.Minute
-	interval = 30 * time.Second
+	Wait                    = 10 * time.Minute
+	WaitForResourceCreation = 2 * time.Minute
+	interval                = 30 * time.Second
 )
 
 //------------------------------------------------------------------------------
@@ -80,6 +79,14 @@ func VerifyAgentResources(t *testing.T, clientset *kubernetes.Clientset, configK
 	require.NoError(t, err, "Error getting CloudWatch Agent Service Account")
 	require.NotNil(t, serviceAccount, "CloudWatch Agent Service Account not found")
 }
+func GetPodList(t *testing.T, clientset *kubernetes.Clientset, namespace string, name string) v1.PodList {
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app=%s", name),
+	})
+	require.NoError(t, err, "Error getting Pods")
+	return *pods
+
+}
 
 //------------------------------------------------------------------------------
 // Metric Functions
@@ -90,24 +97,6 @@ func ValidateMetrics(t *testing.T, metrics []string, namespace string) {
 		t.Run(metric, func(t *testing.T) {
 			awsservice.ValidateMetricWithTest(t, metric, namespace, nil, 5, interval)
 		})
-	}
-}
-
-func GenerateTraffic(t *testing.T) {
-	cmd := exec.Command("kubectl", "get", "nodes", "-o", "jsonpath='{.items[0].status.addresses[?(@.type==\"ExternalIP\")].address}'")
-	output, err := cmd.CombinedOutput()
-	require.NoError(t, err, "Error getting node external IP")
-
-	nodeIP := strings.Trim(string(output), "'")
-	require.NotEmpty(t, nodeIP, "Node IP failed to format")
-
-	for i := 0; i < 5; i++ {
-		resp, err := http.Get(fmt.Sprintf("http://%s:30080/webapp/index.jsp", nodeIP))
-		if err != nil {
-			t.Logf("Request attempt %d failed: %v", i+1, err)
-			continue
-		}
-		require.NoError(t, resp.Body.Close(), "Failed to close response body")
 	}
 }
 

--- a/test/e2e/testutils.go
+++ b/test/e2e/testutils.go
@@ -6,11 +6,11 @@ package e2e
 import (
 	"context"
 	"fmt"
-	v1 "k8s.io/api/core/v1"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 

--- a/test/e2e/utils/helm_manager.go
+++ b/test/e2e/utils/helm_manager.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package utils
 
 import (

--- a/test/e2e/utils/helm_manager.go
+++ b/test/e2e/utils/helm_manager.go
@@ -1,0 +1,90 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// HelmValueType is a string-based enum for Helm value types
+type HelmValueType string
+
+// Enum values for HelmValueType
+const (
+	HelmValueText HelmValueType = "text" // Default
+	HelmValueJSON HelmValueType = "json"
+)
+
+// IsValid checks if the HelmValueType is a valid enum value
+func (hvt HelmValueType) IsValid() bool {
+	switch hvt {
+	case HelmValueText, HelmValueJSON:
+		return true
+	default:
+		return false
+	}
+}
+
+// HelmManager handles Helm operations.
+type HelmManager struct{}
+
+// NewHelmManager creates a new instance of HelmManager.
+func NewHelmManager() *HelmManager {
+	return &HelmManager{}
+}
+
+// HelmValue represents a Helm chart value with a type
+type HelmValue struct {
+	Value string        `json:"value"`
+	Type  HelmValueType `json:"type,omitempty"`
+}
+
+// NewHelmValue creates a new HelmValue with the given value and default text type
+func NewHelmValue(value string) HelmValue {
+	return HelmValue{
+		Value: value,
+		Type:  HelmValueText,
+	}
+}
+
+// InstallOrUpdate installs or upgrades a Helm release.
+func (h *HelmManager) InstallOrUpdate(releaseName, chartPath string, values map[string]HelmValue, namespace string) error {
+	args := []string{"upgrade", "--install", releaseName, chartPath, "--namespace", namespace, "--create-namespace"}
+
+	// Convert values map to --set flags
+	for key, value := range values {
+		if !value.Type.IsValid() {
+			return fmt.Errorf("invalid helm value type: %s for %s", value.Type, key)
+		}
+		if value.Value == "" {
+			continue
+		}
+		setFlag := "--set"
+		if value.Type == HelmValueJSON {
+			setFlag = "--set-json"
+		}
+		args = append(args, setFlag, fmt.Sprintf("%s=%v", key, value.Value))
+	}
+
+	helmCmd := exec.Command("helm", args...)
+	helmCmd.Stdout = os.Stdout
+	helmCmd.Stderr = os.Stderr
+	if err := helmCmd.Run(); err != nil {
+		return fmt.Errorf("failed to install/update Helm release: %w \n %s", err,
+			strings.Join(helmCmd.Args, " "))
+	}
+
+	return nil
+}
+
+// Uninstall removes a Helm release.
+func (h *HelmManager) Uninstall(releaseName, namespace string) error {
+	helmCmd := exec.Command("helm", "uninstall", releaseName, "--namespace", namespace)
+	helmCmd.Stdout = os.Stdout
+	helmCmd.Stderr = os.Stderr
+	if err := helmCmd.Run(); err != nil {
+		return fmt.Errorf("failed to uninstall Helm release: %w", err)
+	}
+	return nil
+}

--- a/test/e2e/utils/k8s_manager.go
+++ b/test/e2e/utils/k8s_manager.go
@@ -1,11 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package utils
 
 import (
 	"fmt"
-	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 )
 
 // K8CtlManager handles Kubernetes (kubectl or oc) operations.

--- a/test/e2e/utils/k8s_manager.go
+++ b/test/e2e/utils/k8s_manager.go
@@ -1,0 +1,87 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// K8CtlManager handles Kubernetes (kubectl or oc) operations.
+type K8CtlManager struct {
+	Command string // "kubectl" or "oc"
+}
+
+// NewK8CtlManager creates a new instance of K8CtlManager.
+func NewK8CtlManager(env *environment.MetaData) *K8CtlManager {
+	return &K8CtlManager{Command: "kubectl"}
+}
+
+// ApplyResource applies a Kubernetes YAML manifest.
+func (k *K8CtlManager) ApplyResource(manifestPath string) error {
+	cmd := exec.Command(k.Command, "apply", "-f", manifestPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to apply resource: %w\nOutput: %s", err, output)
+	}
+	return nil
+}
+func (k *K8CtlManager) DeleteResource(manifestPath string) error {
+	cmd := exec.Command(k.Command, "delete", "-f", manifestPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to delete resource: %w\nOutput: %s", err, output)
+	}
+	return nil
+}
+
+// DeleteResource deletes a Kubernetes resource.
+func (k *K8CtlManager) DeleteSpecificResource(resourceType, resourceName, namespace string) error {
+	cmd := exec.Command(k.Command, "delete", resourceType, resourceName, "-n", namespace, "--timeout=60s")
+	output, err := cmd.CombinedOutput()
+	if err != nil && !strings.Contains(string(output), "not found") {
+		return fmt.Errorf("failed to delete resource: %w\nOutput: %s", err, output)
+	}
+	return nil
+}
+
+// UpdateKubeConfig updates the kubeconfig for an EKS cluster.
+func (k *K8CtlManager) UpdateKubeConfig(clusterName string) error {
+	if k.Command == "oc" {
+		return nil
+	}
+	cmd := exec.Command("aws", "eks", "update-kubeconfig", "--name", clusterName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to update kubeconfig: %w\nOutput: %s", err, output)
+	}
+	return nil
+}
+
+// ExecuteCommandOnPod runs a command inside a specified pod.
+func (k *K8CtlManager) ExecuteCommandOnPod(podName, namespace string, command []string) (string, error) {
+	cmdArgs := append([]string{"exec", podName, "-n", namespace, "--"}, command...)
+	cmd := exec.Command(k.Command, cmdArgs...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to execute command on pod %s: %w\nOutput: %s", podName, err, output)
+	}
+	return string(output), nil
+}
+func (k *K8CtlManager) Execute(cmdArgs []string) (string, error) {
+	cmd := exec.Command(k.Command, cmdArgs...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to execute command %s: %w\nOutput: %s", err, output)
+	}
+	return string(output), nil
+}
+func (k *K8CtlManager) ConditionalWait(condition string, timeout time.Duration, resource string, namespace string) error {
+	wait := exec.Command(k.Command, "wait", condition, fmt.Sprintf("--timeout=%s", timeout.String()), resource, "-n", namespace)
+	output, err := wait.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to wait for %s: %w\nOutput: %s", resource, err, output)
+	}
+	return nil
+}

--- a/test/e2e/utils/k8s_manager.go
+++ b/test/e2e/utils/k8s_manager.go
@@ -52,9 +52,6 @@ func (k *K8CtlManager) DeleteSpecificResource(resourceType, resourceName, namesp
 
 // UpdateKubeConfig updates the kubeconfig for an EKS cluster.
 func (k *K8CtlManager) UpdateKubeConfig(clusterName string) error {
-	if k.Command == "oc" {
-		return nil
-	}
 	cmd := exec.Command("aws", "eks", "update-kubeconfig", "--name", clusterName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/test/e2e/utils/k8s_manager.go
+++ b/test/e2e/utils/k8s_manager.go
@@ -74,7 +74,7 @@ func (k *K8CtlManager) Execute(cmdArgs []string) (string, error) {
 	cmd := exec.Command(k.Command, cmdArgs...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("failed to execute command %s: %w\nOutput: %s", err, output)
+		return "", fmt.Errorf("failed to execute command %s:\nOutput: %s", err, output)
 	}
 	return string(output), nil
 }


### PR DESCRIPTION
# Description of the issue
This pull request refactors the end-to-end tests in the `amazon-cloudwatch-agent-test` repository. The updates address inconsistencies in resource management and traffic generation, streamline the deployment process with Kubernetes and Helm, and improve test reliability.

# Description of changes
- **Traffic Generation**: Replaced the old `GenerateTraffic` method with k6s, offering a more robust and efficient load generation approach.
- **Helm Management**: Introduced generic Helm management that accepts specific values, simplifying deployments and reducing reliance on hardcoded commands.
- **Service Configuration**: Changed the service type from `NodePort` to `ClusterIP` as it is better suited with k6s for a safer and more controlled testing environment.
- **Resource Application and Destruction**: Refactored `ApplyResources` and `DestroyResources` in `test/e2e/envutils.go` to leverage the new `k8ctl` and `helm` managers for Kubernetes and Helm operations.
- **Agent Configuration**: Updated the `jvm_tomcat.json` configuration to include an `agent` section specifying the AWS region.
- **Test Utilities**: Increased the wait time from 5 to 10 minutes in `test/e2e/testutils.go` to ensure metrics are fully populated and added a new function for retrieving pod lists based on label selectors.
- **New Utility Files**: Added `helm_manager.go` and `k8s_manager.go` to encapsulate Kubernetes and Helm operations.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14136399143
