### PR TITLE
Migrate tool/clean from agent repo

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Verify Terraform version
         run: terraform --version
       - uses: actions/checkout@v3
-      - name: Setup Go 1.19
-        uses: actions/setup-go@v3
+      - name: Setup Go 1.22
+        uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.2
+          go-version: ~1.22.2
       - name: Lint Terraform
         if: runner.os == 'Linux'
         run: cd terraform && make check-fmt

--- a/clean/README.md
+++ b/clean/README.md
@@ -1,0 +1,18 @@
+**What does the cleaner do?**
+
+###Cleaner cleans out old ami (ami older than 60 days)
+
+The cleaner first searches for ami names (these are the ami created by the pipeline for use int he integration tests)
+1. cloudwatch-agent-integration-test*
+
+Then checks to see if the creation date is greater than 60 days. (The aws sdk v2 gives creation date as a pointer to string. To convert to golang time we use the aws smithy go time. This allows us to compare to 60 days in past time)
+
+If the ami is older than 60 days old then we delete the ami
+
+###Cleans dedicated hosts for mac
+
+The cleaner first searches for dedicated host tag Name:IntegrationTestMacDedicatedHost
+
+Then checks to see if the creation date is greater than 26 hours and host status is available
+
+Delete is true

--- a/clean/clean_ami/clean_ami.go
+++ b/clean/clean_ami/clean_ami.go
@@ -1,0 +1,202 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithyTime "github.com/aws/smithy-go/time"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/clean"
+)
+
+// Image Prefixes are taken from checking the Image Builder Pipelines in us-west-2
+var imagePrefixes = []string{
+	"cloudwatch-agent-integration-test-aarch64-al2023",
+	"cloudwatch-agent-integration-test-al2",
+	"cloudwatch-agent-integration-test-alma-linux-8",
+	"cloudwatch-agent-integration-test-alma-linux-9",
+	"cloudwatch-agent-integration-test-arm64-al2",
+	"cloudwatch-agent-integration-test-debian-12-arm64",
+	"cloudwatch-agent-integration-test-nvidia-gpu-al2",
+	"cloudwatch-agent-integration-test-ol8",
+	"cloudwatch-agent-integration-test-ol9",
+	"cloudwatch-agent-integration-test-rocky-linux-8",
+	"cloudwatch-agent-integration-test-rocky-linux-9",
+	"cloudwatch-agent-integration-test-sles-15",
+	"cloudwatch-agent-integration-test-ubuntu-24",
+	"cloudwatch-agent-integration-test-ubuntu",
+	"cloudwatch-agent-integration-test-ubuntu-LTS-22",
+	"cloudwatch-agent-integration-test-win-10",
+	"cloudwatch-agent-integration-test-win-11",
+	"cloudwatch-agent-integration-test-win-2016",
+	"cloudwatch-agent-integration-test-win-2019",
+	"cloudwatch-agent-integration-test-win-2022",
+	"cloudwatch-agent-integration-test-x86-al2023",
+	"cloudwatch-agent-integration-test-mac",
+	"cloudwatch-agent-integration-test-nvidia-gpu",
+}
+
+func main() {
+	err := cleanAMIs()
+	if err != nil {
+		log.Fatalf("errors cleaning %v", err)
+	}
+}
+
+// takes a list of AMIs and sorts them by creation date (youngest to oldest)
+func sortAMIsByCreationDate(amiList []types.Image, errList *[]error) []types.Image {
+	sort.Slice(amiList, func(i, j int) bool {
+		if amiList[i].CreationDate != nil && amiList[j].CreationDate != nil {
+			iCreationDate, iErr := smithyTime.ParseDateTime(*amiList[i].CreationDate)
+			jCreationDate, jErr := smithyTime.ParseDateTime(*amiList[j].CreationDate)
+
+			if err := errors.Join(iErr, jErr); err != nil && errList != nil {
+				*errList = append(*errList, err)
+				return false
+			}
+
+			return iCreationDate.After(jCreationDate)
+		} else {
+			return false
+		}
+	})
+
+	return amiList
+}
+
+// given a slice of AMIs, deregisters them one by one
+func deregisterAMIs(ctx context.Context, ec2client *ec2.Client, images []types.Image, errList *[]error) {
+	for _, image := range images {
+		if image.Name != nil && image.ImageId != nil && image.CreationDate != nil {
+			log.Printf("Try to delete ami %v tags %v image id %v image creation date raw %v", *image.Name, image.Tags, *image.ImageId, *image.CreationDate)
+			deregisterImageInput := &ec2.DeregisterImageInput{ImageId: image.ImageId}
+			_, err := ec2client.DeregisterImage(ctx, deregisterImageInput)
+
+			if err != nil && errList != nil {
+				log.Printf("Error while deregistering ami %v", *image.Name)
+				*errList = append(*errList, err)
+			}
+		}
+	}
+}
+
+// given a map of macos version/architecture to a list of corresponding AMIs, deregister AMIs that are no longer needed
+func cleanMacAMIs(ctx context.Context, ec2client *ec2.Client, macosImageAmiMap map[string][]types.Image, expirationDate time.Time, errList *[]error) {
+	for name, amiList := range macosImageAmiMap {
+		// don't delete an ami if it's the only one for that version/architecture
+		if len(amiList) == 1 {
+			continue
+		}
+
+		// Sort AMIs by creation date (youngest to oldest)
+		amiList = sortAMIsByCreationDate(amiList, errList)
+
+		// find the youngest AMI in the list
+		youngestCreationDate, err := smithyTime.ParseDateTime(aws.ToString(amiList[0].CreationDate))
+
+		if err != nil && errList != nil {
+			*errList = append(*errList, err)
+			continue
+		}
+
+		if expirationDate.After(youngestCreationDate) {
+			// If the youngest AMI is over 60 days old, we keep one (the youngest) and can delete the rest
+			log.Printf("Youngest AMI for %s is over 60 days old. Deleting all but the youngest.", name)
+			deregisterAMIs(ctx, ec2client, amiList[1:], errList)
+		} else {
+			// If the youngest AMI is under 60 days old, keep incrementing until we find AMIs older than 60 days and delete them
+			for index, ami := range amiList {
+				creationDate, err := smithyTime.ParseDateTime(aws.ToString(ami.CreationDate))
+				if err != nil && errList != nil {
+					*errList = append(*errList, err)
+					continue
+				}
+				if expirationDate.After(creationDate) {
+					// once you find the first AMI that's over 60 days old, delete the ones that follow
+					deregisterAMIs(ctx, ec2client, amiList[index:], errList)
+					break
+				}
+			}
+		}
+	}
+}
+
+// given a single non macos image, determine its age and deregister if needed
+func cleanNonMacAMIs(ctx context.Context, ec2client *ec2.Client, image types.Image, expirationDate time.Time, errList *[]error) {
+	creationDate, err := smithyTime.ParseDateTime(aws.ToString(image.CreationDate))
+	if err != nil && errList != nil {
+		*errList = append(*errList, err)
+		return
+	}
+
+	if expirationDate.After(creationDate) {
+		deregisterAMIs(ctx, ec2client, []types.Image{image}, errList)
+	}
+}
+
+func cleanAMIs() error {
+	log.Print("Begin to clean EC2 AMI")
+
+	// sets expiration date to 60 days in the past
+	expirationDate := time.Now().UTC().Add(clean.KeepDurationSixtyDay)
+	log.Printf("Expiration date set as %v", expirationDate)
+
+	// load default config
+	ctx := context.Background()
+	defaultConfig, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return err
+	}
+	ec2client := ec2.NewFromConfig(defaultConfig)
+
+	// stores a list of AMIs per each macos version/architecture
+	macosImageAmiMap := make(map[string][]types.Image)
+
+	// Cleanup for each AMI image type
+	var errList []error
+	for _, filter := range imagePrefixes {
+		nameFilter := types.Filter{Name: aws.String("name"), Values: []string{
+			fmt.Sprintf("%s*", filter),
+		}}
+
+		//get instances to delete
+		describeImagesInput := ec2.DescribeImagesInput{Filters: []types.Filter{nameFilter}}
+		describeImagesOutput, err := ec2client.DescribeImages(ctx, &describeImagesInput)
+		if err != nil {
+			log.Printf("Image filter %s returned an error, skipping :%v", filter, err.Error())
+			continue
+		}
+
+		log.Printf("%s: %d images found", filter, len(describeImagesOutput.Images))
+		if len(describeImagesOutput.Images) <= 1 {
+			log.Printf("1 or less image found for filter %s, skipping", filter)
+			continue
+		}
+
+		for _, image := range describeImagesOutput.Images {
+			if image.Name != nil && filter == "cloudwatch-agent-integration-test-mac" {
+				// mac image - add it to the map and do nothing else for now
+				macosImageAmiMap[*image.Name] = append(macosImageAmiMap[*image.Name], image)
+			} else {
+				// non mac image - clean it if it's older than 60 days
+				cleanNonMacAMIs(ctx, ec2client, image, expirationDate, &errList)
+			}
+		}
+	}
+
+	// handle the mac AMIs
+	cleanMacAMIs(ctx, ec2client, macosImageAmiMap, expirationDate, &errList)
+
+	return nil
+}

--- a/clean/clean_auto_scaling_groups/clean_auto_scaling_groups.go
+++ b/clean/clean_auto_scaling_groups/clean_auto_scaling_groups.go
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/clean"
+)
+
+// Clean eks clusters if they have been open longer than 7 day
+func main() {
+	err := cleanAutoScalingGroups()
+	if err != nil {
+		log.Fatalf("errors cleaning %v", err)
+	}
+}
+
+func cleanAutoScalingGroups() error {
+	log.Print("Begin to clean auto scaling groups Clusters")
+	ctx := context.Background()
+	defaultConfig, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return err
+	}
+	autoScalingClient := autoscaling.NewFromConfig(defaultConfig)
+
+	// filters are and statements not or thus run this 2 times
+	// wilds cards do not work for asg tags unlike ec2
+	ecsFilter := types.Filter{Name: aws.String("tag:BaseClusterName"), Values: []string{
+		"cwagent-integ-test-cluster",
+	}}
+	eksFilter := types.Filter{Name: aws.String("tag:eks:nodegroup-name"), Values: []string{
+		"cwagent-eks-integ-node",
+	}}
+	terminateAutoScaling(ctx, autoScalingClient, ecsFilter)
+	terminateAutoScaling(ctx, autoScalingClient, eksFilter)
+	return nil
+}
+
+func terminateAutoScaling(ctx context.Context, client *autoscaling.Client, filter types.Filter) {
+	expirationDateCluster := time.Now().UTC().Add(clean.KeepDurationOneWeek)
+	describeAutoScalingGroupsInput := autoscaling.DescribeAutoScalingGroupsInput{Filters: []types.Filter{
+		filter,
+	}}
+	describeAutoScalingGroupsOutput, err := client.DescribeAutoScalingGroups(ctx, &describeAutoScalingGroupsInput)
+	if err != nil {
+		log.Fatalf("could not get auto scaling groups")
+	}
+	deletePass := 0
+	deleteFail := 0
+	for _, group := range describeAutoScalingGroupsOutput.AutoScalingGroups {
+		if expirationDateCluster.After(*group.CreatedTime) {
+			log.Printf("try to delete auto scaling group %s", *group.AutoScalingGroupName)
+			deleteAutoScalingGroupInput := autoscaling.DeleteAutoScalingGroupInput{
+				AutoScalingGroupName: group.AutoScalingGroupName,
+				ForceDelete:          aws.Bool(true),
+			}
+			_, err := client.DeleteAutoScalingGroup(ctx, &deleteAutoScalingGroupInput)
+			if err != nil {
+				log.Printf("could not delete auto scaling group %s err %v", *group.AutoScalingGroupName, err)
+				deleteFail++
+			} else {
+				deletePass++
+			}
+		}
+	}
+	log.Printf("was able to delete %d/%d for filter %v", deletePass, deletePass+deleteFail, filter)
+}

--- a/clean/clean_dedicated_host/clean_dedicated_host.go
+++ b/clean/clean_dedicated_host/clean_dedicated_host.go
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/clean"
+)
+
+// Can't release a host if it was being used within the last 24 hr add 2 hr as a buffer
+const tagName = "tag:Name"
+const tagValue = "IntegrationTestMacDedicatedHost"
+
+func main() {
+	err := cleanDedicatedHost()
+	if err != nil {
+		log.Fatalf("errors cleaning %v", err)
+	}
+}
+
+func cleanDedicatedHost() error {
+	log.Print("Begin to clean EC2 Dedicated Host")
+
+	expirationDateDedicatedHost := time.Now().UTC().Add(clean.KeepDurationTwentySixHours)
+	cxt := context.Background()
+	defaultConfig, err := config.LoadDefaultConfig(cxt)
+	if err != nil {
+		return err
+	}
+	ec2client := ec2.NewFromConfig(defaultConfig)
+
+	dedicatedHosts, err := getDedicatedHost(cxt, ec2client)
+	if err != nil {
+		return err
+	}
+
+	dedicatedHostIds := make([]string, 0)
+	for _, dedicatedHost := range dedicatedHosts {
+		log.Printf("dedicated host id %v experation date %v dedicated host creation date raw %v host state %v",
+			*dedicatedHost.HostId, expirationDateDedicatedHost, *dedicatedHost.AllocationTime, dedicatedHost.State)
+		if expirationDateDedicatedHost.After(*dedicatedHost.AllocationTime) && dedicatedHost.State == types.AllocationStateAvailable {
+			log.Printf("Try to delete dedicated host %s tags %v launch-date %s", *dedicatedHost.HostId, dedicatedHost.Tags, *dedicatedHost.AllocationTime)
+			dedicatedHostIds = append(dedicatedHostIds, *dedicatedHost.HostId)
+		}
+	}
+
+	if len(dedicatedHostIds) == 0 {
+		log.Printf("No dedicated hosts to release")
+		return nil
+	}
+
+	log.Printf("Dedicated hosts to release %v", dedicatedHostIds)
+	releaseDedicatedHost := ec2.ReleaseHostsInput{HostIds: dedicatedHostIds}
+	_, err = ec2client.ReleaseHosts(cxt, &releaseDedicatedHost)
+	return err
+}
+
+func getDedicatedHost(cxt context.Context, ec2client *ec2.Client) ([]types.Host, error) {
+	// Get list of dedicated host
+	nameFilter := types.Filter{Name: aws.String(tagName), Values: []string{
+		tagValue,
+	}}
+
+	describeDedicatedHostInput := ec2.DescribeHostsInput{Filter: []types.Filter{nameFilter}}
+	describeDedicatedHostOutput, err := ec2client.DescribeHosts(cxt, &describeDedicatedHostInput)
+	if err != nil {
+		return nil, err
+	}
+	return describeDedicatedHostOutput.Hosts, nil
+}

--- a/clean/clean_ebs/clean_ebs.go
+++ b/clean/clean_ebs/clean_ebs.go
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/clean"
+)
+
+// Clean ebs volumes if they have been open longer than 7 day and unused
+func main() {
+	err := cleanVolumes()
+	if err != nil {
+		log.Fatalf("errors cleaning %v", err)
+	}
+}
+
+func cleanVolumes() error {
+	log.Print("Begin to clean EBS Volumes")
+	ctx := context.Background()
+	defaultConfig, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return err
+	}
+	ec2Client := ec2.NewFromConfig(defaultConfig)
+
+	return deleteUnusedVolumes(ctx, ec2Client)
+
+}
+
+func deleteUnusedVolumes(ctx context.Context, client *ec2.Client) error {
+
+	input := &ec2.DescribeVolumesInput{
+		Filters: []types.Filter{
+			{
+				//if the status is availble, then EBS volume is not currently attached to any ec2 instance (so not being used)
+				Name:   aws.String("status"),
+				Values: []string{"available"},
+			},
+		},
+	}
+
+	volumes, err := client.DescribeVolumes(ctx, input)
+	if err != nil {
+		return err
+	}
+	for _, volume := range volumes.Volumes {
+		if time.Since(*volume.CreateTime) > clean.KeepDurationOneWeek && len(volume.Attachments) == 0 {
+			log.Printf("Deleting unused volume %s", *volume.VolumeId)
+			_, err = client.DeleteVolume(ctx, &ec2.DeleteVolumeInput{
+				VolumeId: volume.VolumeId,
+			})
+		}
+		if err != nil {
+			log.Printf("Error deleting volume %s: %v", *volume.VolumeId, err)
+		}
+	}
+	return nil
+}

--- a/clean/clean_ecs/clean_ecs.go
+++ b/clean/clean_ecs/clean_ecs.go
@@ -1,0 +1,139 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build clean
+// +build clean
+
+package main
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/clean"
+)
+
+// Clean ecs clusters if they have been open longer than 7 day
+func main() {
+	err := cleanCluster()
+	if err != nil {
+		log.Fatalf("errors cleaning %v", err)
+	}
+}
+
+func cleanCluster() error {
+	log.Print("Begin to clean ECS Clusters")
+
+	cxt := context.Background()
+	defaultConfig, err := config.LoadDefaultConfig(cxt)
+	if err != nil {
+		return err
+	}
+	ecsClient := ecs.NewFromConfig(defaultConfig)
+
+	terminateClusters(cxt, ecsClient)
+	return err
+}
+
+func terminateClusters(ctx context.Context, client *ecs.Client) {
+	// you can only filter ecs by name or arn
+	// not regex of tag name like ec2
+	// describe cluster input max is 100
+	ecsListClusterInput := ecs.ListClustersInput{
+		MaxResults: aws.Int32(100),
+	}
+	for {
+		clusterIds := make([]*string, 0)
+		expirationDateCluster := time.Now().UTC().Add(clean.KeepDurationOneWeek)
+		listClusterOutput, err := client.ListClusters(ctx, &ecsListClusterInput)
+		if err != nil || listClusterOutput.ClusterArns == nil || len(listClusterOutput.ClusterArns) == 0 {
+			break
+		}
+		describeClustersInput := ecs.DescribeClustersInput{Clusters: listClusterOutput.ClusterArns}
+		describeClustersOutput, err := client.DescribeClusters(ctx, &describeClustersInput)
+		if err != nil || describeClustersOutput.Clusters == nil || len(describeClustersOutput.Clusters) == 0 {
+			break
+		}
+		for _, cluster := range describeClustersOutput.Clusters {
+			if !strings.HasPrefix(*cluster.ClusterName, "cwagent-integ-test-cluster-") {
+				continue
+			}
+			if cluster.RunningTasksCount == 0 && cluster.PendingTasksCount == 0 {
+				clusterIds = append(clusterIds, cluster.ClusterArn)
+				continue
+			}
+			describeTaskInput := ecs.DescribeTasksInput{Cluster: cluster.ClusterArn}
+			describeTasks, err := client.DescribeTasks(ctx, &describeTaskInput)
+			if err != nil {
+				continue
+			}
+			addCluster := true
+			for _, task := range describeTasks.Tasks {
+				if expirationDateCluster.After(*task.StartedAt) {
+					log.Printf("Task %s launch-date %s", *task.TaskArn, *task.StartedAt)
+				} else {
+					addCluster = false
+					break
+				}
+			}
+			if addCluster {
+				clusterIds = append(clusterIds, cluster.ClusterArn)
+			}
+		}
+		if len(clusterIds) == 0 {
+			log.Printf("No clusters to terminate")
+			return
+		}
+
+		for _, clusterId := range clusterIds {
+			log.Printf("cluster to temrinate %s", *clusterId)
+			listContainerInstanceInput := ecs.ListContainerInstancesInput{Cluster: clusterId}
+			listContainerInstances, err := client.ListContainerInstances(ctx, &listContainerInstanceInput)
+			if err != nil {
+				log.Printf("Error %v getting container instances cluster %s", err, *clusterId)
+				continue
+			}
+			for _, instance := range listContainerInstances.ContainerInstanceArns {
+				deregisterContainerInstanceInput := ecs.DeregisterContainerInstanceInput{
+					ContainerInstance: aws.String(instance),
+					Cluster:           clusterId,
+					Force:             aws.Bool(true),
+				}
+				_, err = client.DeregisterContainerInstance(ctx, &deregisterContainerInstanceInput)
+				if err != nil {
+					log.Printf("Error %v deregister container instances cluster %s container %v", err, *clusterId, instance)
+					continue
+				}
+			}
+			serviceInput := ecs.ListServicesInput{Cluster: clusterId}
+			services, err := client.ListServices(ctx, &serviceInput)
+			if err != nil {
+				log.Printf("Error %v getting services cluster %s", err, *clusterId)
+				continue
+			}
+			for _, service := range services.ServiceArns {
+				deleteServiceInput := ecs.DeleteServiceInput{Cluster: clusterId, Service: aws.String(service)}
+				_, err := client.DeleteService(ctx, &deleteServiceInput)
+				if err != nil {
+					log.Printf("Error %v deleteing service %s cluster %s", err, serviceInput, *clusterId)
+					continue
+				}
+			}
+			terminateClusterInput := ecs.DeleteClusterInput{Cluster: clusterId}
+			_, err = client.DeleteCluster(ctx, &terminateClusterInput)
+			if err != nil {
+				log.Printf("Error %v terminating cluster %s", err, *clusterId)
+			}
+		}
+		if ecsListClusterInput.NextToken == nil {
+			break
+		}
+		ecsListClusterInput.NextToken = listClusterOutput.NextToken
+	}
+}

--- a/clean/clean_eks/clean_eks.go
+++ b/clean/clean_eks/clean_eks.go
@@ -1,0 +1,131 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/clean"
+)
+
+// make this configurable or construct based on some configs?
+const betaEksEndpoint = "https://api.beta.us-west-2.wesley.amazonaws.com"
+
+var (
+	ClustersToClean = []string{
+		"cwagent-eks-integ-",
+		"cwagent-operator-helm-integ-",
+		"cwagent-helm-chart-integ-",
+		"cwagent-operator-eks-integ-",
+		"cwagent-monitoring-config-e2e-eks-",
+		"cwagent-addon-eks-integ-",
+	}
+)
+
+// Clean eks clusters if they have been open longer than 7 day
+func main() {
+	err := cleanCluster()
+	if err != nil {
+		log.Fatalf("errors cleaning %v", err)
+	}
+}
+
+func cleanCluster() error {
+	log.Print("Begin to clean EKS Clusters")
+	ctx := context.Background()
+	defaultConfig, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return err
+	}
+	eksClient := eks.NewFromConfig(defaultConfig)
+	terminateClusters(ctx, eksClient)
+
+	// delete beta clusters
+	betaConfig, err := config.LoadDefaultConfig(ctx, config.WithEndpointResolverWithOptions(eksBetaEndpointResolver()))
+	if err != nil {
+		return err
+	}
+	betaClient := eks.NewFromConfig(betaConfig)
+	terminateClusters(ctx, betaClient)
+
+	return nil
+}
+
+func eksBetaEndpointResolver() aws.EndpointResolverWithOptionsFunc {
+	return func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+		endpoint, err := eks.NewDefaultEndpointResolver().ResolveEndpoint(region, eks.EndpointResolverOptions{})
+		if err != nil {
+			return aws.Endpoint{}, err
+		}
+		endpoint.URL = betaEksEndpoint
+		return endpoint, nil
+	}
+}
+
+func clusterNameMatchesClustersToClean(clusterName string, clustersToClean []string) bool {
+	for _, clusterToClean := range clustersToClean {
+		if strings.HasPrefix(clusterName, clusterToClean) {
+			return true
+		}
+	}
+	return false
+}
+
+func terminateClusters(ctx context.Context, client *eks.Client) {
+	listClusterInput := eks.ListClustersInput{}
+	expirationDateCluster := time.Now().UTC().Add(clean.KeepDurationOneDay)
+
+	clusters, err := client.ListClusters(ctx, &listClusterInput)
+	if err != nil {
+		log.Fatalf("could not get cluster list")
+	}
+	for _, cluster := range clusters.Clusters {
+		describeClusterInput := eks.DescribeClusterInput{Name: aws.String(cluster)}
+		describeClusterOutput, err := client.DescribeCluster(ctx, &describeClusterInput)
+		if err != nil {
+			return
+		}
+		if !expirationDateCluster.After(*describeClusterOutput.Cluster.CreatedAt) {
+			log.Printf("Ignoring cluster %s with a launch-date %s since it was created in the last %s", cluster, *describeClusterOutput.Cluster.CreatedAt, clean.KeepDurationOneDay)
+			continue
+		}
+		if !clusterNameMatchesClustersToClean(*describeClusterOutput.Cluster.Name, ClustersToClean) {
+			log.Printf("Ignoring cluster %s since it doesnt match any of the clean regexes", cluster)
+			continue
+		}
+		log.Printf("Try to delete cluster %s launch-date %s", cluster, *describeClusterOutput.Cluster.CreatedAt)
+		describeNodegroupInput := eks.ListNodegroupsInput{ClusterName: aws.String(cluster)}
+		nodeGroupOutput, err := client.ListNodegroups(ctx, &describeNodegroupInput)
+		if err != nil {
+			log.Printf("could not query node groups cluster %s err %v", cluster, err)
+		}
+		// it takes about 5 minutes to delete node groups
+		// it will fail to delete cluster if we need to delete node groups
+		// this will delete the cluster on next run the next day
+		// I do not want to wait for node groups to be deleted
+		// as it will increase the runtime of this cleaner
+		for _, nodegroup := range nodeGroupOutput.Nodegroups {
+			deleteNodegroupInput := eks.DeleteNodegroupInput{
+				ClusterName:   aws.String(cluster),
+				NodegroupName: aws.String(nodegroup),
+			}
+			_, err := client.DeleteNodegroup(ctx, &deleteNodegroupInput)
+			if err != nil {
+				log.Printf("could not delete node groups %s cluster %s err %v", nodegroup, cluster, err)
+			}
+		}
+		deleteClusterInput := eks.DeleteClusterInput{Name: aws.String(cluster)}
+		_, err = client.DeleteCluster(ctx, &deleteClusterInput)
+		if err != nil {
+			log.Printf("could not delete cluster %s err %v", cluster, err)
+		}
+	}
+}

--- a/clean/clean_file_system/clean_file_system.go
+++ b/clean/clean_file_system/clean_file_system.go
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build clean
+// +build clean
+
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/efs"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/clean"
+)
+
+func main() {
+	log.Printf("Begin to clean EFS resources")
+	expirationDate := time.Now().UTC().Add(clean.KeepDurationOneDay)
+	cxt := context.Background()
+	defaultConfig, err := config.LoadDefaultConfig(cxt)
+	if err != nil {
+		log.Fatalf("Error getting default config %v", err)
+	}
+	efsclient := efs.NewFromConfig(defaultConfig)
+
+	//get efs to delete
+	var nextToken *string
+	fileSystemIdSlice := make([]*string, 0)
+	for {
+		describeFileSystemsInput := efs.DescribeFileSystemsInput{Marker: nextToken}
+		describeFileSystemsOutput, err := efsclient.DescribeFileSystems(cxt, &describeFileSystemsInput)
+		if err != nil {
+			log.Fatalf("Err %v", err)
+		}
+		for _, fileSystem := range describeFileSystemsOutput.FileSystems {
+			if expirationDate.After(*fileSystem.CreationTime) {
+				log.Printf("Trying to delete file system %s launch-date %v", *fileSystem.FileSystemId, fileSystem.CreationTime)
+				if fileSystem.NumberOfMountTargets > 0 {
+					err = deleteMountTargets(cxt, efsclient, fileSystem.FileSystemId)
+				}
+
+				if err == nil {
+					fileSystemIdSlice = append(fileSystemIdSlice, fileSystem.FileSystemId)
+				} else {
+					log.Printf("Unable to delete all the mount targets for %s due to %v", *fileSystem.FileSystemId, err)
+				}
+			}
+		}
+		if describeFileSystemsOutput.NextMarker == nil {
+			break
+		}
+		nextToken = describeFileSystemsOutput.NextMarker
+	}
+	for _, fileSystemId := range fileSystemIdSlice {
+		terminateFileSystemsInput := efs.DeleteFileSystemInput{FileSystemId: fileSystemId}
+		if _, err = efsclient.DeleteFileSystem(cxt, &terminateFileSystemsInput); err != nil {
+			log.Printf("Unable to delete file system %s due to %v", *fileSystemId, err)
+		} else {
+			log.Printf("Deleted file system %s successfully", *fileSystemId)
+		}
+	}
+}
+
+func deleteMountTargets(cxt context.Context, client *efs.Client, fileSystemId *string) error {
+	var marker *string
+	for {
+		dmti := &efs.DescribeMountTargetsInput{Marker: marker, FileSystemId: fileSystemId}
+		dmto, err := client.DescribeMountTargets(cxt, dmti)
+		if err != nil {
+			return err
+		}
+		for _, mountTarget := range dmto.MountTargets {
+			dlmti := &efs.DeleteMountTargetInput{MountTargetId: mountTarget.MountTargetId}
+			if _, err = client.DeleteMountTarget(cxt, dlmti); err != nil {
+				return err
+			}
+			log.Printf("Deleted mount target %s for %s successfully", *mountTarget.MountTargetId, *fileSystemId)
+		}
+		if dmto.Marker == nil {
+			break
+		}
+		marker = dmto.Marker
+	}
+	return nil
+}

--- a/clean/clean_host/clean_host.go
+++ b/clean/clean_host/clean_host.go
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go/aws"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/clean"
+)
+
+// Clean integration hosts if they have been open longer than 1 day
+func main() {
+	err := cleanHost()
+	if err != nil {
+		log.Fatalf("errors cleaning %v", err)
+	}
+}
+
+func cleanHost() error {
+	log.Print("Begin to clean EC2 Host")
+
+	cxt := context.Background()
+	defaultConfig, err := config.LoadDefaultConfig(cxt, config.WithRegion(os.Args[1]))
+	if err != nil {
+		return err
+	}
+	ec2client := ec2.NewFromConfig(defaultConfig)
+
+	terminateInstances(cxt, ec2client)
+	return err
+}
+
+func terminateInstances(cxt context.Context, ec2client *ec2.Client) {
+	maxResults := int32(1000)
+	nameFilter := types.Filter{Name: aws.String("tag:Name"), Values: []string{
+		"buildLinuxPackage",
+		"buildPKG",
+		"buildMSI",
+		"MSIUpgrade_*",
+		"Ec2IntegrationTest",
+		"IntegrationTestBase",
+		"CWADockerImageBuilderX86",
+		"CWADockerImageBuilderARM64",
+		"cwagent-integ-test-ec2*",
+		"cwagent-integ-test-ec2-windows-*",
+		"cwagent-performance-*",
+		"cwagent-stress-*",
+		"LocalStackIntegrationTestInstance",
+		"NvidiaDataCollector-*",
+	}}
+
+	instanceInput := ec2.DescribeInstancesInput{
+		Filters: []types.Filter{
+			nameFilter,
+			{Name: aws.String("instance-state-name"),
+				Values: []string{"running"}}},
+		MaxResults: aws.Int32(maxResults)}
+	for {
+		instanceIds := make([]string, 0)
+		expirationDateInstance := time.Now().UTC().Add(clean.KeepDurationOneDay)
+		describeInstanceOutput, _ := ec2client.DescribeInstances(cxt, &instanceInput)
+		for _, reservation := range describeInstanceOutput.Reservations {
+			for _, instance := range reservation.Instances {
+				log.Printf("instance id %v expiration date %v host creation date raw %v host state %v",
+					*instance.InstanceId, expirationDateInstance, *instance.LaunchTime, instance.State)
+				if expirationDateInstance.After(*instance.LaunchTime) {
+					log.Printf("Try to delete instance %s tags %v launch-date %s", *instance.InstanceId, instance.Tags, *instance.LaunchTime)
+					instanceIds = append(instanceIds, *instance.InstanceId)
+				}
+			}
+		}
+		if len(instanceIds) == 0 {
+			log.Printf("No instances to terminate")
+			return
+		}
+
+		log.Printf("instances to terminate %v", instanceIds)
+		terminateInstance := ec2.TerminateInstancesInput{InstanceIds: instanceIds}
+		_, err := ec2client.TerminateInstances(cxt, &terminateInstance)
+		if err != nil {
+			log.Printf("Error %v terminating instances %v", err, instanceIds)
+		}
+		if describeInstanceOutput.NextToken == nil {
+			break
+		}
+		instanceInput.NextToken = describeInstanceOutput.NextToken
+		// prevent throttle https://docs.aws.amazon.com/AWSEC2/latest/APIReference/throttling.html
+		time.Sleep(time.Minute)
+	}
+}

--- a/clean/clean_iam_roles/clean_iam_roles.go
+++ b/clean/clean_iam_roles/clean_iam_roles.go
@@ -1,0 +1,183 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/clean"
+)
+
+const retentionPeriod = clean.KeepDurationOneWeek
+
+var (
+	roleNamePrefixes = []string{
+		"cwa-integ-assume-role",
+		"cwagent-eks-Worker-Role",
+		"cwagent-integ-test-task-role",
+		"cwagent-integ-test-task-execution-role",
+		"cwagent-operator-eks-Worker-Role",
+		"cwagent-operator-helm-integ-Worker-Role",
+	}
+)
+
+type iamClient interface {
+	ListRoles(ctx context.Context, input *iam.ListRolesInput, optFns ...func(*iam.Options)) (*iam.ListRolesOutput, error)
+	GetRole(ctx context.Context, input *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error)
+	DeleteRole(ctx context.Context, input *iam.DeleteRoleInput, optFns ...func(*iam.Options)) (*iam.DeleteRoleOutput, error)
+	ListAttachedRolePolicies(ctx context.Context, input *iam.ListAttachedRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error)
+	DetachRolePolicy(ctx context.Context, input *iam.DetachRolePolicyInput, optFns ...func(*iam.Options)) (*iam.DetachRolePolicyOutput, error)
+	ListInstanceProfilesForRole(ctx context.Context, input *iam.ListInstanceProfilesForRoleInput, optFns ...func(*iam.Options)) (*iam.ListInstanceProfilesForRoleOutput, error)
+	RemoveRoleFromInstanceProfile(ctx context.Context, input *iam.RemoveRoleFromInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.RemoveRoleFromInstanceProfileOutput, error)
+	DeleteInstanceProfile(ctx context.Context, input *iam.DeleteInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.DeleteInstanceProfileOutput, error)
+}
+
+func main() {
+	log.Print("Begin to clean IAM Roles")
+	ctx := context.Background()
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		log.Fatalf("unable to load AWS config: %v", err)
+	}
+	client := iam.NewFromConfig(cfg)
+	if err = deleteRoles(ctx, client, getExpirationDate()); err != nil {
+		log.Printf("errors cleaning: %v\n", err)
+	}
+}
+
+func getExpirationDate() time.Time {
+	return time.Now().UTC().Add(retentionPeriod)
+}
+
+func deleteRoles(ctx context.Context, client iamClient, expirationDate time.Time) error {
+	var errs error
+	var marker *string
+	for {
+		output, err := client.ListRoles(ctx, &iam.ListRolesInput{Marker: marker})
+		if err != nil {
+			return err
+		}
+		for _, role := range output.Roles {
+			if hasPrefix(*role.RoleName) && expirationDate.After(*role.CreateDate) {
+				var getRoleOutput *iam.GetRoleOutput
+				getRoleOutput, err = client.GetRole(ctx, &iam.GetRoleInput{RoleName: role.RoleName})
+				if err != nil {
+					return err
+				}
+				role = *getRoleOutput.Role
+				if role.RoleLastUsed == nil || role.RoleLastUsed.LastUsedDate == nil || expirationDate.After(*role.RoleLastUsed.LastUsedDate) {
+					errs = errors.Join(errs, deleteRole(ctx, client, role))
+				}
+			}
+		}
+		if output.Marker == nil {
+			break
+		}
+		marker = output.Marker
+	}
+	return errs
+}
+
+func deleteRole(ctx context.Context, client iamClient, role types.Role) error {
+	lastUsed := "never"
+	if role.RoleLastUsed != nil && role.RoleLastUsed.LastUsedDate != nil {
+		lastUsed = fmt.Sprintf("%d days ago", int(time.Since(*role.RoleLastUsed.LastUsedDate).Hours()/24))
+	}
+	log.Printf("Trying to delete role (%q) last used %s", *role.RoleName, lastUsed)
+	if err := detachPolicies(ctx, client, role); err != nil {
+		return err
+	}
+	if err := deleteProfiles(ctx, client, role); err != nil {
+		return err
+	}
+	if _, err := client.DeleteRole(ctx, &iam.DeleteRoleInput{RoleName: role.RoleName}); err != nil {
+		log.Printf("Failed to delete role (%q): %v", *role.RoleName, err)
+		return err
+	}
+	log.Printf("Deleted role (%q) successfully", *role.RoleName)
+	return nil
+}
+
+func detachPolicies(ctx context.Context, client iamClient, role types.Role) error {
+	var marker *string
+	for {
+		output, err := client.ListAttachedRolePolicies(ctx, &iam.ListAttachedRolePoliciesInput{RoleName: role.RoleName, Marker: marker})
+		if err != nil {
+			return err
+		}
+		for _, policy := range output.AttachedPolicies {
+			log.Printf("Trying to detach policy (%q) from role (%q)", *policy.PolicyName, *role.RoleName)
+			if _, err = client.DetachRolePolicy(ctx, &iam.DetachRolePolicyInput{PolicyArn: policy.PolicyArn, RoleName: role.RoleName}); err != nil {
+				log.Printf("Failed to detach policy (%q): %v", *policy.PolicyName, err)
+				return err
+			}
+			log.Printf("Detached policy (%q) from role (%q) successfully", *policy.PolicyName, *role.RoleName)
+		}
+		if output.Marker == nil {
+			break
+		}
+		marker = output.Marker
+	}
+	return nil
+}
+
+func deleteProfiles(ctx context.Context, client iamClient, role types.Role) error {
+	var marker *string
+	for {
+		output, err := client.ListInstanceProfilesForRole(ctx, &iam.ListInstanceProfilesForRoleInput{RoleName: role.RoleName, Marker: marker})
+		if err != nil {
+			return err
+		}
+		for _, profile := range output.InstanceProfiles {
+			if err = deleteProfile(ctx, client, role, profile); err != nil {
+				return err
+			}
+		}
+		if output.Marker == nil {
+			break
+		}
+		marker = output.Marker
+	}
+	return nil
+}
+
+func deleteProfile(ctx context.Context, client iamClient, role types.Role, profile types.InstanceProfile) error {
+	log.Printf("Trying to remove role (%q) from instance profile (%q)", *role.RoleName, *profile.InstanceProfileName)
+	_, err := client.RemoveRoleFromInstanceProfile(ctx, &iam.RemoveRoleFromInstanceProfileInput{
+		InstanceProfileName: profile.InstanceProfileName,
+		RoleName:            role.RoleName,
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("Removed role (%q) from instance profile (%q) successfully", *role.RoleName, *profile.InstanceProfileName)
+	// profile's only role is about to be deleted, so delete it too
+	if len(profile.Roles) == 1 {
+		log.Printf("Trying to delete instance profile (%q) attached to role (%q)", *profile.InstanceProfileName, *role.RoleName)
+		if _, err = client.DeleteInstanceProfile(ctx, &iam.DeleteInstanceProfileInput{InstanceProfileName: profile.InstanceProfileName}); err != nil {
+			log.Printf("Failed to delete instance profile (%q): %v", *profile.InstanceProfileName, err)
+			return err
+		}
+		log.Printf("Deleted instance profile (%q) successfully", *profile.InstanceProfileName)
+	}
+	return nil
+}
+
+func hasPrefix(roleName string) bool {
+	for _, prefix := range roleNamePrefixes {
+		if strings.HasPrefix(roleName, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/clean/clean_iam_roles/clean_iam_roles_test.go
+++ b/clean/clean_iam_roles/clean_iam_roles_test.go
@@ -1,0 +1,141 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+const (
+	expiredTestRoleName = "cwa-integ-assume-role-expired"
+	activeTestRoleName  = "cwagent-integ-test-task-role-active"
+)
+
+type mockIamClient struct {
+	mock.Mock
+}
+
+var _ iamClient = (*mockIamClient)(nil)
+
+func (m *mockIamClient) ListRoles(ctx context.Context, input *iam.ListRolesInput, optFns ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
+	args := m.Called(ctx, input, optFns)
+	return args.Get(0).(*iam.ListRolesOutput), args.Error(1)
+}
+
+func (m *mockIamClient) GetRole(ctx context.Context, input *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
+	args := m.Called(ctx, input, optFns)
+	return args.Get(0).(*iam.GetRoleOutput), args.Error(1)
+}
+
+func (m *mockIamClient) DeleteRole(ctx context.Context, input *iam.DeleteRoleInput, optFns ...func(*iam.Options)) (*iam.DeleteRoleOutput, error) {
+	args := m.Called(ctx, input, optFns)
+	return args.Get(0).(*iam.DeleteRoleOutput), args.Error(1)
+}
+
+func (m *mockIamClient) ListAttachedRolePolicies(ctx context.Context, input *iam.ListAttachedRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error) {
+	args := m.Called(ctx, input, optFns)
+	return args.Get(0).(*iam.ListAttachedRolePoliciesOutput), args.Error(1)
+}
+
+func (m *mockIamClient) DetachRolePolicy(ctx context.Context, input *iam.DetachRolePolicyInput, optFns ...func(*iam.Options)) (*iam.DetachRolePolicyOutput, error) {
+	args := m.Called(ctx, input, optFns)
+	return args.Get(0).(*iam.DetachRolePolicyOutput), args.Error(1)
+}
+
+func (m *mockIamClient) ListInstanceProfilesForRole(ctx context.Context, input *iam.ListInstanceProfilesForRoleInput, optFns ...func(*iam.Options)) (*iam.ListInstanceProfilesForRoleOutput, error) {
+	args := m.Called(ctx, input, optFns)
+	return args.Get(0).(*iam.ListInstanceProfilesForRoleOutput), args.Error(1)
+}
+
+func (m *mockIamClient) RemoveRoleFromInstanceProfile(ctx context.Context, input *iam.RemoveRoleFromInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
+	args := m.Called(ctx, input, optFns)
+	return args.Get(0).(*iam.RemoveRoleFromInstanceProfileOutput), args.Error(1)
+}
+
+func (m *mockIamClient) DeleteInstanceProfile(ctx context.Context, input *iam.DeleteInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.DeleteInstanceProfileOutput, error) {
+	args := m.Called(ctx, input, optFns)
+	return args.Get(0).(*iam.DeleteInstanceProfileOutput), args.Error(1)
+}
+
+func TestDeleteRoles(t *testing.T) {
+	expirationDate := getExpirationDate()
+
+	ctx := context.Background()
+	ignoredRole := types.Role{
+		CreateDate: aws.Time(expirationDate.Add(-2 * time.Hour)),
+		RoleName:   aws.String("does-not-match-any-prefix"),
+		RoleLastUsed: &types.RoleLastUsed{
+			LastUsedDate: aws.Time(expirationDate.Add(-1 * time.Hour)),
+		},
+	}
+	expiredRole := types.Role{
+		CreateDate: aws.Time(expirationDate.Add(-2 * time.Hour)),
+		RoleName:   aws.String(expiredTestRoleName),
+		RoleLastUsed: &types.RoleLastUsed{
+			LastUsedDate: aws.Time(expirationDate.Add(-1 * time.Hour)),
+		},
+	}
+	activeRole := types.Role{
+		CreateDate: aws.Time(expirationDate.Add(-2 * time.Hour)),
+		RoleName:   aws.String(activeTestRoleName),
+		RoleLastUsed: &types.RoleLastUsed{
+			LastUsedDate: aws.Time(expirationDate.Add(time.Hour)),
+		},
+	}
+	testRoles := []types.Role{ignoredRole, expiredRole, activeRole}
+	testPolicies := []types.AttachedPolicy{
+		{
+			PolicyArn:  aws.String("policy-arn"),
+			PolicyName: aws.String("policy-name"),
+		},
+	}
+	testProfile := types.InstanceProfile{
+		InstanceProfileName: aws.String("instance-profile-name"),
+		Roles:               []types.Role{expiredRole},
+	}
+
+	client := &mockIamClient{}
+	client.On("ListRoles", ctx, &iam.ListRolesInput{}, mock.Anything).Return(&iam.ListRolesOutput{Roles: testRoles}, nil)
+	client.On("GetRole", ctx, &iam.GetRoleInput{RoleName: aws.String(expiredTestRoleName)}, mock.Anything).Return(&iam.GetRoleOutput{Role: &expiredRole}, nil)
+	client.On("GetRole", ctx, &iam.GetRoleInput{RoleName: aws.String(activeTestRoleName)}, mock.Anything).Return(&iam.GetRoleOutput{Role: &activeRole}, nil)
+	client.On("DeleteRole", ctx, mock.Anything, mock.Anything).Return(&iam.DeleteRoleOutput{}, nil)
+	client.On("ListAttachedRolePolicies", ctx, mock.Anything, mock.Anything).Return(&iam.ListAttachedRolePoliciesOutput{
+		AttachedPolicies: testPolicies,
+	}, nil)
+	client.On("DetachRolePolicy", ctx, mock.Anything, mock.Anything).Return(&iam.DetachRolePolicyOutput{}, nil)
+	client.On("ListInstanceProfilesForRole", ctx, &iam.ListInstanceProfilesForRoleInput{
+		RoleName: aws.String(expiredTestRoleName),
+	}, mock.Anything).Return(&iam.ListInstanceProfilesForRoleOutput{InstanceProfiles: []types.InstanceProfile{testProfile}}, nil)
+	client.On("RemoveRoleFromInstanceProfile", ctx, &iam.RemoveRoleFromInstanceProfileInput{
+		RoleName:            aws.String(expiredTestRoleName),
+		InstanceProfileName: testProfile.InstanceProfileName,
+	}, mock.Anything).Return(&iam.RemoveRoleFromInstanceProfileOutput{}, nil)
+	client.On("DeleteInstanceProfile", ctx, &iam.DeleteInstanceProfileInput{
+		InstanceProfileName: testProfile.InstanceProfileName,
+	}, mock.Anything).Return(&iam.DeleteInstanceProfileOutput{}, nil)
+	assert.NoError(t, deleteRoles(ctx, client, expirationDate))
+	assert.Len(t, client.Calls, 9)
+	for _, call := range client.Calls {
+		switch call.Method {
+		case "DeleteRole":
+			input := call.Arguments.Get(1).(*iam.DeleteRoleInput)
+			assert.Equal(t, expiredTestRoleName, *input.RoleName)
+		case "ListAttachedRolePolicies":
+			input := call.Arguments.Get(1).(*iam.ListAttachedRolePoliciesInput)
+			assert.Equal(t, expiredTestRoleName, *input.RoleName)
+		case "DetachRolePolicy":
+			input := call.Arguments.Get(1).(*iam.DetachRolePolicyInput)
+			assert.Equal(t, expiredTestRoleName, *input.RoleName)
+			assert.Equal(t, "policy-arn", *input.PolicyArn)
+		}
+	}
+}

--- a/clean/clean_launch_configuration/clean_launch_configuration.go
+++ b/clean/clean_launch_configuration/clean_launch_configuration.go
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/clean"
+)
+
+func main() {
+	err := cleanLaunchConfiguration()
+	if err != nil {
+		log.Fatalf("errors cleaning %v", err)
+	}
+}
+func cleanLaunchConfiguration() error {
+	expirationDate := time.Now().UTC().Add(clean.KeepDurationSixtyDay)
+	ctx := context.Background()
+	defaultConfig, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return err
+	}
+	autoScalingClient := autoscaling.NewFromConfig(defaultConfig)
+	describeLaunchConfigurationsInput := autoscaling.DescribeLaunchConfigurationsInput{}
+	launchConfigOut, err := autoScalingClient.DescribeLaunchConfigurations(ctx, &describeLaunchConfigurationsInput)
+	if err != nil {
+		return err
+	}
+	if len(launchConfigOut.LaunchConfigurations) == 0 {
+		return errors.New("no launch configuration found")
+	}
+	log.Printf("Found %d launch configurations", len(launchConfigOut.LaunchConfigurations))
+	for _, launchConfig := range launchConfigOut.LaunchConfigurations {
+		log.Printf("Found %s with creation date: %v", *launchConfig.LaunchConfigurationName, *launchConfig.CreatedTime)
+		// if not cwagent-integ-test ignore it
+		if !strings.Contains(*launchConfig.LaunchConfigurationName, "integ") {
+			continue
+		}
+		if expirationDate.After(*launchConfig.CreatedTime) {
+			log.Printf("Try to delete %s", *launchConfig.LaunchConfigurationName)
+			_, err := autoScalingClient.DeleteLaunchConfiguration(ctx, &autoscaling.DeleteLaunchConfigurationInput{
+				LaunchConfigurationName: launchConfig.LaunchConfigurationName,
+			})
+			if err != nil {
+				return err
+			}
+			log.Printf("Succesfully deleted %s", *launchConfig.LaunchConfigurationName)
+		}
+	}
+	return nil
+}

--- a/clean/clean_log_group/clean_log_group.go
+++ b/clean/clean_log_group/clean_log_group.go
@@ -1,0 +1,286 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/clean"
+)
+
+type cloudwatchlogsClient interface {
+	DeleteLogGroup(ctx context.Context, params *cloudwatchlogs.DeleteLogGroupInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DeleteLogGroupOutput, error)
+	DescribeLogGroups(ctx context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
+	DescribeLogStreams(ctx context.Context, params *cloudwatchlogs.DescribeLogStreamsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogStreamsOutput, error)
+}
+
+const (
+	LogGroupProcessChanSize = 500
+)
+
+// Config holds the application configuration
+type Config struct {
+	creationThreshold time.Duration
+	inactiveThreshold time.Duration
+	numWorkers        int
+	deleteBatchCap    int
+	exceptionList     []string
+	dryRun            bool
+}
+
+// Global configuration
+var (
+	cfg Config
+)
+
+func init() {
+	// Set default configuration
+	cfg = Config{
+		creationThreshold: 3 * clean.KeepDurationOneDay,
+		inactiveThreshold: 1 * clean.KeepDurationOneDay,
+		numWorkers:        15,
+		exceptionList:     []string{"lambda"},
+		dryRun:            true,
+	}
+
+}
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+	// Parse command line flags
+	flag.BoolVar(&cfg.dryRun, "dry-run", false, "Enable dry-run mode (no actual deletion)")
+	flag.Parse()
+	// Load AWS configuration
+	awsCfg, err := loadAWSConfig(ctx)
+	if err != nil {
+		log.Fatalf("Error loading AWS config: %v", err)
+	}
+
+	// Create CloudWatch Logs client
+	client := cloudwatchlogs.NewFromConfig(awsCfg)
+
+	// Compute cutoff times
+	cutoffTimes := calculateCutoffTimes()
+
+	log.Printf("🔍 Searching for CloudWatch Log Groups older than %d days AND inactive for %d days in %s region\n",
+		cfg.creationThreshold, cfg.inactiveThreshold, awsCfg.Region)
+
+	// Delete old log groups
+	deletedGroups := deleteOldLogGroups(ctx, client, cutoffTimes)
+	log.Printf("Total log groups deleted: %d", len(deletedGroups))
+}
+
+type cutoffTimes struct {
+	creation int64
+	inactive int64
+}
+
+func calculateCutoffTimes() cutoffTimes {
+	return cutoffTimes{
+		creation: time.Now().Add(cfg.creationThreshold).UnixMilli(),
+		inactive: time.Now().Add(cfg.inactiveThreshold).UnixMilli(),
+	}
+}
+
+func loadAWSConfig(ctx context.Context) (aws.Config, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("loading AWS config: %w", err)
+	}
+	cfg.RetryMode = aws.RetryModeAdaptive
+	return cfg, nil
+}
+
+func deleteOldLogGroups(ctx context.Context, client cloudwatchlogsClient, times cutoffTimes) []string {
+	var (
+		wg                      sync.WaitGroup
+		deletedLogGroup         []string
+		foundLogGroupChan       = make(chan *types.LogGroup, LogGroupProcessChanSize)
+		deletedLogGroupNameChan = make(chan string, LogGroupProcessChanSize)
+		handlerWg               sync.WaitGroup
+	)
+
+	// Start worker pool
+	log.Printf("👷 Creating %d workers\n", cfg.numWorkers)
+	for i := 0; i < cfg.numWorkers; i++ {
+		wg.Add(1)
+		w := worker{
+			id:                   i,
+			wg:                   &wg,
+			incomingLogGroupChan: foundLogGroupChan,
+			deletedLogGroupChan:  deletedLogGroupNameChan,
+			times:                times,
+		}
+		go w.processLogGroup(ctx, client)
+	}
+
+	// Start handler with its own WaitGroup
+	handlerWg.Add(1)
+	go func() {
+		handleDeletedLogGroups(&deletedLogGroup, deletedLogGroupNameChan)
+		handlerWg.Done()
+	}()
+
+	// Process log groups in batches
+	if err := fetchAndProcessLogGroups(ctx, client, foundLogGroupChan); err != nil {
+		log.Printf("Error processing log groups: %v", err)
+	}
+
+	close(foundLogGroupChan)
+	wg.Wait()
+	close(deletedLogGroupNameChan)
+	handlerWg.Wait()
+
+	return deletedLogGroup
+}
+
+func handleDeletedLogGroups(deletedLogGroups *[]string, deletedLogGroupNameChan chan string) {
+	for logGroupName := range deletedLogGroupNameChan {
+		*deletedLogGroups = append(*deletedLogGroups, logGroupName)
+		log.Printf("🔍 Processed %d log groups so far\n", len(*deletedLogGroups))
+	}
+}
+
+type worker struct {
+	id                   int
+	wg                   *sync.WaitGroup
+	incomingLogGroupChan <-chan *types.LogGroup
+	deletedLogGroupChan  chan<- string
+	times                cutoffTimes
+}
+
+func (w *worker) processLogGroup(ctx context.Context, client cloudwatchlogsClient) {
+	defer w.wg.Done()
+
+	for logGroup := range w.incomingLogGroupChan {
+		if err := w.handleLogGroup(ctx, client, logGroup); err != nil {
+			log.Printf("Worker %d: Error processing log group: %v", w.id, err)
+		}
+	}
+}
+
+func (w *worker) handleLogGroup(ctx context.Context, client cloudwatchlogsClient, logGroup *types.LogGroup) error {
+	if logGroup.CreationTime == nil {
+		return fmt.Errorf("log group has no creation time: %v", logGroup)
+	}
+
+	logGroupName := *logGroup.LogGroupName
+	creationTime := *logGroup.CreationTime
+
+	if creationTime >= w.times.creation {
+		return nil
+	}
+
+	lastLogTime := getLastLogEventTime(ctx, client, logGroupName)
+	if lastLogTime == 0 {
+		return nil
+	}
+
+	if lastLogTime < w.times.inactive {
+		log.Printf("🚨 Worker: %d| Old & Inactive Log Group: %s (Created: %v, Last Event: %v)\n",
+			w.id, logGroupName, time.Unix(creationTime, 0), time.Unix(lastLogTime, 0))
+
+		w.deletedLogGroupChan <- logGroupName
+
+		if cfg.dryRun {
+			log.Printf("🛑 Dry-Run: Would delete log group: %s", logGroupName)
+			return nil
+		}
+
+		return deleteLogGroup(ctx, client, logGroupName)
+	}
+
+	return nil
+}
+
+func deleteLogGroup(ctx context.Context, client cloudwatchlogsClient, logGroupName string) error {
+	_, err := client.DeleteLogGroup(ctx, &cloudwatchlogs.DeleteLogGroupInput{
+		LogGroupName: aws.String(logGroupName),
+	})
+	if err != nil {
+		return fmt.Errorf("deleting log group %s: %w", logGroupName, err)
+	}
+	log.Printf("✅ Deleted log group: %s", logGroupName)
+	return nil
+}
+
+func fetchAndProcessLogGroups(ctx context.Context, client cloudwatchlogsClient,
+	logGroupChan chan<- *types.LogGroup) error {
+
+	var nextToken *string
+	describeCount := 0
+
+	for {
+		output, err := client.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return fmt.Errorf("describing log groups: %w", err)
+		}
+
+		log.Printf("🔍 Described %d times | Found %d log groups\n", describeCount, len(output.LogGroups))
+
+		for _, logGroup := range output.LogGroups {
+			if isLogGroupException(*logGroup.LogGroupName) {
+				log.Printf("⏭️ Skipping Log Group: %s (in exception list)\n", *logGroup.LogGroupName)
+				continue
+			}
+			logGroupChan <- &logGroup
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		nextToken = output.NextToken
+		describeCount++
+	}
+
+	return nil
+}
+
+func getLastLogEventTime(ctx context.Context, client cloudwatchlogsClient, logGroupName string) int64 {
+	var latestTimestamp int64
+	latestTimestamp = 0
+	output, err := client.DescribeLogStreams(ctx, &cloudwatchlogs.DescribeLogStreamsInput{
+		LogGroupName: aws.String(logGroupName),
+		OrderBy:      types.OrderByLastEventTime,
+		Descending:   aws.Bool(true),
+	})
+	if err != nil {
+		log.Printf("⚠️ Warning: Failed to retrieve log streams for %s: %v\n", logGroupName, err)
+		return 0
+	}
+	if len(output.LogStreams) == 0 {
+		return 0
+	}
+	stream := output.LogStreams[0]
+
+	if stream.LastEventTimestamp != nil && *stream.LastEventTimestamp > latestTimestamp {
+		latestTimestamp = *stream.LastEventTimestamp
+	}
+
+	return latestTimestamp
+}
+
+func isLogGroupException(logGroupName string) bool {
+	for _, exception := range cfg.exceptionList {
+		if strings.Contains(logGroupName, exception) {
+			return true
+		}
+	}
+	return false
+}

--- a/clean/clean_log_group/clean_log_group_test.go
+++ b/clean/clean_log_group/clean_log_group_test.go
@@ -1,0 +1,286 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+// main_test.go
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/clean"
+)
+
+// MockCloudWatchLogsClient is a stub for cloudwatchlogs.Client
+type MockCloudWatchLogsClient struct {
+	mock.Mock
+}
+
+var _ cloudwatchlogsClient = (*MockCloudWatchLogsClient)(nil)
+
+func (m *MockCloudWatchLogsClient) DescribeLogGroups(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+	args := m.Called(ctx, input, optFns)
+	return args.Get(0).(*cloudwatchlogs.DescribeLogGroupsOutput), args.Error(1)
+}
+
+func (m *MockCloudWatchLogsClient) DeleteLogGroup(ctx context.Context, input *cloudwatchlogs.DeleteLogGroupInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DeleteLogGroupOutput, error) {
+	args := m.Called(ctx, input, optFns)
+	return args.Get(0).(*cloudwatchlogs.DeleteLogGroupOutput), args.Error(1)
+}
+
+func (m *MockCloudWatchLogsClient) DescribeLogStreams(ctx context.Context, input *cloudwatchlogs.DescribeLogStreamsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogStreamsOutput, error) {
+	args := m.Called(ctx, input, optFns)
+	return args.Get(0).(*cloudwatchlogs.DescribeLogStreamsOutput), args.Error(1)
+}
+
+// Test getLastLogEventTime simulating multiple pages of log streams.
+func TestGetLastLogEventTime(t *testing.T) {
+	mockClient := new(MockCloudWatchLogsClient)
+
+	// Create two pages of responses
+	firstPage := &cloudwatchlogs.DescribeLogStreamsOutput{
+		LogStreams: []types.LogStream{
+			{LastEventTimestamp: aws.Int64(1000)},
+			{LastEventTimestamp: aws.Int64(1500)},
+		},
+		NextToken: aws.String("token1"),
+	}
+	secondPage := &cloudwatchlogs.DescribeLogStreamsOutput{
+		LogStreams: []types.LogStream{
+			{LastEventTimestamp: aws.Int64(2000)},
+			{LastEventTimestamp: aws.Int64(1800)},
+		},
+		NextToken: nil,
+	}
+
+	// Set up expectations for the two API calls
+	mockClient.On("DescribeLogStreams",
+		mock.Anything,
+		&cloudwatchlogs.DescribeLogStreamsInput{
+			LogGroupName: aws.String("dummy-log-group"),
+			OrderBy:      types.OrderByLastEventTime,
+			Descending:   aws.Bool(true),
+			NextToken:    nil,
+		},
+		mock.Anything).Return(firstPage, nil).Once()
+
+	mockClient.On("DescribeLogStreams",
+		mock.Anything,
+		&cloudwatchlogs.DescribeLogStreamsInput{
+			LogGroupName: aws.String("dummy-log-group"),
+			OrderBy:      types.OrderByLastEventTime,
+			Descending:   aws.Bool(true),
+			NextToken:    aws.String("token1"),
+		},
+		mock.Anything).Return(secondPage, nil).Once()
+
+	lastEventTime := getLastLogEventTime(context.Background(), mockClient, "dummy-log-group")
+
+	assert.Equal(t, int64(2000), lastEventTime)
+	mockClient.AssertExpectations(t)
+}
+func testHandleLogGroup(cfg Config, logGroupName string, logCreationDate, logStreamCreationDate int) ([]string, error) {
+	cfg.dryRun = true // Prevent actual deletion.
+
+	// Calculate cutoffs relative to now.
+	now := time.Now()
+	times := cutoffTimes{
+		creation: now.Add(cfg.creationThreshold).UnixMilli(),
+		inactive: now.Add(cfg.inactiveThreshold).UnixMilli(),
+	}
+	// Create a dummy log group.
+	creationTime := now.AddDate(0, 0, -logCreationDate).UnixMilli()
+	logGroup := &types.LogGroup{
+		LogGroupName: aws.String(logGroupName),
+		CreationTime: aws.Int64(creationTime),
+	}
+
+	mockClient := new(MockCloudWatchLogsClient)
+
+	// Set up expectation for DescribeLogStreams
+	mockClient.On("DescribeLogStreams",
+		mock.Anything,
+		&cloudwatchlogs.DescribeLogStreamsInput{
+			LogGroupName: aws.String(logGroupName),
+			OrderBy:      types.OrderByLastEventTime,
+			Descending:   aws.Bool(true),
+			NextToken:    nil,
+		},
+		mock.Anything).Return(&cloudwatchlogs.DescribeLogStreamsOutput{
+		LogStreams: []types.LogStream{
+			{LastEventTimestamp: aws.Int64(now.AddDate(0, 0, -logStreamCreationDate).UnixMilli())},
+		},
+		NextToken: nil,
+	}, nil).Once()
+
+	var (
+		deletedLogGroup         []string
+		wg                      sync.WaitGroup
+		foundLogGroupChan       = make(chan *types.LogGroup, 500)
+		deletedLogGroupNameChan = make(chan string, 500)
+	)
+
+	w := worker{
+		id:                   1,
+		wg:                   &wg,
+		incomingLogGroupChan: foundLogGroupChan,
+		deletedLogGroupChan:  deletedLogGroupNameChan,
+		times:                times,
+	}
+	go handleDeletedLogGroups(&deletedLogGroup, deletedLogGroupNameChan)
+	// Call handleLogGroup in dry-run mode (so no deletion call is made).
+	err := w.handleLogGroup(context.Background(), mockClient, logGroup)
+	time.Sleep(1 * time.Second) // give time for deleted group to be handled
+	return deletedLogGroup, err
+
+}
+
+// Test handleLogGroup to simulate deletion when a log group is old and inactive.
+func TestHandleLogGroup(t *testing.T) {
+	cfg := Config{
+		creationThreshold: 3 * clean.KeepDurationOneDay,
+		inactiveThreshold: 2 * clean.KeepDurationOneDay,
+		numWorkers:        0,
+		deleteBatchCap:    0,
+		exceptionList:     []string{"EXCEPTION"},
+		dryRun:            true,
+	}
+	testCases := []struct {
+		name                  string
+		logGroupName          string
+		logCreationDate       int
+		logStreamCreationDate int
+		expected              []string
+	}{
+		{
+			"Expired log group",
+			"expired-test-log-group",
+			7,
+			7,
+			[]string{"expired-test-log-group"},
+		},
+		{
+			"Fresh log group",
+			"fresh-test-log-group",
+			1,
+			7,
+			[]string{},
+		},
+		{
+			"Old but still used log group",
+			"old-test-log-group",
+			7,
+			1,
+			[]string{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.logGroupName, func(t *testing.T) {
+			deletedLogGroup, err := testHandleLogGroup(cfg, tc.logGroupName, tc.logCreationDate, tc.logStreamCreationDate)
+			assert.NoError(t, err)
+			assert.Len(t, deletedLogGroup, len(tc.expected))
+			assert.ElementsMatch(t, deletedLogGroup, tc.expected)
+		})
+	}
+
+}
+func testDeleteLogGroup(cfg Config, logGroupName string, logCreationDate, logStreamCreationDate int) []string {
+	cfg.dryRun = true // Prevent actual deletion.
+	now := time.Now()
+
+	mockClient := new(MockCloudWatchLogsClient)
+
+	// Set up expectation for DescribeLogGroups
+	mockClient.On("DescribeLogGroups",
+		mock.Anything,
+		&cloudwatchlogs.DescribeLogGroupsInput{
+			NextToken: nil,
+		},
+		mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
+		LogGroups: []types.LogGroup{
+			{LogGroupName: aws.String(logGroupName),
+				CreationTime: aws.Int64(now.AddDate(0, 0, -logCreationDate).UnixMilli())},
+		},
+		NextToken: nil,
+	}, nil).Once()
+	mockClient.On("DescribeLogStreams",
+		mock.Anything,
+		&cloudwatchlogs.DescribeLogStreamsInput{
+			LogGroupName: aws.String(logGroupName),
+			OrderBy:      types.OrderByLastEventTime,
+			Descending:   aws.Bool(true),
+			NextToken:    nil,
+		},
+		mock.Anything).Return(&cloudwatchlogs.DescribeLogStreamsOutput{
+		LogStreams: []types.LogStream{
+			{LastEventTimestamp: aws.Int64(now.AddDate(0, 0, -logStreamCreationDate).UnixMilli())},
+		},
+		NextToken: nil,
+	}, nil).Once()
+
+	// Call handleLogGroup in dry-run mode (so no deletion call is made).
+	return deleteOldLogGroups(context.Background(), mockClient, calculateCutoffTimes())
+
+}
+func TestDeleteLogGroups(t *testing.T) {
+	cfg := Config{
+		creationThreshold: 3,
+		inactiveThreshold: 2,
+		numWorkers:        0,
+		deleteBatchCap:    0,
+		exceptionList:     []string{"except"},
+		dryRun:            true,
+	}
+	testCases := []struct {
+		name                  string
+		logGroupName          string
+		logCreationDate       int
+		logStreamCreationDate int
+		expected              []string
+	}{
+		{
+			"Expired log group",
+			"expired-test-log-group",
+			7,
+			7,
+			[]string{"expired-test-log-group"},
+		},
+		{
+			"Fresh log group",
+			"fresh-test-log-group",
+			1,
+			7,
+			[]string{},
+		},
+		{
+			"Old but still used log group",
+			"old-test-log-group",
+			7,
+			1,
+			[]string{},
+		},
+		{
+			"Exception log group",
+			"exceptional-test-log-group",
+			7,
+			1,
+			[]string{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.logGroupName, func(t *testing.T) {
+			deletedLogGroup := testDeleteLogGroup(cfg, tc.logGroupName, tc.logCreationDate, tc.logStreamCreationDate)
+			assert.Len(t, deletedLogGroup, len(tc.expected))
+			assert.ElementsMatch(t, deletedLogGroup, tc.expected)
+		})
+	}
+
+}

--- a/clean/clean_security_group/clean_security_group.go
+++ b/clean/clean_security_group/clean_security_group.go
@@ -1,0 +1,448 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/clean"
+)
+
+type ec2Client interface {
+	DescribeSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error)
+	DescribeNetworkInterfaces(ctx context.Context, params *ec2.DescribeNetworkInterfacesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error)
+	DeleteSecurityGroup(ctx context.Context, params *ec2.DeleteSecurityGroupInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error)
+	RevokeSecurityGroupIngress(ctx context.Context, params *ec2.RevokeSecurityGroupIngressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error)
+	RevokeSecurityGroupEgress(ctx context.Context, params *ec2.RevokeSecurityGroupEgressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error)
+}
+
+const (
+	SecurityGroupProcessChanSize = 500
+)
+
+// Config holds the application configuration
+type Config struct {
+	ageThreshold  time.Duration
+	numWorkers    int
+	exceptionList []string
+	dryRun        bool
+	skipVpcSGs    bool
+	skipWithRules bool
+}
+
+// Global configuration
+var (
+	cfg Config
+)
+
+func init() {
+	// Set default configuration
+	cfg = Config{
+		ageThreshold:  1 * clean.KeepDurationOneDay,
+		numWorkers:    30,
+		exceptionList: []string{"default"},
+		dryRun:        true,
+		skipVpcSGs:    false,
+		skipWithRules: false,
+	}
+}
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	// Parse command line flags
+	flag.BoolVar(&cfg.dryRun, "dry-run", true, "Enable dry-run mode (no actual deletion)")
+	flag.DurationVar(&cfg.ageThreshold, "age", 1*clean.KeepDurationOneDay, "Age threshold for security groups (e.g. 24h)")
+	flag.BoolVar(&cfg.skipVpcSGs, "skip-vpc", false, "Skip security groups associated with VPCs")
+	flag.BoolVar(&cfg.skipWithRules, "skip-with-rules", false, "Skip security groups that have ingress or egress rules")
+	flag.Parse()
+
+	// Load AWS configuration
+	awsCfg, err := loadAWSConfig(ctx)
+	if err != nil {
+		log.Fatalf("Error loading AWS config: %v", err)
+	}
+
+	// Create EC2 client
+	client := ec2.NewFromConfig(awsCfg)
+
+	log.Printf("🔍 Searching for unused Security Groups older than %v in %s region\n",
+		cfg.ageThreshold, awsCfg.Region)
+
+	// Delete old security groups
+	deletedGroups, err := deleteUnusedSecurityGroups(ctx, client)
+	if err != nil {
+		log.Printf("Error deleting security groups: %v", err)
+	}
+	log.Printf("Total security groups deleted: %d", len(deletedGroups))
+}
+
+func loadAWSConfig(ctx context.Context) (aws.Config, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("loading AWS config: %w", err)
+	}
+	cfg.RetryMode = aws.RetryModeAdaptive
+	return cfg, nil
+}
+
+func deleteUnusedSecurityGroups(ctx context.Context, client ec2Client) ([]string, error) {
+	var (
+		wg                       sync.WaitGroup
+		deletedSecurityGroups    []string
+		foundSecurityGroupChan   = make(chan types.SecurityGroup, SecurityGroupProcessChanSize)
+		deletedSecurityGroupChan = make(chan string, SecurityGroupProcessChanSize)
+		handlerWg                sync.WaitGroup
+	)
+
+	// Start worker pool
+	log.Printf("👷 Creating %d workers\n", cfg.numWorkers)
+	for i := 0; i < cfg.numWorkers; i++ {
+		wg.Add(1)
+		w := worker{
+			id:                        i,
+			wg:                        &wg,
+			incomingSecurityGroupChan: foundSecurityGroupChan,
+			deletedSecurityGroupChan:  deletedSecurityGroupChan,
+		}
+		go w.processSecurityGroup(ctx, client)
+	}
+
+	// Start handler with its own WaitGroup
+	handlerWg.Add(1)
+	go func() {
+		handleDeletedSecurityGroups(&deletedSecurityGroups, deletedSecurityGroupChan)
+		handlerWg.Done()
+	}()
+
+	// Process security groups in batches
+	if err := fetchAndProcessSecurityGroups(ctx, client, foundSecurityGroupChan); err != nil {
+		log.Printf("Error processing security groups: %v", err)
+		return nil, err
+	}
+
+	close(foundSecurityGroupChan)
+	wg.Wait()
+	close(deletedSecurityGroupChan)
+	handlerWg.Wait()
+
+	return deletedSecurityGroups, nil
+}
+
+func handleDeletedSecurityGroups(deletedSecurityGroups *[]string, deletedSecurityGroupChan chan string) {
+	for securityGroupId := range deletedSecurityGroupChan {
+		*deletedSecurityGroups = append(*deletedSecurityGroups, securityGroupId)
+		log.Printf("🔍 Processed %d security groups so far\n", len(*deletedSecurityGroups))
+	}
+}
+
+type worker struct {
+	id                        int
+	wg                        *sync.WaitGroup
+	incomingSecurityGroupChan <-chan types.SecurityGroup
+	deletedSecurityGroupChan  chan<- string
+}
+
+func (w *worker) processSecurityGroup(ctx context.Context, client ec2Client) {
+	defer w.wg.Done()
+
+	for {
+		select {
+		case securityGroup, ok := <-w.incomingSecurityGroupChan:
+			if !ok {
+				return
+			}
+			if err := w.handleSecurityGroup(ctx, client, securityGroup); err != nil {
+				log.Printf("Worker %d: Error processing security group: %v", w.id, err)
+			}
+		case <-ctx.Done():
+			log.Printf("Worker %d: Stopping due to context cancellation", w.id)
+			return
+		}
+	}
+}
+
+func (w *worker) handleSecurityGroup(ctx context.Context, client ec2Client, securityGroup types.SecurityGroup) error {
+	sgID := *securityGroup.GroupId
+	sgName := *securityGroup.GroupName
+
+	// Skip default security groups
+	if isDefaultSecurityGroup(securityGroup) {
+		log.Printf("⏭️ Worker %d: Skipping default security group: %s (%s)", w.id, sgID, sgName)
+		return nil
+	}
+
+	// Skip security groups in exception list
+	if isSecurityGroupException(securityGroup) {
+		log.Printf("⏭️ Worker %d: Skipping security group in exception list: %s (%s)", w.id, sgID, sgName)
+		return nil
+	}
+
+	// Check if security group is in use
+	isInUse, err := isSecurityGroupInUse(ctx, client, sgID)
+	if err != nil {
+		return fmt.Errorf("checking if security group is in use: %w", err)
+	}
+
+	if isInUse {
+		log.Printf("⏭️ Worker %d: Security group is in use: %s (%s)", w.id, sgID, sgName)
+		return nil
+	}
+
+	// Check if security group has rules and we're configured to skip those
+	if cfg.skipWithRules && hasRules(securityGroup) {
+		log.Printf("⏭️ Worker %d: Skipping security group with rules: %s (%s)", w.id, sgID, sgName)
+		return nil
+	}
+
+	log.Printf("🚨 Worker %d: Found unused security group: %s (%s)", w.id, sgID, sgName)
+
+	// Clean up any rules before deletion
+	if hasRules(securityGroup) {
+		if err := cleanSecurityGroupRules(ctx, client, securityGroup); err != nil {
+			return fmt.Errorf("cleaning security group rules: %w", err)
+		}
+	}
+
+	w.deletedSecurityGroupChan <- sgID
+
+	if cfg.dryRun {
+		log.Printf("🛑 Dry-Run: Would delete security group: %s (%s)", sgID, sgName)
+		return nil
+	}
+
+	return deleteSecurityGroup(ctx, client, sgID)
+}
+
+func deleteSecurityGroup(ctx context.Context, client ec2Client, securityGroupID string) error {
+	_, err := client.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{
+		GroupId: aws.String(securityGroupID),
+	})
+	if err != nil {
+		return fmt.Errorf("deleting security group %s: %w", securityGroupID, err)
+	}
+	log.Printf("✅ Deleted security group: %s", securityGroupID)
+	return nil
+}
+
+func cleanSecurityGroupRules(ctx context.Context, client ec2Client, securityGroup types.SecurityGroup) error {
+	sgID := *securityGroup.GroupId
+
+	// Get fresh security group data in one call
+	describeOutput, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		GroupIds: []string{sgID},
+	})
+	if err != nil {
+		return fmt.Errorf("describing security group %s: %w", sgID, err)
+	}
+
+	if len(describeOutput.SecurityGroups) == 0 {
+		return fmt.Errorf("security group %s not found", sgID)
+	}
+
+	sg := describeOutput.SecurityGroups[0]
+
+	// Handle both ingress and egress rules concurrently
+	var wg sync.WaitGroup
+	var ingressErr, egressErr error
+
+	if len(sg.IpPermissions) > 0 {
+		if cfg.dryRun {
+			log.Printf("🛑 Dry-Run: Would revoke %d ingress rules from security group: %s",
+				len(sg.IpPermissions), sgID)
+		} else {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := client.RevokeSecurityGroupIngress(ctx, &ec2.RevokeSecurityGroupIngressInput{
+					GroupId:       aws.String(sgID),
+					IpPermissions: sg.IpPermissions,
+				})
+				if err != nil {
+					ingressErr = fmt.Errorf("revoking ingress rules: %w", err)
+				} else {
+					log.Printf("✅ Revoked ingress rules from security group: %s", sgID)
+				}
+			}()
+		}
+	}
+
+	if len(sg.IpPermissionsEgress) > 0 {
+		if cfg.dryRun {
+			log.Printf("🛑 Dry-Run: Would revoke %d egress rules from security group: %s",
+				len(sg.IpPermissionsEgress), sgID)
+		} else {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := client.RevokeSecurityGroupEgress(ctx, &ec2.RevokeSecurityGroupEgressInput{
+					GroupId:       aws.String(sgID),
+					IpPermissions: sg.IpPermissionsEgress,
+				})
+				if err != nil {
+					egressErr = fmt.Errorf("revoking egress rules: %w", err)
+				} else {
+					log.Printf("✅ Revoked egress rules from security group: %s", sgID)
+				}
+			}()
+		}
+	}
+
+	wg.Wait()
+
+	if ingressErr != nil {
+		return ingressErr
+	}
+	if egressErr != nil {
+		return egressErr
+	}
+
+	return nil
+}
+
+func fetchAndProcessSecurityGroups(ctx context.Context, client ec2Client,
+	securityGroupChan chan<- types.SecurityGroup) error {
+
+	maxResults := int32(100) // AWS maximum allowed
+	var nextToken *string
+	describeCount := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			output, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+				MaxResults: aws.Int32(maxResults),
+				NextToken:  nextToken,
+			})
+			if err != nil {
+				return fmt.Errorf("describing security groups: %w", err)
+			}
+
+			log.Printf("🔍 Described %d times | Found %d security groups\n", describeCount, len(output.SecurityGroups))
+
+			// Process in batches with context awareness
+			for _, securityGroup := range output.SecurityGroups {
+				select {
+				case securityGroupChan <- securityGroup:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+
+			if output.NextToken == nil {
+				break
+			}
+
+			nextToken = output.NextToken
+			describeCount++
+		}
+	}
+
+	return nil
+}
+
+func isSecurityGroupInUse(ctx context.Context, client ec2Client, securityGroupID string) (bool, error) {
+	// Use a channel to handle concurrent checks
+	resultChan := make(chan bool, 2)
+	errChan := make(chan error, 2)
+
+	// Check network interfaces concurrently
+	go func() {
+		output, err := client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+			Filters: []types.Filter{
+				{
+					Name:   aws.String("group-id"),
+					Values: []string{securityGroupID},
+				},
+			},
+		})
+		if err != nil {
+			errChan <- fmt.Errorf("describing network interfaces: %w", err)
+			return
+		}
+		resultChan <- len(output.NetworkInterfaces) > 0
+	}()
+
+	// Check security group references concurrently
+	go func() {
+		output, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{})
+		if err != nil {
+			errChan <- fmt.Errorf("describing security groups: %w", err)
+			return
+		}
+
+		for _, sg := range output.SecurityGroups {
+			if *sg.GroupId == securityGroupID {
+				continue
+			}
+
+			// Check both ingress and egress rules
+			if isReferencedInRules(sg.IpPermissions, securityGroupID) ||
+				isReferencedInRules(sg.IpPermissionsEgress, securityGroupID) {
+				resultChan <- true
+				return
+			}
+		}
+		resultChan <- false
+	}()
+
+	// Wait for both checks
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-errChan:
+			return false, err
+		case isUsed := <-resultChan:
+			if isUsed {
+				return true, nil
+			}
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+	}
+
+	return false, nil
+}
+
+func isReferencedInRules(permissions []types.IpPermission, securityGroupID string) bool {
+	for _, permission := range permissions {
+		for _, userIdGroupPair := range permission.UserIdGroupPairs {
+			if userIdGroupPair.GroupId != nil && *userIdGroupPair.GroupId == securityGroupID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isDefaultSecurityGroup(securityGroup types.SecurityGroup) bool {
+	return *securityGroup.GroupName == "default"
+}
+
+func isSecurityGroupException(securityGroup types.SecurityGroup) bool {
+	sgName := *securityGroup.GroupName
+	for _, exception := range cfg.exceptionList {
+		if strings.Contains(sgName, exception) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRules(securityGroup types.SecurityGroup) bool {
+	return len(securityGroup.IpPermissions) > 0 || len(securityGroup.IpPermissionsEgress) > 0
+}

--- a/clean/clean_security_group/clean_security_group_test.go
+++ b/clean/clean_security_group/clean_security_group_test.go
@@ -1,0 +1,298 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// Mock EC2 client for testing
+type mockEC2Client struct {
+	describeSecurityGroupsOutput    *ec2.DescribeSecurityGroupsOutput
+	describeNetworkInterfacesOutput *ec2.DescribeNetworkInterfacesOutput
+	deleteSecurityGroupCalled       bool
+	deleteSecurityGroupInput        *ec2.DeleteSecurityGroupInput
+	revokeIngressCalled             bool
+	revokeEgressCalled              bool
+}
+
+func (m *mockEC2Client) DescribeSecurityGroups(_ context.Context, params *ec2.DescribeSecurityGroupsInput, _ ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+	if params != nil && len(params.GroupIds) > 0 {
+		// When called with specific GroupIds, return only those groups
+		matchingGroups := []types.SecurityGroup{}
+		for _, sg := range m.describeSecurityGroupsOutput.SecurityGroups {
+			for _, requestedID := range params.GroupIds {
+				if *sg.GroupId == requestedID {
+					matchingGroups = append(matchingGroups, sg)
+					break
+				}
+			}
+		}
+		return &ec2.DescribeSecurityGroupsOutput{
+			SecurityGroups: matchingGroups,
+		}, nil
+	}
+	return m.describeSecurityGroupsOutput, nil
+}
+
+func (m *mockEC2Client) DescribeNetworkInterfaces(_ context.Context, _ *ec2.DescribeNetworkInterfacesInput, _ ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	return m.describeNetworkInterfacesOutput, nil
+}
+
+func (m *mockEC2Client) DeleteSecurityGroup(_ context.Context, params *ec2.DeleteSecurityGroupInput, _ ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error) {
+	m.deleteSecurityGroupCalled = true
+	m.deleteSecurityGroupInput = params
+	return &ec2.DeleteSecurityGroupOutput{}, nil
+}
+
+func (m *mockEC2Client) RevokeSecurityGroupIngress(_ context.Context, _ *ec2.RevokeSecurityGroupIngressInput, _ ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	m.revokeIngressCalled = true
+	return &ec2.RevokeSecurityGroupIngressOutput{}, nil
+}
+
+func (m *mockEC2Client) RevokeSecurityGroupEgress(_ context.Context, _ *ec2.RevokeSecurityGroupEgressInput, _ ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+	m.revokeEgressCalled = true
+	return &ec2.RevokeSecurityGroupEgressOutput{}, nil
+}
+
+func TestIsDefaultSecurityGroup(t *testing.T) {
+	tests := []struct {
+		name          string
+		securityGroup types.SecurityGroup
+		expected      bool
+	}{
+		{
+			name: "Default security group",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-12345"),
+				GroupName: aws.String("default"),
+			},
+			expected: true,
+		},
+		{
+			name: "Non-default security group",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-67890"),
+				GroupName: aws.String("my-security-group"),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isDefaultSecurityGroup(tt.securityGroup)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsSecurityGroupException(t *testing.T) {
+	// Set up test exception list
+	cfg.exceptionList = []string{"default", "special"}
+
+	tests := []struct {
+		name          string
+		securityGroup types.SecurityGroup
+		expected      bool
+	}{
+		{
+			name: "Security group in exception list",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-12345"),
+				GroupName: aws.String("special-group"),
+			},
+			expected: true,
+		},
+		{
+			name: "Security group not in exception list",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-67890"),
+				GroupName: aws.String("my-security-group"),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isSecurityGroupException(tt.securityGroup)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHasRules(t *testing.T) {
+	tests := []struct {
+		name          string
+		securityGroup types.SecurityGroup
+		expected      bool
+	}{
+		{
+			name: "Security group with ingress rules",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-12345"),
+				GroupName: aws.String("test-group"),
+				IpPermissions: []types.IpPermission{
+					{
+						IpProtocol: aws.String("tcp"),
+						FromPort:   aws.Int32(22),
+						ToPort:     aws.Int32(22),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Security group with egress rules",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-67890"),
+				GroupName: aws.String("test-group"),
+				IpPermissionsEgress: []types.IpPermission{
+					{
+						IpProtocol: aws.String("-1"),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Security group with no rules",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-abcde"),
+				GroupName: aws.String("test-group"),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasRules(tt.securityGroup)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHandleSecurityGroup(t *testing.T) {
+	// Save original dry run setting and restore after test
+	originalDryRun := cfg.dryRun
+	defer func() { cfg.dryRun = originalDryRun }()
+
+	tests := []struct {
+		name                 string
+		securityGroup        types.SecurityGroup
+		dryRun               bool
+		hasNetworkInterfaces bool
+		expectDelete         bool
+		expectRevokeRules    bool
+	}{
+		{
+			name: "Default security group - should not delete",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-12345"),
+				GroupName: aws.String("default"),
+			},
+			dryRun:               false,
+			hasNetworkInterfaces: false,
+			expectDelete:         false,
+			expectRevokeRules:    false,
+		},
+		{
+			name: "Security group with network interfaces - should not delete",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-67890"),
+				GroupName: aws.String("test-group"),
+			},
+			dryRun:               false,
+			hasNetworkInterfaces: true,
+			expectDelete:         false,
+			expectRevokeRules:    false,
+		},
+		{
+			name: "Unused security group with rules - should delete and revoke rules",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-abcde"),
+				GroupName: aws.String("test-group"),
+				IpPermissions: []types.IpPermission{
+					{
+						IpProtocol: aws.String("tcp"),
+						FromPort:   aws.Int32(22),
+						ToPort:     aws.Int32(22),
+					},
+				},
+				IpPermissionsEgress: []types.IpPermission{
+					{
+						IpProtocol: aws.String("-1"),
+					},
+				},
+			},
+			dryRun:               false,
+			hasNetworkInterfaces: false,
+			expectDelete:         true,
+			expectRevokeRules:    true,
+		},
+		{
+			name: "Dry run - should not actually delete",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-abcde"),
+				GroupName: aws.String("test-group"),
+			},
+			dryRun:               true,
+			hasNetworkInterfaces: false,
+			expectDelete:         false,
+			expectRevokeRules:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg.dryRun = tt.dryRun
+
+			// Create mock client
+			mockClient := &mockEC2Client{
+				describeNetworkInterfacesOutput: &ec2.DescribeNetworkInterfacesOutput{
+					NetworkInterfaces: make([]types.NetworkInterface, 0),
+				},
+				describeSecurityGroupsOutput: &ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []types.SecurityGroup{tt.securityGroup},
+				},
+			}
+
+			if tt.hasNetworkInterfaces {
+				mockClient.describeNetworkInterfacesOutput.NetworkInterfaces = append(
+					mockClient.describeNetworkInterfacesOutput.NetworkInterfaces,
+					types.NetworkInterface{
+						NetworkInterfaceId: aws.String("eni-12345"),
+					},
+				)
+			}
+
+			// Create worker
+			w := worker{
+				id:                       1,
+				wg:                       &sync.WaitGroup{},
+				deletedSecurityGroupChan: make(chan string, 1),
+			}
+
+			// Call the function
+			err := w.handleSecurityGroup(context.Background(), mockClient, tt.securityGroup)
+
+			// Check results
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectDelete && !tt.dryRun, mockClient.deleteSecurityGroupCalled)
+			assert.Equal(t, tt.expectRevokeRules && !tt.dryRun, mockClient.revokeIngressCalled || mockClient.revokeEgressCalled)
+
+			// Clean up channel
+			close(w.deletedSecurityGroupChan)
+		})
+	}
+}

--- a/clean/clean_util.go
+++ b/clean/clean_util.go
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package clean
+
+import "time"
+
+const (
+	KeepDurationOneWeek        = KeepDurationOneDay * 7
+	KeepDurationFourDays       = KeepDurationOneDay * 4
+	KeepDurationOneDay         = -1 * time.Hour * 24
+	KeepDurationSixtyDay       = KeepDurationOneDay * time.Duration(60)
+	KeepDurationTwentySixHours = KeepDurationOneDay + time.Hour*2
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/aws/amazon-cloudwatch-agent-test
 
-go 1.18
+go 1.22
+
+toolchain go1.22.5
 
 // Avoid checksum mismatch for go-collectd https://github.com/collectd/go-collectd/issues/94
 replace collectd.org v0.5.0 => github.com/collectd/go-collectd v0.5.0
@@ -9,21 +11,26 @@ require (
 	collectd.org v0.5.0
 	github.com/DataDog/datadog-go v4.8.3+incompatible
 	github.com/aws/aws-sdk-go v1.48.12
-	github.com/aws/aws-sdk-go-v2 v1.23.5
+	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.25.11
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.12.9
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.9
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.15.4
+	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.42.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.31.2
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.29.2
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.26.3
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.2
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.35.2
+	github.com/aws/aws-sdk-go-v2/service/efs v1.35.1
+	github.com/aws/aws-sdk-go-v2/service/eks v1.60.1
+	github.com/aws/aws-sdk-go-v2/service/iam v1.40.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.47.2
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.44.2
 	github.com/aws/aws-sdk-go-v2/service/xray v1.23.2
 	github.com/aws/aws-xray-sdk-go v1.8.3
+	github.com/aws/smithy-go v1.22.2
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/google/uuid v1.4.0
 	github.com/mitchellh/mapstructure v1.5.0
@@ -49,8 +56,8 @@ require (
 	github.com/andybalholm/brotli v1.0.6 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.3 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.16.9 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.8 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.8 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.7.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.18.2 // indirect
@@ -62,7 +69,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.18.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.26.2 // indirect
-	github.com/aws/smithy-go v1.18.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -86,6 +92,7 @@ require (
 	github.com/qri-io/jsonpointer v0.1.1 // indirect
 	github.com/shoenig/go-m1cpu v0.1.4 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/aws/amazon-cloudwatch-agent-test
 
 go 1.22
 
-toolchain go1.22.5
-
 // Avoid checksum mismatch for go-collectd https://github.com/collectd/go-collectd/issues/94
 replace collectd.org v0.5.0 => github.com/collectd/go-collectd v0.5.0
 

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,7 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
+github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
@@ -58,8 +59,8 @@ github.com/andybalholm/brotli v1.0.6/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.48.12 h1:n+eGzflzzvYubu2cOjqpVll7lF+Ci0ThyCpg5kzfzbo=
 github.com/aws/aws-sdk-go v1.48.12/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
-github.com/aws/aws-sdk-go-v2 v1.23.5 h1:xK6C4udTyDMd82RFvNkDQxtAd00xlzFUtX4fF2nMZyg=
-github.com/aws/aws-sdk-go-v2 v1.23.5/go.mod h1:t3szzKfP0NeRU27uBFczDivYJjsmSnqI8kIvKyWb9ds=
+github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
+github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.3 h1:Zx9+31KyB8wQna6SXFWOewlgoY5uGdDAu6PTOEU3OQI=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.3/go.mod h1:zxbEJhRdKTH1nqS2qu6UJ7zGe25xaHxZXaC2CvuQFnA=
 github.com/aws/aws-sdk-go-v2/config v1.25.11 h1:RWzp7jhPRliIcACefGkKp03L0Yofmd2p8M25kbiyvno=
@@ -72,14 +73,16 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.9 h1:FZVFahMyZle6WcogZCOxo6D
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.9/go.mod h1:kjq7REMIkxdtcEC9/4BVXjOsNY5isz6jQbEgk6osRTU=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.15.4 h1:TUCNKBd4/JEefsZDxo5deRmrRRPZHqGyBYiUAeBKOWU=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.15.4/go.mod h1:egDkcl+zsgFqS6VO142bKboip5Pe1sNMwN55Xy38QsM=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.8 h1:8GVZIR0y6JRIUNSYI1xAMF4HDfV8H/bOsZ/8AD/uY5Q=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.8/go.mod h1:rwBfu0SoUkBUZndVgPZKAD9Y2JigaZtRP68unRiYToQ=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.8 h1:ZE2ds/qeBkhk3yqYvS3CDCFNvd9ir5hMjlVStLZWrvM=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.8/go.mod h1:/lAPPymDYL023+TS6DJmjuL42nxix2AvEvfjqOBRODk=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 h1:ZK5jHhnrioRkUNOc+hOgQKlUL5JeC3S6JgLxtQ+Rm0Q=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34/go.mod h1:p4VfIceZokChbA9FzMbRGz5OV+lekcVtHlPKEO0gSZY=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 h1:SZwFm17ZUNNg5Np0ioo/gq8Mn6u9w19Mri8DnJ15Jf0=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34/go.mod h1:dFZsC0BLo346mvKQLWmoJxT+Sjp+qcVR1tRVHQGOH9Q=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.7.1 h1:uR9lXYjdPX0xY+NhvaJ4dD8rpSRz5VY81ccIIoNG+lw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.7.1/go.mod h1:6fQQgfuGmw8Al/3M2IgIllycxV7ZW7WCdVSqfBeUiCY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.8 h1:abKT+RuM1sdCNZIGIfZpLkvxEX3Rpsto019XG/rkYG8=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.8/go.mod h1:Owc4ysUE71JSruVTTa3h4f2pp3E4hlcAtmeNXxDmjj4=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.1 h1:wj4AION3NjQvjOiI8wm+TVU8y+8EsTl7fSgJAzk9cgc=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.1/go.mod h1:CDqMoc3KRdZJ8qziW96J35lKH01Wq3B2aihtHj2JbRs=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.42.0 h1:Eub6qmSRH5ahS1zhVLa1i1qT3raC9Sxrn2kgtG19J3I=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.42.0/go.mod h1:ehWDbgXo5Zy6eLjP+xX+Vf8wXaSyLGeRf6KlvoVAaXk=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.31.2 h1:HWB+RXvOQQkhEp8QCpTlgullbCiysRQlo6ulVZRBBtM=
@@ -94,6 +97,12 @@ github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.2 h1:e3Imv1oXz+W3Tfclflkh72t5TUP
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.2/go.mod h1:d1hAqgLDOPaSO1Piy/0bBmj6oAplFwv6p0cquHntNHM=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.35.2 h1:yIr1T8uPhZT2cKCBeO39utfzG/RKJn3SxbuBOdj18Nc=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.35.2/go.mod h1:MvDz+yXfa2sSEfHB57rdf83deKJIeKEopqHFhVmaRlk=
+github.com/aws/aws-sdk-go-v2/service/efs v1.35.1 h1:T/DHMp4fZACJisxJEHQCVwci9QxI4feCs1t4Di45YmU=
+github.com/aws/aws-sdk-go-v2/service/efs v1.35.1/go.mod h1:XT6hcgC1HV33EBGPWdXnbgyeqND4k43qX3argLyEZM8=
+github.com/aws/aws-sdk-go-v2/service/eks v1.60.1 h1:Q5YEz2N233+N2rKuPF5qO0OR0qp69BnukHRmrnMjV0c=
+github.com/aws/aws-sdk-go-v2/service/eks v1.60.1/go.mod h1:v1xXy6ea0PHtWkjFUvAUh6B/5wv7UF909Nru0dOIJDk=
+github.com/aws/aws-sdk-go-v2/service/iam v1.40.2 h1:F1hBvOiplp6lHg5clau/reqayZT+K5EBXkFRNrHF+To=
+github.com/aws/aws-sdk-go-v2/service/iam v1.40.2/go.mod h1:mPJkGQzeCoPs82ElNILor2JzZgYENr4UaSKUT8K27+c=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.3 h1:e3PCNeEaev/ZF01cQyNZgmYE9oYYePIMJs2mWSKG514=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.3/go.mod h1:gIeeNyaL8tIEqZrzAnTeyhHcE0yysCtcaP+N9kxLZ+E=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.2.8 h1:xyfOAYV/ujzZOo01H9+OnyeiRKmTEp6EsITTsmq332Q=
@@ -118,8 +127,8 @@ github.com/aws/aws-sdk-go-v2/service/xray v1.23.2 h1:mFHM/R2FYnCkmUB52SqJncU5TWD
 github.com/aws/aws-sdk-go-v2/service/xray v1.23.2/go.mod h1:zz5H6SRVFHj93yt3lxA8Ql63c/pY90YjNvvalulrCTk=
 github.com/aws/aws-xray-sdk-go v1.8.3 h1:S8GdgVncBRhzbNnNUgTPwhEqhwt2alES/9rLASyhxjU=
 github.com/aws/aws-xray-sdk-go v1.8.3/go.mod h1:tv8uLMOSCABolrIF8YCcp3ghyswArsan8dfLCA1ZATk=
-github.com/aws/smithy-go v1.18.1 h1:pOdBTUfXNazOlxLrgeYalVnuTpKreACHtc62xLwIB3c=
-github.com/aws/smithy-go v1.18.1/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
+github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
+github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -252,6 +261,7 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
+github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.1 h1:6UKoz5ujsI55KNpsJH3UwCq3T8kKbZwNZBNPuTTje8U=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.1/go.mod h1:YvJ2f6MplWDhfxiUC3KpyTy76kYUZA4W3pTv/wdKQ9Y=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -279,6 +289,7 @@ github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6K
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -327,6 +338,7 @@ github.com/qri-io/jsonschema v0.2.1 h1:NNFoKms+kut6ABPf6xiKNM5214jzxAhDBrPHCJ97W
 github.com/qri-io/jsonschema v0.2.1/go.mod h1:g7DPkiOsK1xv6T/Ao5scXRkd+yTFygcANPBaaqW+VrI=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil/v3 v3.23.3 h1:Syt5vVZXUDXPEXpIBt5ziWsJ4LdSAAxF4l/xZeQgSEE=
@@ -392,6 +404,7 @@ go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -505,6 +518,7 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
+golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -748,6 +762,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=


### PR DESCRIPTION
# Description of changes
The tool/clean module contains all our cleaner scripts to purge any orphaned resources created by our integ tests. Moving this over from the agent repo to the test repo.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
GH run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14090243153
