### PR TITLE
Check for delta metrics

### DIFF
--- a/test/amp/amp_test.go
+++ b/test/amp/amp_test.go
@@ -332,8 +332,10 @@ func (t AmpTestRunner) getOtlpMetrics() ([]string, []string) {
 	return []string{
 			"my_gauge",
 			"my_cumulative_counter",
+			"my_delta_counter",
 		}, []string{
 			"my_cumulative_histogram",
+			"my_delta_histogram",
 		}
 }
 


### PR DESCRIPTION
# Description of the issue
Currently, the CloudWatch Agent uses the [prometheusremotewrite exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter) to send metrics to Amazon Managed Prometheus. It does not support delta metrics so the metrics are dropped:

> Non-cumulative monotonic, histogram, and summary OTLP metrics are dropped by this exporter.

This issue was discovered while updating the AMP integration test: https://github.com/aws/amazon-cloudwatch-agent-test/pull/465#issue-2864562335

The agent is being updated to support delta metrics when sending to AMP destinations: https://github.com/aws/amazon-cloudwatch-agent/pull/1624

# Description of changes
Check for newly supported delta counter (sum) and delta histogram metrics in AMP integration test.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran integration test against updated agent and newly supported delta metrics are found in AMP: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14094417672/job/39478852051#step:7:860
