### PR TITLE
Updating metric value bench mark test failure

### DIFF
--- a/test/metric_value_benchmark/jmx_kafka_test.go
+++ b/test/metric_value_benchmark/jmx_kafka_test.go
@@ -84,7 +84,7 @@ func (t *JMXKafkaTestRunner) SetupBeforeAgentRun() error {
 		"(yes | nohup kafka_2.13-3.9.0/bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9092) > /tmp/kafka-console-producer-logs.txt 2>&1 &",
 		"kafka_2.13-3.9.0/bin/kafka-console-consumer.sh --topic quickstart-events --from-beginning --bootstrap-server localhost:9092 > /tmp/kafka-console-consumer-logs.txt 2>&1 &",
 		fmt.Sprintf("tar -xzf %s", zookeeperArchive),
-		"mkdir apache-zookeeper-3.8.4-bin/data",
+		"rm -rf apache-zookeeper-3.8.4-bin/data && mkdir apache-zookeeper-3.8.4-bin/data",
 		"touch apache-zookeeper-3.8.4-bin/conf/zoo.cfg",
 		"echo -e 'tickTime = 2000\ndataDir = ../data\nclientPort = 2181\ninitLimit = 5\nsyncLimit = 2\n' >> apache-zookeeper-3.8.4-bin/conf/zoo.cfg",
 		"sudo apache-zookeeper-3.8.4-bin/bin/zkServer.sh start",


### PR DESCRIPTION
# Description of the issue
The metric value benchmark test fails because some amis already have directory apache-zookeeper-3.8.4-bin/data created so the jmx command fails with exit status 1. Adding a remove to make sure the directory doesn't exist fixes this issue. 
Failing run (before change): https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14092963651/job/39474178977

Passing run (after change) : [aws/amazon-cloudwatch-agent/actions/runs/14096842424/job/39485825767](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14096842424/job/39485825767)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._
