### PR TITLE
Skipping Ca_bundle test until fixed

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -68,7 +68,8 @@ var testTypeToTestConfig = map[string][]testConfig{
 		{testDir: "./test/nvidia_gpu"},
 	},
 	testTypeKeyEc2Linux: {
-		{testDir: "./test/ca_bundle"},
+		//Skipping this test for now until test is not flakey
+		//{testDir: "./test/ca_bundle"},
 		{testDir: "./test/cloudwatchlogs"},
 		{
 			testDir: "./test/metrics_number_dimension",
@@ -133,7 +134,8 @@ var testTypeToTestConfig = map[string][]testConfig{
 		},
 	},
 	testTypeKeyEc2SELinux: {
-		{testDir: "./test/ca_bundle"},
+		//skip test until test is not flakey
+		//{testDir: "./test/ca_bundle"},
 		{testDir: "./test/cloudwatchlogs"},
 		{
 			testDir: "./test/metrics_number_dimension",

--- a/test/metric_value_benchmark/jmx_kafka_test.go
+++ b/test/metric_value_benchmark/jmx_kafka_test.go
@@ -84,7 +84,7 @@ func (t *JMXKafkaTestRunner) SetupBeforeAgentRun() error {
 		"(yes | nohup kafka_2.13-3.9.0/bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9092) > /tmp/kafka-console-producer-logs.txt 2>&1 &",
 		"kafka_2.13-3.9.0/bin/kafka-console-consumer.sh --topic quickstart-events --from-beginning --bootstrap-server localhost:9092 > /tmp/kafka-console-consumer-logs.txt 2>&1 &",
 		fmt.Sprintf("tar -xzf %s", zookeeperArchive),
-		"mkdir apache-zookeeper-3.8.4-bin/data",
+		"rm -rf apache-zookeeper-3.8.4-bin/data && mkdir apache-zookeeper-3.8.4-bin/data",
 		"touch apache-zookeeper-3.8.4-bin/conf/zoo.cfg",
 		"echo -e 'tickTime = 2000\ndataDir = ../data\nclientPort = 2181\ninitLimit = 5\nsyncLimit = 2\n' >> apache-zookeeper-3.8.4-bin/conf/zoo.cfg",
 		"sudo apache-zookeeper-3.8.4-bin/bin/zkServer.sh start",


### PR DESCRIPTION
# Description of the issue
Currently the ca_bundle test is flaky, we need to skip this test until it is fixed in order to unblock other prs.
Example: https://github.com/aws/amazon-cloudwatch-agent/pull/1629. The test is currently being fixed and once that is fixed, ca_bundle test will be added.

Flaky test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14234895874/job/39892482506
# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._
