### PR TITLE
Adding retries to Prometheus EMF tests

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -70,31 +70,31 @@ var testTypeToTestConfig = map[string][]testConfig{
 	testTypeKeyEc2Linux: {
 		//Skipping this test for now until test is not flakey
 		//{testDir: "./test/ca_bundle"},
-		{testDir: "./test/cloudwatchlogs"},
 		{
-			testDir: "./test/metrics_number_dimension",
-			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
-		},
-		{
-			testDir:     "./test/emf_concurrent",
+			testDir:     "./test/emf_prometheus",
 			targets:     map[string]map[string]struct{}{"os": {"al2": {}}},
-			maxAttempts: 1,
+			maxAttempts: 2,
+		},
+
+		{
+			testDir:     "./test/emf_prometheus",
+			targets:     map[string]map[string]struct{}{"os": {"al2": {}}},
+			maxAttempts: 2,
 		},
 		{
 			testDir:     "./test/emf_prometheus",
 			targets:     map[string]map[string]struct{}{"os": {"al2": {}}},
 			maxAttempts: 2,
 		},
-		{testDir: "./test/metric_value_benchmark"},
-		{testDir: "./test/run_as_user"},
-		{testDir: "./test/collection_interval"},
-		{testDir: "./test/metric_dimension"},
-		{testDir: "./test/restart"},
-		{testDir: "./test/xray"},
-		{testDir: "./test/otlp"},
 		{
-			testDir: "./test/acceptance",
-			targets: map[string]map[string]struct{}{"os": {"ubuntu-20.04": {}}},
+			testDir:     "./test/emf_prometheus",
+			targets:     map[string]map[string]struct{}{"os": {"al2": {}}},
+			maxAttempts: 2,
+		},
+		{
+			testDir:     "./test/emf_prometheus",
+			targets:     map[string]map[string]struct{}{"os": {"al2": {}}},
+			maxAttempts: 2,
 		},
 		// skipping FIPS test as the test cannot be verified
 		// neither ssh nor SSM works after a reboot once FIPS is enabled
@@ -102,96 +102,30 @@ var testTypeToTestConfig = map[string][]testConfig{
 		//	testDir: "./test/fips",
 		//	targets: map[string]map[string]struct{}{"os": {"rhel8": {}}},
 		//},
-		{
-			testDir: "./test/lvm",
-			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
-		},
-		{
-			testDir: "./test/proxy",
-			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
-		},
-		{
-			testDir: "./test/ssl_cert",
-			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
-		},
-		{
-			testDir:      "./test/userdata",
-			terraformDir: "terraform/ec2/userdata",
-			targets:      map[string]map[string]struct{}{"os": {"ol9": {}}},
-		},
-		{
-			testDir:      "./test/credentials_file",
-			terraformDir: "terraform/ec2/creds",
-			targets:      map[string]map[string]struct{}{"os": {"al2": {}}},
-		},
-		{
-			testDir: "./test/amp",
-			targets: map[string]map[string]struct{}{"os": {"al2": {}}, "arc": {"amd64": {}}},
-		},
-		{
-			testDir: "./test/agent_otel_merging",
-			targets: map[string]map[string]struct{}{"os": {"al2": {}}, "arc": {"amd64": {}}},
-		},
-		{
-			testDir:      "./test/assume_role",
-			terraformDir: "terraform/ec2/assume_role",
-			targets:      map[string]map[string]struct{}{"os": {"al2": {}}},
-		},
 	},
 	testTypeKeyEc2SELinux: {
 		//skip test until test is not flakey
 		//{testDir: "./test/ca_bundle"},
-		{testDir: "./test/cloudwatchlogs"},
 		{
-			testDir: "./test/metrics_number_dimension",
-			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
-		},
-		{
-			testDir:     "./test/emf_concurrent",
-			targets:     map[string]map[string]struct{}{"os": {"al2": {}}},
-			maxAttempts: 1,
+			testDir:     "./test/emf_prometheus",
+			maxAttempts: 2,
 		},
 		{
 			testDir:     "./test/emf_prometheus",
 			maxAttempts: 2,
 		},
-		{testDir: "./test/metric_value_benchmark"},
-		{testDir: "./test/run_as_user"},
-		{testDir: "./test/collection_interval"},
-		{testDir: "./test/metric_dimension"},
-		{testDir: "./test/restart"},
-		{testDir: "./test/xray"},
-		{testDir: "./test/selinux_negative_test"},
-		{testDir: "./test/otlp"},
 		{
-			testDir: "./test/lvm",
-			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
+			testDir:     "./test/emf_prometheus",
+			maxAttempts: 2,
 		},
 		{
-			testDir: "./test/proxy",
-			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
+			testDir:     "./test/emf_prometheus",
+			maxAttempts: 2,
 		},
 		{
-			testDir: "./test/ssl_cert",
-			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
-		},
-		{
-			testDir:      "./test/credentials_file",
-			terraformDir: "terraform/ec2/creds",
-			targets:      map[string]map[string]struct{}{"os": {"al2": {}}},
-		},
-		{
-			testDir: "./test/amp",
-			targets: map[string]map[string]struct{}{"os": {"al2": {}}, "arc": {"amd64": {}}},
-		},
-		{
-			testDir: "./test/agent_otel_merging",
-			targets: map[string]map[string]struct{}{"os": {"al2": {}}, "arc": {"amd64": {}}},
-		},
-		{
-			testDir:      "./test/assume_role",
-			terraformDir: "terraform/ec2/assume_role",
-			targets:      map[string]map[string]struct{}{"os": {"al2": {}}},
+			testDir:     "./test/emf_prometheus",
+			targets:     map[string]map[string]struct{}{"os": {"al2": {}}},
+			maxAttempts: 2,
 		},
 	},
 	/*
@@ -199,130 +133,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 		Therefore, limit down the scope for testing in Mac since EC2 can be done with Linux
 		and Mac under the hood share similar plugins with Linux
 	*/
-	"ec2_mac": {
-		{testDir: "../../../test/feature/mac"},
-	},
-	"ec2_windows": {
-		{testDir: "../../../test/feature/windows"},
-		{testDir: "../../../test/restart"},
-		{testDir: "../../../test/acceptance"},
-		{testDir: "../../../test/feature/windows/event_logs"},
-		{
-			testDir: "../../../test/feature/windows/custom_start/userdata",
-			targets: map[string]map[string]struct{}{"os": {"win-2019": {}}},
-		},
-		{
-			testDir: "../../../test/feature/windows/custom_start/ssm_start",
-			targets: map[string]map[string]struct{}{"os": {"win-2019": {}}},
-		},
-		// assume role test doesn't add much value, and it already being tested with linux
-		//{testDir: "../../../test/assume_role"},
-	},
-	"ec2_performance": {
-		{testDir: "../../test/performance/emf"},
-		{testDir: "../../test/performance/logs"},
-		{testDir: "../../test/performance/system"},
-		{testDir: "../../test/performance/statsd"},
-		{testDir: "../../test/performance/collectd"},
-		{testDir: "../../test/performance/trace/xray", runMockServer: true},
-	},
-	"ec2_windows_performance": {
-		{testDir: "../../test/performance/windows/logs"},
-		{testDir: "../../test/performance/windows/system"},
-	},
-	"ec2_stress": {
-		{testDir: "../../test/stress/emf"},
-		{testDir: "../../test/stress/logs"},
-		{testDir: "../../test/stress/system"},
-		{testDir: "../../test/stress/statsd"},
-		{testDir: "../../test/stress/collectd"},
-	},
-	"ec2_windows_stress": {
-		{testDir: "../../test/stress/windows/logs"},
-		{testDir: "../../test/stress/windows/system"},
-	},
-	"ecs_fargate": {
-		{testDir: "./test/ecs/ecs_metadata"},
-	},
-	"ecs_ec2_daemon": {
-		{
-			testDir: "./test/metric_value_benchmark",
-			targets: map[string]map[string]struct{}{"metadataEnabled": {"enabled": {}}},
-		},
-		{
-			testDir: "./test/statsd",
-			targets: map[string]map[string]struct{}{"metadataEnabled": {"enabled": {}}},
-		},
-		{
-			testDir: "./test/emf",
-			targets: map[string]map[string]struct{}{"metadataEnabled": {"disabled": {}}},
-		},
-		{
-			testDir: "./test/emf",
-			targets: map[string]map[string]struct{}{"metadataEnabled": {"enabled": {}}},
-		},
-	},
-	"eks_addon": {
-		{
-			testDir:      "../../../../test/gpu",
-			terraformDir: "terraform/eks/addon/gpu",
-		},
-	},
-	"eks_daemon": {
-		{
-			testDir:      "./test/metric_value_benchmark",
-			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
-			instanceType: "g4dn.xlarge",
-		},
-		{
-			testDir:      "./test/metric_value_benchmark",
-			terraformDir: "terraform/eks/daemon/windows/2019",
-			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
-		},
-		{
-			testDir:      "./test/metric_value_benchmark",
-			terraformDir: "terraform/eks/daemon/windows/2022",
-			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
-		},
-		{
-			testDir: "./test/statsd", terraformDir: "terraform/eks/daemon/statsd",
-			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
-		},
-		{
-			testDir: "./test/emf", terraformDir: "terraform/eks/daemon/emf",
-			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
-		},
-		{
-			testDir: "./test/fluent", terraformDir: "terraform/eks/daemon/fluent/d",
-			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
-		},
-		{testDir: "./test/fluent", terraformDir: "terraform/eks/daemon/fluent/bit"},
-		{testDir: "./test/fluent", terraformDir: "terraform/eks/daemon/fluent/windows/2022"},
-		{
-			testDir: "./test/gpu", terraformDir: "terraform/eks/daemon/gpu",
-			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
-		},
-		{
-			testDir: "./test/awsneuron", terraformDir: "terraform/eks/daemon/awsneuron",
-			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
-		},
-		{
-			testDir: "./test/entity", terraformDir: "terraform/eks/daemon/entity",
-			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
-		},
-		//Skipping test until efa team implements fix
-		//{
-		//	testDir: "./test/efa", terraformDir: "terraform/eks/daemon/efa",
-		//	targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
-		//},
-		{
-			testDir: "./test/metric_value_benchmark", terraformDir: "terraform/eks/daemon/credentials/pod_identity",
-			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
-		},
-	},
-	"eks_deployment": {
-		{testDir: "./test/metric_value_benchmark"},
-	},
+
 }
 
 var testTypeToTestConfigE2E = map[string][]testConfig{

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -70,31 +70,31 @@ var testTypeToTestConfig = map[string][]testConfig{
 	testTypeKeyEc2Linux: {
 		//Skipping this test for now until test is not flakey
 		//{testDir: "./test/ca_bundle"},
+		{testDir: "./test/cloudwatchlogs"},
 		{
-			testDir:     "./test/emf_prometheus",
-			targets:     map[string]map[string]struct{}{"os": {"al2": {}}},
-			maxAttempts: 2,
-		},
-
-		{
-			testDir:     "./test/emf_prometheus",
-			targets:     map[string]map[string]struct{}{"os": {"al2": {}}},
-			maxAttempts: 2,
+			testDir: "./test/metrics_number_dimension",
+			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
 		},
 		{
-			testDir:     "./test/emf_prometheus",
+			testDir:     "./test/emf_concurrent",
 			targets:     map[string]map[string]struct{}{"os": {"al2": {}}},
-			maxAttempts: 2,
+			maxAttempts: 1,
 		},
 		{
 			testDir:     "./test/emf_prometheus",
 			targets:     map[string]map[string]struct{}{"os": {"al2": {}}},
 			maxAttempts: 2,
 		},
+		{testDir: "./test/metric_value_benchmark"},
+		{testDir: "./test/run_as_user"},
+		{testDir: "./test/collection_interval"},
+		{testDir: "./test/metric_dimension"},
+		{testDir: "./test/restart"},
+		{testDir: "./test/xray"},
+		{testDir: "./test/otlp"},
 		{
-			testDir:     "./test/emf_prometheus",
-			targets:     map[string]map[string]struct{}{"os": {"al2": {}}},
-			maxAttempts: 2,
+			testDir: "./test/acceptance",
+			targets: map[string]map[string]struct{}{"os": {"ubuntu-20.04": {}}},
 		},
 		// skipping FIPS test as the test cannot be verified
 		// neither ssh nor SSM works after a reboot once FIPS is enabled
@@ -102,30 +102,96 @@ var testTypeToTestConfig = map[string][]testConfig{
 		//	testDir: "./test/fips",
 		//	targets: map[string]map[string]struct{}{"os": {"rhel8": {}}},
 		//},
+		{
+			testDir: "./test/lvm",
+			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
+		},
+		{
+			testDir: "./test/proxy",
+			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
+		},
+		{
+			testDir: "./test/ssl_cert",
+			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
+		},
+		{
+			testDir:      "./test/userdata",
+			terraformDir: "terraform/ec2/userdata",
+			targets:      map[string]map[string]struct{}{"os": {"ol9": {}}},
+		},
+		{
+			testDir:      "./test/credentials_file",
+			terraformDir: "terraform/ec2/creds",
+			targets:      map[string]map[string]struct{}{"os": {"al2": {}}},
+		},
+		{
+			testDir: "./test/amp",
+			targets: map[string]map[string]struct{}{"os": {"al2": {}}, "arc": {"amd64": {}}},
+		},
+		{
+			testDir: "./test/agent_otel_merging",
+			targets: map[string]map[string]struct{}{"os": {"al2": {}}, "arc": {"amd64": {}}},
+		},
+		{
+			testDir:      "./test/assume_role",
+			terraformDir: "terraform/ec2/assume_role",
+			targets:      map[string]map[string]struct{}{"os": {"al2": {}}},
+		},
 	},
 	testTypeKeyEc2SELinux: {
 		//skip test until test is not flakey
 		//{testDir: "./test/ca_bundle"},
+		{testDir: "./test/cloudwatchlogs"},
 		{
-			testDir:     "./test/emf_prometheus",
-			maxAttempts: 2,
+			testDir: "./test/metrics_number_dimension",
+			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
 		},
 		{
-			testDir:     "./test/emf_prometheus",
-			maxAttempts: 2,
-		},
-		{
-			testDir:     "./test/emf_prometheus",
-			maxAttempts: 2,
-		},
-		{
-			testDir:     "./test/emf_prometheus",
-			maxAttempts: 2,
-		},
-		{
-			testDir:     "./test/emf_prometheus",
+			testDir:     "./test/emf_concurrent",
 			targets:     map[string]map[string]struct{}{"os": {"al2": {}}},
+			maxAttempts: 1,
+		},
+		{
+			testDir:     "./test/emf_prometheus",
 			maxAttempts: 2,
+		},
+		{testDir: "./test/metric_value_benchmark"},
+		{testDir: "./test/run_as_user"},
+		{testDir: "./test/collection_interval"},
+		{testDir: "./test/metric_dimension"},
+		{testDir: "./test/restart"},
+		{testDir: "./test/xray"},
+		{testDir: "./test/selinux_negative_test"},
+		{testDir: "./test/otlp"},
+		{
+			testDir: "./test/lvm",
+			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
+		},
+		{
+			testDir: "./test/proxy",
+			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
+		},
+		{
+			testDir: "./test/ssl_cert",
+			targets: map[string]map[string]struct{}{"os": {"al2": {}}},
+		},
+		{
+			testDir:      "./test/credentials_file",
+			terraformDir: "terraform/ec2/creds",
+			targets:      map[string]map[string]struct{}{"os": {"al2": {}}},
+		},
+		{
+			testDir: "./test/amp",
+			targets: map[string]map[string]struct{}{"os": {"al2": {}}, "arc": {"amd64": {}}},
+		},
+		{
+			testDir: "./test/agent_otel_merging",
+			targets: map[string]map[string]struct{}{"os": {"al2": {}}, "arc": {"amd64": {}}},
+		},
+		{
+			testDir:      "./test/assume_role",
+			terraformDir: "terraform/ec2/assume_role",
+			targets:      map[string]map[string]struct{}{"os": {"al2": {}}},
 		},
 	},
 	/*
@@ -133,7 +199,130 @@ var testTypeToTestConfig = map[string][]testConfig{
 		Therefore, limit down the scope for testing in Mac since EC2 can be done with Linux
 		and Mac under the hood share similar plugins with Linux
 	*/
-
+	"ec2_mac": {
+		{testDir: "../../../test/feature/mac"},
+	},
+	"ec2_windows": {
+		{testDir: "../../../test/feature/windows"},
+		{testDir: "../../../test/restart"},
+		{testDir: "../../../test/acceptance"},
+		{testDir: "../../../test/feature/windows/event_logs"},
+		{
+			testDir: "../../../test/feature/windows/custom_start/userdata",
+			targets: map[string]map[string]struct{}{"os": {"win-2019": {}}},
+		},
+		{
+			testDir: "../../../test/feature/windows/custom_start/ssm_start",
+			targets: map[string]map[string]struct{}{"os": {"win-2019": {}}},
+		},
+		// assume role test doesn't add much value, and it already being tested with linux
+		//{testDir: "../../../test/assume_role"},
+	},
+	"ec2_performance": {
+		{testDir: "../../test/performance/emf"},
+		{testDir: "../../test/performance/logs"},
+		{testDir: "../../test/performance/system"},
+		{testDir: "../../test/performance/statsd"},
+		{testDir: "../../test/performance/collectd"},
+		{testDir: "../../test/performance/trace/xray", runMockServer: true},
+	},
+	"ec2_windows_performance": {
+		{testDir: "../../test/performance/windows/logs"},
+		{testDir: "../../test/performance/windows/system"},
+	},
+	"ec2_stress": {
+		{testDir: "../../test/stress/emf"},
+		{testDir: "../../test/stress/logs"},
+		{testDir: "../../test/stress/system"},
+		{testDir: "../../test/stress/statsd"},
+		{testDir: "../../test/stress/collectd"},
+	},
+	"ec2_windows_stress": {
+		{testDir: "../../test/stress/windows/logs"},
+		{testDir: "../../test/stress/windows/system"},
+	},
+	"ecs_fargate": {
+		{testDir: "./test/ecs/ecs_metadata"},
+	},
+	"ecs_ec2_daemon": {
+		{
+			testDir: "./test/metric_value_benchmark",
+			targets: map[string]map[string]struct{}{"metadataEnabled": {"enabled": {}}},
+		},
+		{
+			testDir: "./test/statsd",
+			targets: map[string]map[string]struct{}{"metadataEnabled": {"enabled": {}}},
+		},
+		{
+			testDir: "./test/emf",
+			targets: map[string]map[string]struct{}{"metadataEnabled": {"disabled": {}}},
+		},
+		{
+			testDir: "./test/emf",
+			targets: map[string]map[string]struct{}{"metadataEnabled": {"enabled": {}}},
+		},
+	},
+	"eks_addon": {
+		{
+			testDir:      "../../../../test/gpu",
+			terraformDir: "terraform/eks/addon/gpu",
+		},
+	},
+	"eks_daemon": {
+		{
+			testDir:      "./test/metric_value_benchmark",
+			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
+			instanceType: "g4dn.xlarge",
+		},
+		{
+			testDir:      "./test/metric_value_benchmark",
+			terraformDir: "terraform/eks/daemon/windows/2019",
+			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
+		},
+		{
+			testDir:      "./test/metric_value_benchmark",
+			terraformDir: "terraform/eks/daemon/windows/2022",
+			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
+		},
+		{
+			testDir: "./test/statsd", terraformDir: "terraform/eks/daemon/statsd",
+			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
+		},
+		{
+			testDir: "./test/emf", terraformDir: "terraform/eks/daemon/emf",
+			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
+		},
+		{
+			testDir: "./test/fluent", terraformDir: "terraform/eks/daemon/fluent/d",
+			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
+		},
+		{testDir: "./test/fluent", terraformDir: "terraform/eks/daemon/fluent/bit"},
+		{testDir: "./test/fluent", terraformDir: "terraform/eks/daemon/fluent/windows/2022"},
+		{
+			testDir: "./test/gpu", terraformDir: "terraform/eks/daemon/gpu",
+			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
+		},
+		{
+			testDir: "./test/awsneuron", terraformDir: "terraform/eks/daemon/awsneuron",
+			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
+		},
+		{
+			testDir: "./test/entity", terraformDir: "terraform/eks/daemon/entity",
+			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
+		},
+		//Skipping test until efa team implements fix
+		//{
+		//	testDir: "./test/efa", terraformDir: "terraform/eks/daemon/efa",
+		//	targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
+		//},
+		{
+			testDir: "./test/metric_value_benchmark", terraformDir: "terraform/eks/daemon/credentials/pod_identity",
+			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
+		},
+	},
+	"eks_deployment": {
+		{testDir: "./test/metric_value_benchmark"},
+	},
 }
 
 var testTypeToTestConfigE2E = map[string][]testConfig{

--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -126,11 +126,11 @@ resource "null_resource" "integration_test_run" {
     inline = concat(
       [
         "echo Preparing environment...",
+        "sudo yum install amazon-cloudwatch-agent -y",
       ],
 
       # SELinux test setup (if enabled)
       var.is_selinux_test ? [
-        "sudo yum install amazon-cloudwatch-agent -y",
         "echo Running SELinux test setup...",
         "sudo yum install selinux-policy selinux-policy-targeted policycoreutils-python-utils selinux-policy-devel -y",
         "sudo setenforce 1",


### PR DESCRIPTION
# Description of the issue
Currently test validates before metrics appear sometimes so in order to fix this issue adding a retry to make sure that test are not flaky:

Here is the flaky test fail: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14673647451/job/41185739077 (test retried)

Here is the test run that shows test passing 10+ times: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14710259879/job/41280752001