### PR TITLE
Skipping OTLP and MVB SELinux test to unblock PRs

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -162,7 +162,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 		{testDir: "./test/restart"},
 		{testDir: "./test/xray"},
 		{testDir: "./test/selinux_negative_test"},
-		{testDir: "./test/otlp"},
+		//{testDir: "./test/otlp"}, // Skipping test until it is fixed!
 		{
 			testDir: "./test/lvm",
 			targets: map[string]map[string]struct{}{"os": {"al2": {}}},

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -155,7 +155,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 			testDir:     "./test/emf_prometheus",
 			maxAttempts: 2,
 		},
-		{testDir: "./test/metric_value_benchmark"},
+		//{testDir: "./test/metric_value_benchmark"}, // Skipping test until it is fixed!
 		{testDir: "./test/run_as_user"},
 		{testDir: "./test/collection_interval"},
 		{testDir: "./test/metric_dimension"},


### PR DESCRIPTION
# Description of the issue
Currently the otlp and metric value benchmark selinux test is failing and is blocking prs. Test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14888797510/job/41815609374. These test will be added back once they are fixed.
