### PR TITLE
Increase timeout in userdata test

### DIFF
--- a/terraform/ec2/userdata/main.tf
+++ b/terraform/ec2/userdata/main.tf
@@ -93,7 +93,7 @@ resource "null_resource" "integration_test" {
         "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
         "echo run integration test",
         "cd ~/amazon-cloudwatch-agent-test",
-        "timeout 60 bash -c 'until [ -f /home/ec2-user/amazon-cloudwatch-agent-test/test/sanity/resources/verifyUnixCtlScript.sh ]; do echo \"Waiting for verifyUnixCtlScript.sh...\"; sleep 2; done'",
+        "timeout 120 bash -c 'until [ -f /home/ec2-user/amazon-cloudwatch-agent-test/test/sanity/resources/verifyUnixCtlScript.sh ]; do echo \"Waiting for verifyUnixCtlScript.sh...\"; sleep 2; done'",
         "sudo chmod 777 ~/amazon-cloudwatch-agent-test/test/sanity/resources/verifyUnixCtlScript.sh",
         "echo run sanity test && go test ./test/sanity -p 1 -v",
         "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -v"


### PR DESCRIPTION
# Description of the issue
Userdata test is failing for ol9
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/15330575566/job/43136394248?pr=1706

# Description of changes
Increases timeout during setup of test environment.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Test run completed successfully in local environment
