### PR TITLE
Test ECS Servicediscovery on ecs ec2

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -262,6 +262,10 @@ var testTypeToTestConfig = map[string][]testConfig{
 	},
 	"ecs_ec2_daemon": {
 		{
+			testDir: "./test/ecs/ecs_sd",
+			targets: map[string]map[string]struct{}{"metadataEnabled": {"enabled": {}}},
+		},
+		{
 			testDir: "./test/metric_value_benchmark",
 			targets: map[string]map[string]struct{}{"metadataEnabled": {"enabled": {}}},
 		},

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -262,10 +262,6 @@ var testTypeToTestConfig = map[string][]testConfig{
 	},
 	"ecs_ec2_daemon": {
 		{
-			testDir: "./test/ecs/ecs_sd",
-			targets: map[string]map[string]struct{}{"metadataEnabled": {"enabled": {}}},
-		},
-		{
 			testDir: "./test/metric_value_benchmark",
 			targets: map[string]map[string]struct{}{"metadataEnabled": {"enabled": {}}},
 		},
@@ -279,6 +275,10 @@ var testTypeToTestConfig = map[string][]testConfig{
 		},
 		{
 			testDir: "./test/emf",
+			targets: map[string]map[string]struct{}{"metadataEnabled": {"enabled": {}}},
+		},
+		{
+			testDir: "./test/ecs/ecs_sd",
 			targets: map[string]map[string]struct{}{"metadataEnabled": {"enabled": {}}},
 		},
 	},

--- a/terraform/ecs_ec2/daemon/main.tf
+++ b/terraform/ecs_ec2/daemon/main.tf
@@ -242,7 +242,7 @@ resource "null_resource" "validator" {
     command = <<-EOT
       echo "Validating metrics/logs"
       cd ../../..
-      go test ${var.test_dir} -timeout 0 -computeType=ECS -ecsLaunchType=EC2 -ecsDeploymentStrategy=DAEMON -cwagentConfigSsmParamName=${local.cwagent_config_ssm_param_name} -clusterArn=${aws_ecs_cluster.cluster.arn} -cwagentECSServiceName=${aws_ecs_service.cwagent_service.name} -v
+      go test ${var.test_dir} -timeout 0 -computeType=ECS -ecsLaunchType=EC2 -ecsDeploymentStrategy=DAEMON -cwagentConfigSsmParamName=${local.cwagent_config_ssm_param_name} -clusterArn=${aws_ecs_cluster.cluster.arn} -cwagentECSServiceName=${aws_ecs_service.cwagent_service.name} -clusterName=${aws_ecs_cluster.cluster.name} -v
     EOT
   }
   depends_on = [aws_ecs_service.cwagent_service, aws_ecs_service.extra_apps_service, null_resource.disable_metadata]

--- a/terraform/ecs_ec2/daemon/main.tf
+++ b/terraform/ecs_ec2/daemon/main.tf
@@ -242,7 +242,13 @@ resource "null_resource" "validator" {
     command = <<-EOT
       echo "Validating metrics/logs"
       cd ../../..
-      go test ${var.test_dir} -timeout 0 -computeType=ECS -ecsLaunchType=EC2 -ecsDeploymentStrategy=DAEMON -cwagentConfigSsmParamName=${local.cwagent_config_ssm_param_name} -clusterArn=${aws_ecs_cluster.cluster.arn} -cwagentECSServiceName=${aws_ecs_service.cwagent_service.name} -clusterName=${aws_ecs_cluster.cluster.name} -v
+      go test ${var.test_dir} -timeout 0 \
+      -computeType=ECS \
+      -ecsLaunchType=EC2 \
+      -ecsDeploymentStrategy=DAEMON \
+      -cwagentConfigSsmParamName=${local.cwagent_config_ssm_param_name} \
+      -clusterArn=${aws_ecs_cluster.cluster.arn} \
+      -cwagentECSServiceName=${aws_ecs_service.cwagent_service.name} -v
     EOT
   }
   depends_on = [aws_ecs_service.cwagent_service, aws_ecs_service.extra_apps_service, null_resource.disable_metadata]

--- a/terraform/ecs_fargate/linux/main.tf
+++ b/terraform/ecs_fargate/linux/main.tf
@@ -147,7 +147,12 @@ resource "null_resource" "validator" {
     command = <<-EOT
       echo "Validating metrics/logs"
       cd ../../..
-      go test ${var.test_dir} -v
+      go test ${var.test_dir} \
+      -computeType=ECS \
+      -ecsLaunchType=FARGATE \
+      -ecsDeploymentStrategy=DAEMON \
+      -clusterArn=${aws_ecs_cluster.cluster.arn} \
+      -v
     EOT
   }
   depends_on = [aws_ecs_service.cwagent_service, aws_ecs_service.extra_apps_service]

--- a/terraform/ecs_fargate/linux/main.tf
+++ b/terraform/ecs_fargate/linux/main.tf
@@ -147,7 +147,7 @@ resource "null_resource" "validator" {
     command = <<-EOT
       echo "Validating metrics/logs"
       cd ../../..
-      go test ${var.test_dir} -clusterName=${aws_ecs_cluster.cluster.name} -v
+      go test ${var.test_dir} -v
     EOT
   }
   depends_on = [aws_ecs_service.cwagent_service, aws_ecs_service.extra_apps_service]

--- a/test/ecs/ecs_sd/ecs_servicediscovery_runner.go
+++ b/test/ecs/ecs_sd/ecs_servicediscovery_runner.go
@@ -1,19 +1,23 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
+//go:build !windows
+
 package ecs_sd
 
 import (
 	_ "embed"
 	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
-	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	"log"
-	"strings"
-	"time"
 )
 
 const (

--- a/test/ecs/ecs_sd/ecs_servicediscovery_runner.go
+++ b/test/ecs/ecs_sd/ecs_servicediscovery_runner.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
 package ecs_sd
 
 import (
@@ -35,6 +38,7 @@ func (t ECSServiceDiscoveryTestRunner) GetTestName() string {
 func (t ECSServiceDiscoveryTestRunner) GetAgentConfigFileName() string {
 	return ""
 }
+
 func (t ECSServiceDiscoveryTestRunner) GetMeasuredMetrics() []string {
 	// dummy function to satisfy the interface
 	return []string{}
@@ -88,7 +92,7 @@ func (t ECSServiceDiscoveryTestRunner) ValidateLogGroupFormat(logGroupName strin
 	}
 
 	log.Printf("ECS ServiceDiscovery Test has exhausted %v retry times", MaxRetryCount)
-	return false, fmt.Errorf("%s:%s", "Test Retries Exhausted ", MaxRetryCount)
+	return false, fmt.Errorf("Test Retries Exhausted: %d", MaxRetryCount)
 }
 
 func (t ECSServiceDiscoveryTestRunner) ValidateLogsContent(logGroupName string, start time.Time, end time.Time) error {

--- a/test/ecs/ecs_sd/ecs_servicediscovery_runner.go
+++ b/test/ecs/ecs_sd/ecs_servicediscovery_runner.go
@@ -1,27 +1,28 @@
 package ecs_sd
 
 import (
+	_ "embed"
 	"fmt"
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	"github.com/stretchr/testify/assert"
 	"log"
 	"strings"
 	"time"
 )
 
 const (
-	RetryTime = 15
+	MaxRetryCount = 15
 	// Log group format: https://github.com/aws/amazon-cloudwatch-agent/blob/5ef3dba446cb56a4c2306878592b5d14300ae82f/translator/translate/otel/exporter/awsemf/prometheus.go#L38
 	ECSLogGroupNameFormat = "/aws/ecs/containerinsights/%s/prometheus"
 	// Log stream based on job name in extra_apps.tpl:https://github.com/aws/amazon-cloudwatch-agent-test/blob/main/test/ecs/ecs_sd/resources/extra_apps.tpl#L41
 	LogStreamName = "prometheus-redis"
-
-	namespace = "ecs_servicediscovery" //todo
 )
+
+//go:embed resources/emf_prometheus_redis_schema.json
+var schema string
 
 type ECSServiceDiscoveryTestRunner struct {
 	test_runner.BaseTestRunner
@@ -40,9 +41,8 @@ func (t ECSServiceDiscoveryTestRunner) GetMeasuredMetrics() []string {
 }
 
 func (t ECSServiceDiscoveryTestRunner) Validate() status.TestGroupResult {
-	testResults := []status.TestResult{}
-	testResults = append(testResults, t.validateHistogramMetric("my.delta.histogram")...)
-	testResults = append(testResults, t.validateHistogramMetric("my.cumulative.histogram")...)
+	var testResults []status.TestResult
+	testResults = append(testResults, t.ValidateCloudWatchLogs())
 
 	return status.TestGroupResult{
 		Name:        t.GetTestName(),
@@ -50,41 +50,49 @@ func (t ECSServiceDiscoveryTestRunner) Validate() status.TestGroupResult {
 	}
 }
 
-func TestValidatingCloudWatchLogs(t *testing.T) {
+func (t ECSServiceDiscoveryTestRunner) ValidateCloudWatchLogs() status.TestResult {
 	env := environment.GetEnvironmentMetaData()
-	logGroupName, logGroupFound, start, end := ValidateLogGroupFormat(t, env)
-
-	ValidateLogsContent(t, logGroupName, start, end)
-
-	if logGroupFound {
-		awsservice.DeleteLogGroupAndStream(logGroupName, LogStreamName)
-	}
-}
-
-func ValidateLogGroupFormat(t *testing.T, env *environment.MetaData) (string, bool, time.Time, time.Time) {
-	start := time.Now()
 	logGroupName := fmt.Sprintf(ECSLogGroupNameFormat, env.EcsClusterName)
 
-	var logGroupFound bool
-	for currentRetry := 1; ; currentRetry++ {
-
-		if currentRetry == RetryTime {
-			t.Fatalf("Test has exhausted %v retry time", RetryTime)
-		}
-
-		if !awsservice.IsLogGroupExists(logGroupName) {
-			log.Printf("Current retry: %v/%v and begin to sleep for 20s \n", currentRetry, RetryTime)
-			time.Sleep(20 * time.Second)
-			continue
-		}
-		break
+	testResult := status.TestResult{
+		Name:   fmt.Sprintf("Retrieve Test LogGroup: %s", logGroupName),
+		Status: status.FAILED,
 	}
-	end := time.Now()
-	return logGroupName, logGroupFound, start, end
+
+	logGroupFound, err := t.ValidateLogGroupFormat(logGroupName)
+
+	if logGroupFound {
+		if err != nil {
+			log.Printf("ECS ServiceDiscovery Test LogGroups invalid\n")
+			testResult.Name = err.Error()
+			testResult.Status = status.FAILED
+		} else {
+			testResult.Status = status.SUCCESSFUL
+		}
+		awsservice.DeleteLogGroupAndStream(logGroupName, LogStreamName)
+	}
+	return testResult
 }
 
-func ValidateLogsContent(t *testing.T, logGroupName string, start time.Time, end time.Time) {
-	err := awsservice.ValidateLogs(
+func (t ECSServiceDiscoveryTestRunner) ValidateLogGroupFormat(logGroupName string) (bool, error) {
+	start := time.Now()
+
+	for retries := 0; retries < MaxRetryCount; retries++ {
+		if awsservice.IsLogGroupExists(logGroupName) {
+			end := time.Now()
+			return true, t.ValidateLogsContent(logGroupName, start, end)
+		}
+
+		log.Printf("Retry %d/%d: Log group not found. Waiting 20 seconds...\n", retries+1, MaxRetryCount)
+		time.Sleep(20 * time.Second)
+	}
+
+	log.Printf("ECS ServiceDiscovery Test has exhausted %v retry times", MaxRetryCount)
+	return false, fmt.Errorf("%s:%s", "Test Retries Exhausted ", MaxRetryCount)
+}
+
+func (t ECSServiceDiscoveryTestRunner) ValidateLogsContent(logGroupName string, start time.Time, end time.Time) error {
+	return awsservice.ValidateLogs(
 		logGroupName,
 		LogStreamName,
 		&start,
@@ -102,5 +110,4 @@ func ValidateLogsContent(t *testing.T, logGroupName string, start time.Time, end
 			awsservice.AssertLogContainsSubstring("\"job\":\"prometheus-redis\""),
 		),
 	)
-	assert.NoError(t, err)
 }

--- a/test/ecs/ecs_sd/ecs_servicediscovery_test.go
+++ b/test/ecs/ecs_sd/ecs_servicediscovery_test.go
@@ -5,24 +5,11 @@ package ecs_sd
 
 import (
 	_ "embed"
-	"fmt"
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
-	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
-	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
-	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
 	"github.com/stretchr/testify/suite"
-	"log"
-	"strings"
 	"testing"
-	"time"
-
-	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	"github.com/stretchr/testify/assert"
-
-	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 )
 
 /*
@@ -64,7 +51,6 @@ func (suite *ECSServiceDiscoveryTestSuite) GetSuiteName() string {
 }
 
 func (suite *ECSServiceDiscoveryTestSuite) TestAllInSuite() {
-	
 	for _, testRunner := range testRunners {
 		suite.AddToSuiteResult(testRunner.Run())
 	}

--- a/test/ecs/ecs_sd/ecs_servicediscovery_test.go
+++ b/test/ecs/ecs_sd/ecs_servicediscovery_test.go
@@ -24,12 +24,22 @@ Implementation:
 */
 
 var (
-	testRunners []*test_runner.TestRunner = []*test_runner.TestRunner{
-		{
-			TestRunner: &ECSServiceDiscoveryTestRunner{},
-		},
-	}
+	ecsTestRunners []*test_runner.ECSTestRunner
 )
+
+func getEcsTestRunners(env *environment.MetaData) []*test_runner.ECSTestRunner {
+	if len(ecsTestRunners) == 0 {
+
+		ecsTestRunners = []*test_runner.ECSTestRunner{
+			{
+				Runner:      &ECSServiceDiscoveryTestRunner{},
+				RunStrategy: &test_runner.ECSAgentRunStrategy{},
+				Env:         *env,
+			},
+		}
+	}
+	return ecsTestRunners
+}
 
 var _ test_runner.ITestRunner = (*ECSServiceDiscoveryTestRunner)(nil)
 
@@ -51,8 +61,9 @@ func (suite *ECSServiceDiscoveryTestSuite) GetSuiteName() string {
 }
 
 func (suite *ECSServiceDiscoveryTestSuite) TestAllInSuite() {
-	for _, testRunner := range testRunners {
-		suite.AddToSuiteResult(testRunner.Run())
+	env := environment.GetEnvironmentMetaData()
+	for _, ecsTestRunner := range getEcsTestRunners(env) {
+		ecsTestRunner.Run(suite, env)
 	}
 	suite.Assert().Equal(status.SUCCESSFUL, suite.Result.GetStatus(), "ECS ServiceDiscovery Test Suite Failed")
 }

--- a/test/ecs/ecs_sd/ecs_servicediscovery_test.go
+++ b/test/ecs/ecs_sd/ecs_servicediscovery_test.go
@@ -1,15 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
+//go:build !windows
+
 package ecs_sd
 
 import (
-	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
-	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 /*

--- a/test/ecs/ecs_sd/ecs_servicediscoveryrunner.go
+++ b/test/ecs/ecs_sd/ecs_servicediscoveryrunner.go
@@ -1,0 +1,106 @@
+package ecs_sd
+
+import (
+	"fmt"
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/stretchr/testify/assert"
+	"log"
+	"strings"
+	"time"
+)
+
+const (
+	RetryTime = 15
+	// Log group format: https://github.com/aws/amazon-cloudwatch-agent/blob/5ef3dba446cb56a4c2306878592b5d14300ae82f/translator/translate/otel/exporter/awsemf/prometheus.go#L38
+	ECSLogGroupNameFormat = "/aws/ecs/containerinsights/%s/prometheus"
+	// Log stream based on job name in extra_apps.tpl:https://github.com/aws/amazon-cloudwatch-agent-test/blob/main/test/ecs/ecs_sd/resources/extra_apps.tpl#L41
+	LogStreamName = "prometheus-redis"
+
+	namespace = "ecs_servicediscovery" //todo
+)
+
+type ECSServiceDiscoveryTestRunner struct {
+	test_runner.BaseTestRunner
+}
+
+func (t ECSServiceDiscoveryTestRunner) GetTestName() string {
+	return "ecs_servicediscovery"
+}
+
+func (t ECSServiceDiscoveryTestRunner) GetAgentConfigFileName() string {
+	return ""
+}
+func (t ECSServiceDiscoveryTestRunner) GetMeasuredMetrics() []string {
+	// dummy function to satisfy the interface
+	return []string{}
+}
+
+func (t ECSServiceDiscoveryTestRunner) Validate() status.TestGroupResult {
+	testResults := []status.TestResult{}
+	testResults = append(testResults, t.validateHistogramMetric("my.delta.histogram")...)
+	testResults = append(testResults, t.validateHistogramMetric("my.cumulative.histogram")...)
+
+	return status.TestGroupResult{
+		Name:        t.GetTestName(),
+		TestResults: testResults,
+	}
+}
+
+func TestValidatingCloudWatchLogs(t *testing.T) {
+	env := environment.GetEnvironmentMetaData()
+	logGroupName, logGroupFound, start, end := ValidateLogGroupFormat(t, env)
+
+	ValidateLogsContent(t, logGroupName, start, end)
+
+	if logGroupFound {
+		awsservice.DeleteLogGroupAndStream(logGroupName, LogStreamName)
+	}
+}
+
+func ValidateLogGroupFormat(t *testing.T, env *environment.MetaData) (string, bool, time.Time, time.Time) {
+	start := time.Now()
+	logGroupName := fmt.Sprintf(ECSLogGroupNameFormat, env.EcsClusterName)
+
+	var logGroupFound bool
+	for currentRetry := 1; ; currentRetry++ {
+
+		if currentRetry == RetryTime {
+			t.Fatalf("Test has exhausted %v retry time", RetryTime)
+		}
+
+		if !awsservice.IsLogGroupExists(logGroupName) {
+			log.Printf("Current retry: %v/%v and begin to sleep for 20s \n", currentRetry, RetryTime)
+			time.Sleep(20 * time.Second)
+			continue
+		}
+		break
+	}
+	end := time.Now()
+	return logGroupName, logGroupFound, start, end
+}
+
+func ValidateLogsContent(t *testing.T, logGroupName string, start time.Time, end time.Time) {
+	err := awsservice.ValidateLogs(
+		logGroupName,
+		LogStreamName,
+		&start,
+		&end,
+		awsservice.AssertLogsNotEmpty(),
+		awsservice.AssertPerLog(
+			awsservice.AssertLogSchema(awsservice.WithSchema(schema)),
+			func(event types.OutputLogEvent) error {
+				if strings.Contains(*event.Message, "CloudWatchMetrics") &&
+					!strings.Contains(*event.Message, "\"Namespace\":\"ECS/ContainerInsights/Prometheus\"") {
+					return fmt.Errorf("emf log found for non ECS/ContainerInsights/Prometheus namespace: %s", *event.Message)
+				}
+				return nil
+			},
+			awsservice.AssertLogContainsSubstring("\"job\":\"prometheus-redis\""),
+		),
+	)
+	assert.NoError(t, err)
+}

--- a/test/statsd/statsd_test.go
+++ b/test/statsd/statsd_test.go
@@ -26,8 +26,8 @@ type StatsDTestSuite struct {
 	test_runner.TestSuite
 }
 
-func (suite *StatsDTestSuite) SetupSuite() {
-	fmt.Println(">>>> Starting StatsDTestSuite")
+func (suite *StatsDTestSuite) GetSuiteName() string {
+	return "StatsDTestSuite"
 }
 
 func (suite *StatsDTestSuite) TearDownSuite() {

--- a/test/statsd/statsd_test.go
+++ b/test/statsd/statsd_test.go
@@ -30,11 +30,6 @@ func (suite *StatsDTestSuite) GetSuiteName() string {
 	return "StatsDTestSuite"
 }
 
-func (suite *StatsDTestSuite) TearDownSuite() {
-	suite.Result.Print()
-	fmt.Println(">>>> Finished StatsDTestSuite")
-}
-
 func init() {
 	environment.RegisterEnvironmentMetaDataFlags()
 }

--- a/test/test_runner/ecs_test_runner.go
+++ b/test/test_runner/ecs_test_runner.go
@@ -63,7 +63,7 @@ func (t *ECSTestRunner) Run(s ITestSuite, e *environment.MetaData) {
 	if len(agentConfigFileName) != 0 {
 		err := t.RunStrategy.RunAgentStrategy(e, t.Runner.GetAgentConfigFileName())
 		if err != nil {
-			log.Printf("Failed to run agent with config for the given testm err:%v", err)
+			log.Printf("Failed to run agent with config for the given test err:%v", err)
 			s.AddToSuiteResult(status.TestGroupResult{
 				Name: t.Runner.GetTestName(),
 				TestResults: []status.TestResult{


### PR DESCRIPTION
# Description of the issue
We need to test ECS servicediscovery against ecs_ec2 as well as ecs_fargate. Adding the missing scenario

# Description of changes
Add ecs_sd test dir to the ecs_ec2 test matrix in the generator

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Running integ tests: 
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/15828254148

Test run now includes new test `ecs_ec2_daemon:ecs_ecs_sd_test`