### PR TITLE
Stress test sample count bound variance increase

### DIFF
--- a/validator/validators/stress/stress_validator.go
+++ b/validator/validators/stress/stress_validator.go
@@ -438,8 +438,8 @@ func (s *StressValidator) ValidateStressMetric(metricName, metricNamespace strin
 
 	// Validate if the metrics are not dropping any metrics and able to backfill within the same minute (e.g if the memory_rss metric is having collection_interval 1
 	// , it will need to have 60 sample counts - 1 datapoint / second)
-	if ok := awsservice.ValidateSampleCount(metricName, metricNamespace, metricDimensions, startTime, endTime, metricSampleCount-10, metricSampleCount, int32(boundAndPeriod)); !ok {
-		return fmt.Errorf("\n metric %s is not within sample count bound [ %d, %d]", metricName, metricSampleCount-10, metricSampleCount)
+	if ok := awsservice.ValidateSampleCount(metricName, metricNamespace, metricDimensions, startTime, endTime, metricSampleCount-15, metricSampleCount, int32(boundAndPeriod)); !ok {
+		return fmt.Errorf("\n metric %s is not within sample count bound [ %d, %d]", metricName, metricSampleCount-15, metricSampleCount)
 	}
 
 	return nil


### PR DESCRIPTION
# Description of the issue
Currently sometimes we only get 288 sample count which is not in the bounds of [290-300]. Here is the a failing test: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/15740503860/job/44364409368


# Description of changes
Changing bound from [290-300] to [285-300] in order to make test not flaky.

