### PR TITLE
fix helm struct failures and AMI for eks 1.33

### DIFF
--- a/terraform/eks/daemon/credentials/pod_identity/main.tf
+++ b/terraform/eks/daemon/credentials/pod_identity/main.tf
@@ -213,15 +213,16 @@ resource "helm_release" "aws_observability" {
   namespace        = "amazon-cloudwatch"
   create_namespace = true
 
-  set {
-    name  = "clusterName"
-    value = aws_eks_cluster.this.name
-  }
-
-  set {
-    name  = "region"
-    value = "us-west-2"
-  }
+  set = [
+    {
+      name  = "clusterName"
+      value = aws_eks_cluster.this.name
+    }, 
+    {
+      name  = "region"
+      value = "us-west-2"
+    }
+  ]
   depends_on = [
     aws_eks_cluster.this,
     aws_eks_node_group.this,

--- a/terraform/eks/daemon/credentials/pod_identity/providers.tf
+++ b/terraform/eks/daemon/credentials/pod_identity/providers.tf
@@ -17,7 +17,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority.0.data)
     exec {

--- a/terraform/eks/daemon/entity/main.tf
+++ b/terraform/eks/daemon/entity/main.tf
@@ -181,16 +181,16 @@ resource "helm_release" "aws_observability" {
   chart            = "./helm-charts/charts/amazon-cloudwatch-observability"
   namespace        = "amazon-cloudwatch"
   create_namespace = true
-
-  set {
-    name  = "clusterName"
-    value = aws_eks_cluster.this.name
-  }
-
-  set {
-    name  = "region"
-    value = "us-west-2"
-  }
+  set = [
+    {
+      name  = "clusterName"
+      value = aws_eks_cluster.this.name
+    }, 
+    {
+      name  = "region"
+      value = "us-west-2"
+    }
+  ]
   depends_on = [
     aws_eks_cluster.this,
     aws_eks_node_group.this,

--- a/terraform/eks/daemon/entity/providers.tf
+++ b/terraform/eks/daemon/entity/providers.tf
@@ -17,7 +17,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority.0.data)
     exec {

--- a/terraform/eks/deployment/main.tf
+++ b/terraform/eks/deployment/main.tf
@@ -47,7 +47,7 @@ resource "aws_eks_node_group" "this" {
     min_size     = 1
   }
 
-  ami_type       = "AL2_x86_64"
+  ami_type = var.k8s_version >= "1.33" ? "AL2023_x86_64_STANDARD" : "AL2_x86_64"
   capacity_type  = "ON_DEMAND"
   disk_size      = 20
   instance_types = ["t3.medium"]


### PR DESCRIPTION
# Description of the issue
Integ tests for EKS are failing due to:
- wrong kubernetes object used where the latest helm struct only supports variable
- AL2 AMI being used for eks 1.33 with deployment test

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

