### PR TITLE
Switch null_resource to external for helm git clone step

### DIFF
--- a/terraform/eks/daemon/credentials/pod_identity/main.tf
+++ b/terraform/eks/daemon/credentials/pod_identity/main.tf
@@ -194,17 +194,13 @@ resource "aws_security_group_rule" "nodes_cluster_inbound" {
   type                     = "ingress"
 }
 
-resource "null_resource" "clone_helm_chart" {
-  triggers = {
-    timestamp = "${timestamp()}" # Forces re-run on every apply
-  }
-  provisioner "local-exec" {
-    command = <<-EOT
-      if [ ! -d "./helm-charts" ]; then
-        git clone -b ${var.helm_chart_branch} https://github.com/aws-observability/helm-charts.git ./helm-charts
-      fi
-    EOT
-  }
+data "external" "clone_helm_chart" {
+  program = ["bash", "-c", <<-EOT
+    rm -rf ./helm-charts
+    git clone -b ${var.helm_chart_branch} https://github.com/aws-observability/helm-charts.git ./helm-charts
+    echo '{"status":"ready"}'
+  EOT
+  ]
 }
 
 resource "helm_release" "aws_observability" {
@@ -220,15 +216,15 @@ resource "helm_release" "aws_observability" {
     },
     {
       name  = "region"
-      value = "us-west-2"
+      value = var.region
     }
   ]
   depends_on = [
     aws_eks_cluster.this,
     aws_eks_node_group.this,
-    null_resource.clone_helm_chart,
     aws_eks_addon.pod_identity_addon,
     aws_eks_pod_identity_association.association,
+    data.external.clone_helm_chart,
   ]
 }
 


### PR DESCRIPTION
# Description of the issue
`helm_release` is failing by missing cloned helm charts

# Description of changes
- Change `null_resource` to `external` to make sure the completion of `git clone` step of the charts

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Run `terraform apply` locally
```
helm_release.aws_observability: Still creating... [10s elapsed]
helm_release.aws_observability: Still creating... [20s elapsed]
helm_release.aws_observability: Creation complete after 29s [id=amazon-cloudwatch-observability]
```
