### PR TITLE
Add ECS Service Discovery Tests - TaskDefList & ServiceNameList 

### DIFF
--- a/terraform/ecs_fargate/linux/main.tf
+++ b/terraform/ecs_fargate/linux/main.tf
@@ -152,6 +152,8 @@ resource "null_resource" "validator" {
       -ecsLaunchType=FARGATE \
       -ecsDeploymentStrategy=DAEMON \
       -clusterArn=${aws_ecs_cluster.cluster.arn} \
+      -cwagentECSServiceName=${aws_ecs_service.cwagent_service.name} \
+      -cwagentConfigSsmParamName=${aws_ssm_parameter.cwagent_config.name} \
       -v
     EOT
   }

--- a/test/ecs/ecs_sd/ecs_servicediscovery_runner.go
+++ b/test/ecs/ecs_sd/ecs_servicediscovery_runner.go
@@ -84,7 +84,7 @@ func (t ECSServiceDiscoveryTestRunner) ValidateCloudWatchLogs() status.TestResul
 
 	if logGroupFound {
 		if err != nil {
-			log.Printf("ECS ServiceDiscovery Test LogGroups invalid\n")
+			log.Printf("ECS ServiceDiscovery Test LogGroups invalid: %s\n", err)
 			testResult.Name = err.Error()
 			testResult.Status = status.FAILED
 		} else {
@@ -97,6 +97,11 @@ func (t ECSServiceDiscoveryTestRunner) ValidateCloudWatchLogs() status.TestResul
 
 func (t ECSServiceDiscoveryTestRunner) ValidateLogGroupFormat(logGroupName string) (bool, error) {
 	start := time.Now()
+
+	log.Println("Sleeping to allow metric collection in CloudWatch Logs.")
+	time.Sleep(2 * time.Minute)
+
+	log.Printf("Searching for LogGroup: %s\n", logGroupName)
 
 	for retries := 0; retries < MaxRetryCount; retries++ {
 		if awsservice.IsLogGroupExists(logGroupName) {

--- a/test/ecs/ecs_sd/ecs_servicediscovery_runner.go
+++ b/test/ecs/ecs_sd/ecs_servicediscovery_runner.go
@@ -33,14 +33,27 @@ var schema string
 
 type ECSServiceDiscoveryTestRunner struct {
 	test_runner.BaseTestRunner
+	scenarioName string
 }
 
 func (t ECSServiceDiscoveryTestRunner) GetTestName() string {
+	if t.scenarioName != "" {
+		return "ecs_servicediscovery_" + t.scenarioName
+	}
 	return "ecs_servicediscovery"
 }
 
 func (t ECSServiceDiscoveryTestRunner) GetAgentConfigFileName() string {
-	return ""
+	switch t.scenarioName {
+	case "dockerLabel":
+		return ""
+	case "taskDefinitionList":
+		return "./resources/config_task_definition_list.json"
+	case "serviceNameList":
+		return "./resources/config_service_name_list.json"
+	default:
+		return ""
+	}
 }
 
 func (t ECSServiceDiscoveryTestRunner) GetMeasuredMetrics() []string {

--- a/test/ecs/ecs_sd/ecs_servicediscovery_test.go
+++ b/test/ecs/ecs_sd/ecs_servicediscovery_test.go
@@ -17,13 +17,16 @@ import (
 
 /*
 Purpose:
-1) Validate ECS ServiceDiscovery via DockerLabels by publishing Prometheus EMF to CW  https://github.com/aws/amazon-cloudwatch-agent/blob/main/internal/ecsservicediscovery/README.md
+1) Validate ECS ServiceDiscovery via multiple methods by publishing Prometheus EMF to CW  https://github.com/aws/amazon-cloudwatch-agent/blob/main/internal/ecsservicediscovery/README.md
+   - docker_label
+   - task_definition_list
+   - service_name_list_for_tasks
 2) Detect the changes in metadata endpoint for ECS Container Agent https://github.com/aws/amazon-cloudwatch-agent/blob/main/translator/util/ecsutil/ecsutil.go#L67-L75
 
 
 Implementation:
 1) Check if the LogGroupFormat correctly scrapes the clusterName from metadata endpoint (https://github.com/aws/amazon-cloudwatch-agent/blob/5ef3dba446cb56a4c2306878592b5d14300ae82f/translator/translate/otel/exporter/awsemf/prometheus.go#L38)
-2) Check if expected Prometheus EMF data is correctly published as logs and metrics to CloudWatch
+2) Check if expected Prometheus EMF data is correctly published as logs and metrics to CloudWatch for each service discovery method
 */
 
 var (
@@ -35,7 +38,17 @@ func getEcsTestRunners(env *environment.MetaData) []*test_runner.ECSTestRunner {
 
 		ecsTestRunners = []*test_runner.ECSTestRunner{
 			{
-				Runner:      &ECSServiceDiscoveryTestRunner{},
+				Runner:      &ECSServiceDiscoveryTestRunner{scenarioName: "dockerLabel"},
+				RunStrategy: &test_runner.ECSAgentRunStrategy{},
+				Env:         *env,
+			},
+			{
+				Runner:      &ECSServiceDiscoveryTestRunner{scenarioName: "taskDefinitionList"},
+				RunStrategy: &test_runner.ECSAgentRunStrategy{},
+				Env:         *env,
+			},
+			{
+				Runner:      &ECSServiceDiscoveryTestRunner{scenarioName: "serviceNameList"},
 				RunStrategy: &test_runner.ECSAgentRunStrategy{},
 				Env:         *env,
 			},

--- a/test/ecs/ecs_sd/resources/config_service_name_list.json
+++ b/test/ecs/ecs_sd/resources/config_service_name_list.json
@@ -1,0 +1,58 @@
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "root",
+    "debug": true
+  },
+  "logs": {
+    "metrics_collected": {
+      "emf": { },
+      "prometheus": {
+        "prometheus_config_path": "env:PROMETHEUS_CONFIG_CONTENT",
+        "ecs_service_discovery": {
+          "sd_frequency": "1m",
+          "sd_result_file": "/tmp/cwagent_ecs_auto_sd.yaml",
+          "service_name_list_for_tasks": [
+            {
+              "sd_metrics_ports": "9121",
+              "sd_service_name_pattern": ".*extra-apps-service.*"
+            }
+          ]
+        },
+        "emf_processor": {
+          "metric_declaration": [
+            {
+              "source_labels": ["container_name"],
+              "label_matcher": "^redis-exporter-.*$",
+              "dimensions": [["ClusterName","TaskDefinitionFamily"]],
+              "metric_selectors": [
+                "^redis_net_(in|out)put_bytes_total$",
+                "^redis_(expired|evicted)_keys_total$",
+                "^redis_keyspace_(hits|misses)_total$",
+                "^redis_memory_used_bytes$",
+                "^redis_connected_clients$"
+              ]
+            },
+            {
+              "source_labels": ["container_name"],
+              "label_matcher": "^redis-exporter-.*$",
+              "dimensions": [["ClusterName","TaskDefinitionFamily","cmd"]],
+              "metric_selectors": [
+                "^redis_commands_total$"
+              ]
+            },
+            {
+              "source_labels": ["container_name"],
+              "label_matcher": "^redis-exporter-.*$",
+              "dimensions": [["ClusterName","TaskDefinitionFamily","db"]],
+              "metric_selectors": [
+                "^redis_db_keys$"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "force_flush_interval": 5
+  }
+}

--- a/test/ecs/ecs_sd/resources/config_task_definition_list.json
+++ b/test/ecs/ecs_sd/resources/config_task_definition_list.json
@@ -1,0 +1,58 @@
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "root",
+    "debug": true
+  },
+  "logs": {
+    "metrics_collected": {
+      "emf": { },
+      "prometheus": {
+        "prometheus_config_path": "env:PROMETHEUS_CONFIG_CONTENT",
+        "ecs_service_discovery": {
+          "sd_frequency": "1m",
+          "sd_result_file": "/tmp/cwagent_ecs_auto_sd.yaml",
+          "task_definition_list": [
+            {
+              "sd_metrics_ports": "9121",
+              "sd_task_definition_arn_pattern": ".*:task-definition/.*extra-apps-family.*:[0-9]+"
+            }
+          ]
+        },
+        "emf_processor": {
+          "metric_declaration": [
+            {
+              "source_labels": ["container_name"],
+              "label_matcher": "^redis-exporter-.*$",
+              "dimensions": [["ClusterName","TaskDefinitionFamily"]],
+              "metric_selectors": [
+                "^redis_net_(in|out)put_bytes_total$",
+                "^redis_(expired|evicted)_keys_total$",
+                "^redis_keyspace_(hits|misses)_total$",
+                "^redis_memory_used_bytes$",
+                "^redis_connected_clients$"
+              ]
+            },
+            {
+              "source_labels": ["container_name"],
+              "label_matcher": "^redis-exporter-.*$",
+              "dimensions": [["ClusterName","TaskDefinitionFamily","cmd"]],
+              "metric_selectors": [
+                "^redis_commands_total$"
+              ]
+            },
+            {
+              "source_labels": ["container_name"],
+              "label_matcher": "^redis-exporter-.*$",
+              "dimensions": [["ClusterName","TaskDefinitionFamily","db"]],
+              "metric_selectors": [
+                "^redis_db_keys$"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "force_flush_interval": 5
+  }
+}

--- a/test/test_runner/ecs_test_runner.go
+++ b/test/test_runner/ecs_test_runner.go
@@ -26,22 +26,22 @@ type ECSAgentRunStrategy struct {
 func (r *ECSAgentRunStrategy) RunAgentStrategy(e *environment.MetaData, configFilePath string) error {
 	b, err := os.ReadFile(configFilePath)
 	if err != nil {
-		return fmt.Errorf("Failed while reading config file")
+		return fmt.Errorf("Failed while reading config file: %s\n", configFilePath)
 	}
 
 	agentConfig := string(b)
 
 	err = awsservice.PutStringParameter(e.CwagentConfigSsmParamName, agentConfig)
 	if err != nil {
-		return fmt.Errorf("Failed while reading config file : %s", err.Error())
+		return fmt.Errorf("Failed while reading config file : %s\n", err.Error())
 	}
-	fmt.Print("Put parameter successful")
+	fmt.Println("Put parameter successful.")
 
 	err = awsservice.RestartDaemonService(e.EcsClusterArn, e.EcsServiceName)
 	if err != nil {
 		fmt.Print(err)
 	}
-	fmt.Print("CWAgent service is restarted")
+	fmt.Println("CWAgent service is restarting. Sleeping..")
 
 	time.Sleep(1 * time.Minute)
 
@@ -63,7 +63,7 @@ func (t *ECSTestRunner) Run(s ITestSuite, e *environment.MetaData) {
 	if len(agentConfigFileName) != 0 {
 		err := t.RunStrategy.RunAgentStrategy(e, t.Runner.GetAgentConfigFileName())
 		if err != nil {
-			log.Printf("Failed to run agent with config for the given test err:%v", err)
+			log.Printf("Failed to run agent with config for the given test err: %v\n", err)
 			s.AddToSuiteResult(status.TestGroupResult{
 				Name: t.Runner.GetTestName(),
 				TestResults: []status.TestResult{
@@ -75,6 +75,8 @@ func (t *ECSTestRunner) Run(s ITestSuite, e *environment.MetaData) {
 			})
 			return
 		}
+	} else {
+		log.Printf("CloudWatch Agent started.")
 	}
 
 	testGroupResult := t.Runner.Validate()

--- a/test/test_runner/ecs_test_runner.go
+++ b/test/test_runner/ecs_test_runner.go
@@ -43,7 +43,7 @@ func (r *ECSAgentRunStrategy) RunAgentStrategy(e *environment.MetaData, configFi
 	}
 	fmt.Print("CWAgent service is restarted")
 
-	time.Sleep(5 * time.Minute)
+	time.Sleep(1 * time.Minute)
 
 	return nil
 }


### PR DESCRIPTION
# Description of the issue
Current Service Discovery testing only covers config via DockerLabel. This gap prevents us from effectively determining if any changes impact ECS Service Discovery functionality configured using ECS Task Definition List or ECS Service Name List configs.

# Description of changes
This change introduces additional cloudwatch agent configs for the remaining scenarios, and updates the code to loop through each one and validate published CloudWatch Logs.

This change also includes minor updates to error logging for debugging

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Validated ECS_SD tests succeed against ECS_Fargate and ECS_EC2. No other ECS tasks are broken: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/16484932513/job/46607735033

Note: Some unrelated test failures occur due to test flakiness.