### PR TITLE
[EKS Scalability Testing] Implement metric validation tests for large scale eks cluster

### DIFF
--- a/environment/metadata.go
+++ b/environment/metadata.go
@@ -66,6 +66,8 @@ type MetaData struct {
 	SampleApp                                   string
 	AccountId                                   string
 	EKSInstallationType                         eksinstallationtype.EKSInstallationType
+	PerformanceMetricMapName                    string
+	PerformanceTestName                         string
 }
 
 type MetaDataStrings struct {
@@ -110,6 +112,8 @@ type MetaDataStrings struct {
 	SampleApp                                   string
 	AccountId                                   string
 	EKSInstallationType                         string
+	PerformanceMetricMapName                    string
+	PerformanceTestName                         string
 }
 
 func registerComputeType(dataString *MetaDataStrings) {
@@ -140,6 +144,8 @@ func registerEKSData(d *MetaDataStrings) {
 	flag.StringVar(&(d.EKSClusterName), "eksClusterName", "", "EKS cluster name")
 	flag.StringVar(&(d.EksDeploymentStrategy), "eksDeploymentStrategy", "", "Daemon/Replica/Sidecar")
 	flag.StringVar(&(d.EksGpuType), "eksGpuType", "", "nvidia/inferentia")
+	flag.StringVar(&(d.PerformanceMetricMapName), "performanceMetricMapName", "", "name of eks performance metric map within directory")
+	flag.StringVar(&(d.PerformanceTestName), "performanceTestName", "", "name of eks performance test")
 }
 
 func registerEKSE2ETestData(dataString *MetaDataStrings) {
@@ -282,6 +288,8 @@ func fillEKSData(e *MetaData, data *MetaDataStrings) {
 
 	e.EKSClusterName = data.EKSClusterName
 	e.EksGpuType = data.EksGpuType
+	e.PerformanceMetricMapName = data.PerformanceMetricMapName
+	e.PerformanceTestName = data.PerformanceTestName
 }
 
 func fillEKSInstallationType(e *MetaData, data *MetaDataStrings) {

--- a/test/metric/stat.go
+++ b/test/metric/stat.go
@@ -10,7 +10,7 @@ const (
 	AVERAGE                  Statistics = "Average"
 	SAMPLE_COUNT             Statistics = "SampleCount"
 	MINIMUM                  Statistics = "Minimum"
-	MAXUMUM                  Statistics = "Maximum"
+	MAXIMUM                  Statistics = "Maximum"
 	SUM                      Statistics = "Sum"
 	HighResolutionStatPeriod            = 10
 	MinuteStatPeriod                    = 60

--- a/test/performance/eks/eks_performance_test.go
+++ b/test/performance/eks/eks_performance_test.go
@@ -29,7 +29,7 @@ func TestEKSPerformance(t *testing.T) {
 		dimensions := GetMetricDimensions(metric, env)
 
 		log.Printf("Fetching metric from CloudWatch : %v", metric)
-		testResults = append(testResults, ValidatePerformanceMetrics(metric.Name, metric.Threshold, dimensions))
+		testResults = append(testResults, ValidatePerformanceMetrics(metric.Name, metric.Threshold, metric.Statistic, dimensions))
 	}
 
 	res := status.TestGroupResult{

--- a/test/performance/eks/eks_performance_test.go
+++ b/test/performance/eks/eks_performance_test.go
@@ -3,7 +3,6 @@
 package eks
 
 import (
-	"flag"
 	"log"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 
 func init() {
 	environment.RegisterEnvironmentMetaDataFlags()
-	flag.Parse()
 }
 
 func TestEKSPerformance(t *testing.T) {

--- a/test/performance/eks/eks_performance_test.go
+++ b/test/performance/eks/eks_performance_test.go
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+package eks
+
+import (
+	"flag"
+	"log"
+	"testing"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+)
+
+func init() {
+	environment.RegisterEnvironmentMetaDataFlags()
+	flag.Parse()
+}
+
+func TestEKSPerformance(t *testing.T) {
+	env := environment.GetEnvironmentMetaData()
+	testMetricsMap, err := GetEKSPerformanceMetrics(env.PerformanceMetricMapName)
+	if err != nil {
+		t.Fatalf("Unable to get EKS performance metrics: %v", err)
+	}
+
+	var testResults []status.TestResult
+	for _, metric := range testMetricsMap.Metrics {
+
+		log.Printf("Fetching dimensions")
+		dimensions := GetMetricDimensions(metric, env)
+
+		log.Printf("Fetching metric from CloudWatch : %v", metric)
+		testResults = append(testResults, ValidatePerformanceMetrics(metric.Name, metric.Threshold, dimensions))
+	}
+
+	res := status.TestGroupResult{
+		Name:        env.PerformanceTestName,
+		TestResults: testResults,
+	}
+
+	if res.GetStatus() != status.SUCCESSFUL {
+		log.Printf("%s test group failed", res.Name)
+		t.Fail()
+	}
+}

--- a/test/performance/eks/eks_performance_util.go
+++ b/test/performance/eks/eks_performance_util.go
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package eks
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
+)
+
+// PerformanceMetrics represents a collection of performance metrics and their associated dimensions
+type PerformanceMetrics struct {
+	Metrics []Metric `json:"metrics"`
+}
+
+// Metric represents a single metric with its name, dimensions map and threshold
+type Metric struct {
+	Name       string            `json:"name"`
+	Dimensions map[string]string `json:"dimensions"`
+	Threshold  float64           `json:"threshold"`
+}
+
+// GetEKSPerformanceMetrics - Gets desired EKS performance metrics based on json file
+func GetEKSPerformanceMetrics(performanceMetricMapName string) (*PerformanceMetrics, error) {
+	var metricDimensions *PerformanceMetrics
+
+	configPath := filepath.Join("resources/performance_metric_maps", performanceMetricMapName)
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %v", err)
+	}
+
+	err = json.Unmarshal(content, &metricDimensions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal performance metrics: %v", err)
+	}
+
+	return metricDimensions, nil
+}
+
+// GetMetricDimensions - Gets dimensions for performance metric
+func GetMetricDimensions(metric Metric, env *environment.MetaData) []types.Dimension {
+	var dimensions []types.Dimension
+	for name, value := range metric.Dimensions {
+		if name == "ClusterName" && env.EKSClusterName != "" {
+			value = env.EKSClusterName
+		}
+		dimensions = append(dimensions, types.Dimension{
+			Name:  aws.String(name),
+			Value: aws.String(value),
+		})
+	}
+	return dimensions
+}
+
+// ValidatePerformanceMetrics - Validates that the metric exists and is within the expected threshold (+/- 15%)
+func ValidatePerformanceMetrics(name string, threshold float64, dimensions []types.Dimension) status.TestResult {
+	testResult := status.TestResult{
+		Name:   name,
+		Status: status.FAILED,
+	}
+
+	// get metric from cloudwatch container insights namespace
+	valueFetcher := metric.MetricValueFetcher{}
+	values, err := valueFetcher.Fetch(metric.ContainerInsightsNamespace, name, dimensions, metric.MAXIMUM, metric.MinuteStatPeriod)
+	if err != nil {
+		log.Println("failed to fetch metrics", err)
+		return testResult
+	}
+
+	if !metric.IsAllValuesGreaterThanOrEqualToExpectedValue(name, values, threshold) {
+		return testResult
+	}
+
+	testResult.Status = status.SUCCESSFUL
+	return testResult
+}

--- a/test/performance/eks/eks_performance_util.go
+++ b/test/performance/eks/eks_performance_util.go
@@ -28,6 +28,7 @@ type Metric struct {
 	Name       string            `json:"name"`
 	Dimensions map[string]string `json:"dimensions"`
 	Threshold  float64           `json:"threshold"`
+	Statistic  string            `json:"stat"`
 }
 
 // GetEKSPerformanceMetrics - Gets desired EKS performance metrics based on json file
@@ -64,7 +65,7 @@ func GetMetricDimensions(metric Metric, env *environment.MetaData) []types.Dimen
 }
 
 // ValidatePerformanceMetrics - Validates that the metric exists and is within the expected threshold (+/- 15%)
-func ValidatePerformanceMetrics(name string, threshold float64, dimensions []types.Dimension) status.TestResult {
+func ValidatePerformanceMetrics(name string, threshold float64, stat string, dimensions []types.Dimension) status.TestResult {
 	testResult := status.TestResult{
 		Name:   name,
 		Status: status.FAILED,
@@ -72,7 +73,7 @@ func ValidatePerformanceMetrics(name string, threshold float64, dimensions []typ
 
 	// get metric from cloudwatch container insights namespace
 	valueFetcher := metric.MetricValueFetcher{}
-	values, err := valueFetcher.Fetch(metric.ContainerInsightsNamespace, name, dimensions, metric.MAXIMUM, metric.MinuteStatPeriod)
+	values, err := valueFetcher.Fetch(metric.ContainerInsightsNamespace, name, dimensions, metric.Statistics(stat), metric.MinuteStatPeriod)
 	if err != nil {
 		log.Println("failed to fetch metrics", err)
 		return testResult

--- a/test/performance/eks/resources/leader_election_overrides/base-overrides.yml
+++ b/test/performance/eks/resources/leader_election_overrides/base-overrides.yml
@@ -1,0 +1,24 @@
+# Create separate installation for node and leader agents
+agent:
+  name: cloudwatch-agent-ci
+  mode: deployment
+  config:
+    {
+      "logs": {
+        "metrics_collected": {
+          "kubernetes": {
+            "enhanced_container_insights": true
+          }
+        }
+      }
+    }
+  nodeSelector:
+    kubernetes.io/os: linux
+    kubernetes.io/hostname: ip-10-1-254-12.us-west-2.compute.internal
+  env:
+    - name: CWAGENT_ROLE
+      value: CI_LEADER
+  resources:
+    limits:
+      memory: 5Gi
+      cpu: 2000m

--- a/test/performance/eks/resources/leader_election_overrides/base-overrides.yml
+++ b/test/performance/eks/resources/leader_election_overrides/base-overrides.yml
@@ -4,6 +4,9 @@ agents:
     env:
       - name: CWAGENT_ROLE
         value: CI_NODE
+    nodeSelector:
+      kubernetes.io/os: linux
+      cwagent-target: "true"
   - name: cloudwatch-agent-ci
     mode: deployment
     config:

--- a/test/performance/eks/resources/leader_election_overrides/base-overrides.yml
+++ b/test/performance/eks/resources/leader_election_overrides/base-overrides.yml
@@ -1,24 +1,28 @@
 # Create separate installation for node and leader agents
-agent:
-  name: cloudwatch-agent-ci
-  mode: deployment
-  config:
-    {
-      "logs": {
-        "metrics_collected": {
-          "kubernetes": {
-            "enhanced_container_insights": true
+agents:
+  - name: cloudwatch-agent
+    env:
+      - name: CWAGENT_ROLE
+        value: CI_NODE
+  - name: cloudwatch-agent-ci
+    mode: deployment
+    config:
+      {
+        "logs": {
+          "metrics_collected": {
+            "kubernetes": {
+              "enhanced_container_insights": true
+            }
           }
         }
       }
-    }
-  nodeSelector:
-    kubernetes.io/os: linux
-    kubernetes.io/hostname: ip-10-1-254-12.us-west-2.compute.internal
-  env:
-    - name: CWAGENT_ROLE
-      value: CI_LEADER
-  resources:
-    limits:
-      memory: 5Gi
-      cpu: 2000m
+    nodeSelector:
+      kubernetes.io/os: linux
+      kubernetes.io/hostname: ip-10-1-254-12.us-west-2.compute.internal
+    env:
+      - name: CWAGENT_ROLE
+        value: CI_LEADER
+    resources:
+      limits:
+        memory: 5Gi
+        cpu: 2000m

--- a/test/performance/eks/resources/leader_election_overrides/base-overrides.yml
+++ b/test/performance/eks/resources/leader_election_overrides/base-overrides.yml
@@ -21,7 +21,7 @@ agents:
       }
     nodeSelector:
       kubernetes.io/os: linux
-      kubernetes.io/hostname: ip-10-1-254-12.us-west-2.compute.internal
+      kubernetes.io/hostname: <hostname>
     env:
       - name: CWAGENT_ROLE
         value: CI_LEADER

--- a/test/performance/eks/resources/performance_metric_maps/base-performance-metrics-map.json
+++ b/test/performance/eks/resources/performance_metric_maps/base-performance-metrics-map.json
@@ -17,56 +17,6 @@
       "stat": "Maximum"
     },
     {
-      "name": "pod_status_running",
-      "dimensions": {
-        "ClusterName": "eks-performance",
-        "Namespace": "amazon-cloudwatch",
-        "PodName": "cloudwatch-agent"
-      },
-      "threshold": 5001,
-      "stat": "Sum"
-    },
-    {
-      "name": "pod_cpu_utilization",
-      "dimensions": {
-        "ClusterName": "eks-performance",
-        "Namespace": "amazon-cloudwatch",
-        "PodName": "cloudwatch-agent"
-      },
-      "threshold": 0.5,
-      "stat": "Maximum"
-    },
-    {
-      "name": "pod_cpu_utilization",
-      "dimensions": {
-        "ClusterName": "eks-performance",
-        "Namespace": "amazon-cloudwatch",
-        "PodName": "cloudwatch-agent-ci"
-      },
-      "threshold": 0.35,
-      "stat": "Maximum"
-    },
-    {
-      "name": "pod_memory_utilization",
-      "dimensions": {
-        "ClusterName": "eks-performance",
-        "Namespace": "amazon-cloudwatch",
-        "PodName": "cloudwatch-agent"
-      },
-      "threshold": 1.2,
-      "stat": "Maximum"
-    },
-    {
-      "name": "pod_memory_utilization",
-      "dimensions": {
-        "ClusterName": "eks-performance",
-        "Namespace": "amazon-cloudwatch",
-        "PodName": "cloudwatch-agent-ci"
-      },
-      "threshold": 1.7,
-      "stat": "Maximum"
-    },
-    {
       "name": "cluster_failed_node_count",
       "dimensions": {
         "ClusterName": "eks-performance"
@@ -74,6 +24,66 @@
       "threshold": 0,
       "stat": "Sum"
 
+    },
+    {
+      "name": "pod_status_running",
+      "dimensions": {
+        "ClusterName": "eks-performance",
+        "Namespace": "amazon-cloudwatch",
+        "PodName": "cloudwatch-agent"
+      },
+      "threshold": 5000,
+      "stat": "Sum"
+    },
+    {
+      "name": "pod_status_running",
+      "dimensions": {
+        "ClusterName": "eks-performance",
+        "Namespace": "amazon-cloudwatch",
+        "PodName": "cloudwatch-agent-ci"
+      },
+      "threshold": 1,
+      "stat": "Sum"
+    },
+    {
+      "name": "pod_cpu_utilization",
+      "dimensions": {
+        "ClusterName": "eks-performance",
+        "Namespace": "amazon-cloudwatch",
+        "PodName": "cloudwatch-agent"
+      },
+      "threshold": 0.25,
+      "stat": "Maximum"
+    },
+    {
+      "name": "pod_cpu_utilization",
+      "dimensions": {
+        "ClusterName": "eks-performance",
+        "Namespace": "amazon-cloudwatch",
+        "PodName": "cloudwatch-agent-ci"
+      },
+      "threshold": 0.5,
+      "stat": "Maximum"
+    },
+    {
+      "name": "pod_memory_utilization",
+      "dimensions": {
+        "ClusterName": "eks-performance",
+        "Namespace": "amazon-cloudwatch",
+        "PodName": "cloudwatch-agent"
+      },
+      "threshold": 2.3,
+      "stat": "Maximum"
+    },
+    {
+      "name": "pod_memory_utilization",
+      "dimensions": {
+        "ClusterName": "eks-performance",
+        "Namespace": "amazon-cloudwatch",
+        "PodName": "cloudwatch-agent-ci"
+      },
+      "threshold": 1.8,
+      "stat": "Maximum"
     }
   ]
 }

--- a/test/performance/eks/resources/performance_metric_maps/base-performance-metrics-map.json
+++ b/test/performance/eks/resources/performance_metric_maps/base-performance-metrics-map.json
@@ -1,0 +1,68 @@
+{
+  "metrics": [
+    {
+      "name": "apiserver_request_total",
+      "dimensions": {
+        "ClusterName": "eks-performance"
+      },
+      "threshold": 5
+    },
+    {
+      "name": "rest_client_request_duration_seconds",
+      "dimensions": {
+        "ClusterName": "eks-performance"
+      },
+      "threshold": 5
+    },
+    {
+      "name": "rest_client_requests_total",
+      "dimensions": {
+        "ClusterName": "eks-performance"
+      },
+      "threshold": 5
+    },
+    {
+      "name": "pod_status_running",
+      "dimensions": {
+        "ClusterName": "eks-performance",
+        "Namespace": "amazon-cloudwatch",
+        "PodName": "cloudwatch-agent"
+      },
+      "threshold": 5
+    },
+    {
+      "name": "pod_cpu_utilization",
+      "dimensions": {
+        "ClusterName": "eks-performance",
+        "Namespace": "amazon-cloudwatch",
+        "PodName": "cloudwatch-agent"
+      },
+      "threshold": 5
+    },
+    {
+      "name": "pod_memory_utilization",
+      "dimensions": {
+        "ClusterName": "eks-performance",
+        "Namespace": "amazon-cloudwatch",
+        "PodName": "cloudwatch-agent"
+      },
+      "threshold": 5
+    },
+    {
+      "name": "pod_network_tx_bytes",
+      "dimensions": {
+        "ClusterName": "eks-performance",
+        "Namespace": "amazon-cloudwatch",
+        "PodName": "cloudwatch-agent"
+      },
+      "threshold": 5
+    },
+    {
+      "name": "cluster_failed_node_count",
+      "dimensions": {
+        "ClusterName": "eks-performance"
+      },
+      "threshold": 5
+    }
+  ]
+}

--- a/test/performance/eks/resources/performance_metric_maps/base-performance-metrics-map.json
+++ b/test/performance/eks/resources/performance_metric_maps/base-performance-metrics-map.json
@@ -5,21 +5,16 @@
       "dimensions": {
         "ClusterName": "eks-performance"
       },
-      "threshold": 5
+      "threshold": 13500,
+      "stat": "Sum"
     },
     {
       "name": "rest_client_request_duration_seconds",
       "dimensions": {
         "ClusterName": "eks-performance"
       },
-      "threshold": 5
-    },
-    {
-      "name": "rest_client_requests_total",
-      "dimensions": {
-        "ClusterName": "eks-performance"
-      },
-      "threshold": 5
+      "threshold": 0,
+      "stat": "Maximum"
     },
     {
       "name": "pod_status_running",
@@ -28,7 +23,8 @@
         "Namespace": "amazon-cloudwatch",
         "PodName": "cloudwatch-agent"
       },
-      "threshold": 5
+      "threshold": 5001,
+      "stat": "Sum"
     },
     {
       "name": "pod_cpu_utilization",
@@ -37,7 +33,18 @@
         "Namespace": "amazon-cloudwatch",
         "PodName": "cloudwatch-agent"
       },
-      "threshold": 5
+      "threshold": 0.5,
+      "stat": "Maximum"
+    },
+    {
+      "name": "pod_cpu_utilization",
+      "dimensions": {
+        "ClusterName": "eks-performance",
+        "Namespace": "amazon-cloudwatch",
+        "PodName": "cloudwatch-agent-ci"
+      },
+      "threshold": 0.35,
+      "stat": "Maximum"
     },
     {
       "name": "pod_memory_utilization",
@@ -46,23 +53,27 @@
         "Namespace": "amazon-cloudwatch",
         "PodName": "cloudwatch-agent"
       },
-      "threshold": 5
+      "threshold": 1.2,
+      "stat": "Maximum"
     },
     {
-      "name": "pod_network_tx_bytes",
+      "name": "pod_memory_utilization",
       "dimensions": {
         "ClusterName": "eks-performance",
         "Namespace": "amazon-cloudwatch",
-        "PodName": "cloudwatch-agent"
+        "PodName": "cloudwatch-agent-ci"
       },
-      "threshold": 5
+      "threshold": 1.7,
+      "stat": "Maximum"
     },
     {
       "name": "cluster_failed_node_count",
       "dimensions": {
         "ClusterName": "eks-performance"
       },
-      "threshold": 5
+      "threshold": 0,
+      "stat": "Sum"
+
     }
   ]
 }

--- a/test/performance/eks/resources/petclinic-sample-app/log-generator.yml
+++ b/test/performance/eks/resources/petclinic-sample-app/log-generator.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: log-generator
+  namespace: default
+spec:
+  containers:
+    - name: log-generator
+      image: busybox
+      command: ["/bin/sh", "-c"]
+      args: ["while true; do echo \"Log entry at $(date)\"; sleep 1; done"]
+  restartPolicy: Always

--- a/test/performance/eks/resources/petclinic-sample-app/petclinic-custom-env.yml
+++ b/test/performance/eks/resources/petclinic-sample-app/petclinic-custom-env.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: petclinic-instrumentation-custom-env
+  annotations:
+    instrumentation.opentelemetry.io/inject-java: "true"
+  labels:
+    app: petclinic
+spec:
+  containers:
+    - name: petclinic
+      image: 506463145083.dkr.ecr.us-west-2.amazonaws.com/cwagent-integ-test-petclinic:latest
+      ports:
+        - containerPort: 8080
+      env:
+        - name: OTEL_SERVICE_NAME
+          value: petclinic-custom-service-name
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: deployment.environment=petclinic-custom-environment

--- a/test/performance/eks/resources/petclinic-sample-app/petclinic-instrumentation.yml
+++ b/test/performance/eks/resources/petclinic-sample-app/petclinic-instrumentation.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: petclinic-instrumentation-default-env
+  annotations:
+    instrumentation.opentelemetry.io/inject-java: "true"
+  labels:
+    app: petclinic
+spec:
+  containers:
+    - name: petclinic
+      image: 506463145083.dkr.ecr.us-west-2.amazonaws.com/cwagent-integ-test-petclinic:latest
+      ports:
+        - containerPort: 8080
+      env:
+        - name: OTEL_SERVICE_NAME
+          value: petclinic-custom-service-name

--- a/test/performance/eks/resources/petclinic-sample-app/petclinic-service.yml
+++ b/test/performance/eks/resources/petclinic-sample-app/petclinic-service.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: petclinic-service
+spec:
+  selector:
+    app: petclinic
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/test/performance/eks/resources/petclinic-sample-app/traffic-generator.yml
+++ b/test/performance/eks/resources/petclinic-sample-app/traffic-generator.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: traffic-generator-instrumentation-default-env
+spec:
+  containers:
+    - name: traffic-generator
+      image: alpine
+      command: ["/bin/sh", "-c"]
+      args: ["apk add --no-cache curl && while true; do curl -s http://petclinic-service:8080/client-call; sleep 1; done"]


### PR DESCRIPTION
# Description of the issue
As part of an initiative to improve our performance testing on large scale eks clusters, we need to implement a test that runs on our 5k node cluster.

# Description of changes
1. eks_performance_test.go
   - test gets the metrics from a hardcoded map (base-performance-metrics-map.json - map defines the metric name, thresholds and dimensions)
   - fetches metrics form cloudwatch and confirms average of last 10 datapoints is with 15% of expected value. (leverages existing testing logic)
2. base-overrides.yml
   - Override to ensure the leader pod gets chosen with a specific instance based on hostname. 
   - hostname is overridden via the github action that calls this test (eks-performance-cluster-addon-install.yml)
   - leader pod has name cloudwatch-agent-ci
 3. petclinic-sample-app
    - contains the definitions for resources that are applied using kubectl (eks-performance-cluster-tests.yml)

# Tests
Cluster Scaling Workflow - https://github.com/aws/amazon-cloudwatch-agent/actions/runs/16512847744/job/46697932764
Addon Install Workflow - https://github.com/aws/amazon-cloudwatch-agent/actions/runs/16523571905/job/46731027008
Performance Test Workflow - https://github.com/aws/amazon-cloudwatch-agent/actions/runs/16526410774/job/46740785992
