### PR TITLE
Fixing win-11 event-log flaky integ test

### DIFF
--- a/terraform/ec2/win/main.tf
+++ b/terraform/ec2/win/main.tf
@@ -102,9 +102,8 @@ resource "null_resource" "integration_test_setup_agent" {
     inline = [
       "aws s3 cp s3://${var.s3_bucket}/integration-test/packaging/${var.cwa_github_sha}/amazon-cloudwatch-agent.msi .",
       "start /wait msiexec /i amazon-cloudwatch-agent.msi /norestart /qb-",
-
-      # Verify the presence of amazon-cloudwatch-agent-ctl.ps1 and search for it if not found
-      "powershell.exe -Command \"if (-not (Test-Path 'C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1')) { $scriptPath = Get-ChildItem -Path C:\\ -Filter amazon-cloudwatch-agent-ctl.ps1 -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName; if (-not $scriptPath) { Write-Output 'amazon-cloudwatch-agent-ctl.ps1 not found after installation'; exit 1 } else { Write-Output ('amazon-cloudwatch-agent-ctl.ps1 found at: ' + $scriptPath) } } else { Write-Output 'amazon-cloudwatch-agent-ctl.ps1 found in the expected location' }\""
+      "if %errorlevel% neq 0 (echo MSI install failed with code %errorlevel% & exit 1)",
+      "powershell.exe -Command \"$retries = 0; $maxRetries = 30; $found = $false; while ($retries -lt $maxRetries -and -not $found) { if (Test-Path 'C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1') { $found = $true; Write-Output 'amazon-cloudwatch-agent-ctl.ps1 found in expected location'; } else { $scriptPath = Get-ChildItem -Path 'C:\\Program Files' -Filter amazon-cloudwatch-agent-ctl.ps1 -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName; if ($scriptPath) { $found = $true; Write-Output 'amazon-cloudwatch-agent-ctl.ps1 found at: ' + $scriptPath; } } if (-not $found) { Start-Sleep -Seconds 10; $retries++ } } if (-not $found) { Write-Output 'amazon-cloudwatch-agent-ctl.ps1 not found after installation and retries'; exit 1 }\""
     ]
   }
 }


### PR DESCRIPTION
# Description of the issue
Currently this test seems to be flaky due to not having amazon-cloudwatch-agent-ctl.ps1 installed here's the error message:
`amazon-cloudwatch-agent-ctl.ps1 not found after installation`. Failing test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/16998567192/job/48225508375


# Description of changes
Currently we just check once if the file exists, now we are adding a retryer which retries 30 times sleeps 10 second each time to wait to see if amazon-cloudwatch-agent-ctl.ps1 is found. This fixes the flakiness as it seems the test is just checking before `amazon-cloudwatch-agent-ctl.ps1` is installed. 

# Tests
Ran test 6 times in this run (all passing): https://github.com/aws/amazon-cloudwatch-agent/actions/runs/17052849215/job/48344452928