### PR TITLE
Paramadon/instance store test

### DIFF
--- a/terraform/ec2/common/linux/main.tf
+++ b/terraform/ec2/common/linux/main.tf
@@ -75,6 +75,11 @@ resource "aws_instance" "cwagent" {
     volume_size = 200
   }
 
+  ephemeral_block_device {
+    device_name  = "/dev/sdb"
+    virtual_name = "ephemeral0"
+  }
+
   metadata_options {
     http_endpoint = "enabled"
     http_tokens   = "required"

--- a/test/metric/dimension/provider.go
+++ b/test/metric/dimension/provider.go
@@ -36,6 +36,7 @@ func GetDimensionFactory(env environment.MetaData) Factory {
 		&LocalInstanceTypeDimensionProvider{Provider: Provider{env: env}},
 		&ECSInstanceIdDimensionProvider{Provider: Provider{env: env}},
 		&VolumeIdDimensionProvider{Provider: Provider{env: env}},
+		&SerialIdDimensionProvider{Provider: Provider{env: env}},
 		&CustomDimensionProvider{Provider: Provider{env: env}},
 	}
 

--- a/test/metric/dimension/serial_id_provider.go
+++ b/test/metric/dimension/serial_id_provider.go
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package dimension
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment/computetype"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
+)
+
+type SerialIdDimensionProvider struct {
+	Provider
+}
+
+var _ IProvider = (*SerialIdDimensionProvider)(nil)
+
+func (p *SerialIdDimensionProvider) IsApplicable() bool {
+	return p.env.ComputeType == computetype.EC2
+}
+
+func (p *SerialIdDimensionProvider) GetDimension(instruction Instruction) types.Dimension {
+	if instruction.Key != "SerialId" || instruction.Value.IsKnown() {
+		return types.Dimension{}
+	}
+	serial, err := common.GetAnyInstanceStoreSerialID()
+	if err != nil {
+		log.Print(err)
+		return types.Dimension{}
+	}
+	return types.Dimension{
+		Name:  aws.String("SerialId"),
+		Value: aws.String(serial),
+	}
+}
+
+func (p *SerialIdDimensionProvider) Name() string {
+	return "SerialIdDimensionProvider"
+}

--- a/test/metric_value_benchmark/agent_configs/diskio_instance_store_config.json
+++ b/test/metric_value_benchmark/agent_configs/diskio_instance_store_config.json
@@ -1,0 +1,34 @@
+{
+  "agent": {
+    "metrics_collection_interval": 10,
+    "run_as_user": "root",
+    "debug": true,
+    "region": "us-west-2"
+  },
+  "metrics": {
+    "namespace": "MetricValueBenchmarkTest",
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}"
+    },
+    "metrics_collected": {
+      "diskio": {
+        "resources": [
+          "*"
+        ],
+        "measurement": [
+          "instance_store_total_read_ops",
+          "instance_store_total_write_ops",
+          "instance_store_total_read_bytes",
+          "instance_store_total_write_bytes",
+          "instance_store_total_read_time",
+          "instance_store_total_write_time",
+          "instance_store_performance_exceeded_iops",
+          "instance_store_performance_exceeded_tp",
+          "instance_store_volume_queue_length"
+        ],
+        "metrics_collection_interval": 10
+      }
+    },
+    "force_flush_interval": 5
+  }
+}

--- a/test/metric_value_benchmark/diskio_instance_store_test.go
+++ b/test/metric_value_benchmark/diskio_instance_store_test.go
@@ -1,0 +1,205 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package metric_value_benchmark
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
+	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
+)
+
+const (
+	instanceStoreEntityResourceType = "AWS::EC2::Instance"
+	instanceStoreEntityType         = "AWS::Resource"
+)
+
+type DiskIOInstanceStoreTestRunner struct {
+	test_runner.BaseTestRunner
+}
+
+var _ test_runner.ITestRunner = (*DiskIOInstanceStoreTestRunner)(nil)
+
+func (m *DiskIOInstanceStoreTestRunner) Validate() status.TestGroupResult {
+	metricsToFetch := m.GetMeasuredMetrics()
+	testResults := make([]status.TestResult, 2*len(metricsToFetch))
+	for i, name := range metricsToFetch {
+		testResults[i] = m.validateInstanceStoreMetric(name)
+		if os.Getenv("AWS_REGION") == "us-west-2" {
+			testResults[i+len(metricsToFetch)] = m.validateInstanceStoreEntity(name)
+		}
+	}
+
+	return status.TestGroupResult{
+		Name:        m.GetTestName(),
+		TestResults: testResults,
+	}
+}
+
+func (m *DiskIOInstanceStoreTestRunner) GetTestName() string {
+	return "DiskIOInstanceStore"
+}
+
+func (m *DiskIOInstanceStoreTestRunner) GetAgentConfigFileName() string {
+	return "diskio_instance_store_config.json"
+}
+
+func (m *DiskIOInstanceStoreTestRunner) SetupBeforeAgentRun() error {
+	err := m.BaseTestRunner.SetupBeforeAgentRun()
+	if err != nil {
+		return err
+	}
+
+	err = common.RunCommands([]string{"sudo setcap cap_sys_admin+ep /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent"})
+	if err != nil {
+		log.Printf("unable to setcap: %s", err)
+	}
+	return m.SetUpConfig()
+}
+
+func (m *DiskIOInstanceStoreTestRunner) GetMeasuredMetrics() []string {
+	return []string{
+		"diskio_instance_store_total_read_ops",
+		"diskio_instance_store_total_write_ops",
+		"diskio_instance_store_total_read_bytes",
+		"diskio_instance_store_total_write_bytes",
+		"diskio_instance_store_total_read_time",
+		"diskio_instance_store_total_write_time",
+		"diskio_instance_store_performance_exceeded_iops",
+		"diskio_instance_store_performance_exceeded_tp",
+		"diskio_instance_store_volume_queue_length",
+	}
+}
+
+func (m *DiskIOInstanceStoreTestRunner) GetAgentRunDuration() time.Duration {
+	return 4 * time.Minute
+}
+
+func (m *DiskIOInstanceStoreTestRunner) validateInstanceStoreMetric(metricName string) status.TestResult {
+	testResult := status.TestResult{
+		Name:   metricName,
+		Status: status.FAILED,
+	}
+
+	dims, failed := m.DimensionFactory.GetDimensions([]dimension.Instruction{
+		{
+			Key:   "InstanceId",
+			Value: dimension.UnknownDimensionValue(),
+		},
+		{
+			Key:   "SerialId",
+			Value: dimension.UnknownDimensionValue(),
+		},
+	})
+
+	if len(failed) > 0 {
+		return testResult
+	}
+
+	fetcher := metric.MetricValueFetcher{}
+	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, metric.HighResolutionStatPeriod)
+	if err != nil {
+		return testResult
+	}
+
+	if !metric.IsAllValuesGreaterThanOrEqualToExpectedValue(metricName, values, 0) {
+		return testResult
+	}
+
+	testResult.Status = status.SUCCESSFUL
+	return testResult
+}
+
+func (m *DiskIOInstanceStoreTestRunner) validateInstanceStoreEntity(metricName string) status.TestResult {
+	testResult := status.TestResult{
+		Name:   fmt.Sprintf("%s_entity", metricName),
+		Status: status.FAILED,
+	}
+	env := environment.GetEnvironmentMetaData()
+	serialID, err := common.GetAnyInstanceStoreSerialID()
+	if err != nil {
+		return testResult
+	}
+
+	requestBody := []byte(fmt.Sprintf(`{
+        "Namespace": "%s",
+        "MetricName": "%s",
+        "Dimensions": [
+            {"Name": "InstanceId", "Value": "%s"},
+            {"Name": "SerialId", "Value": "%s"}
+        ]
+    }`, namespace, metricName, env.InstanceId, serialID))
+
+	req, err := common.BuildListEntitiesForMetricRequest(requestBody, region)
+	if err != nil {
+		log.Printf("Failed to build ListEntitiesForMetric request for metric: '%s': %v", metricName, err)
+		return testResult
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("Failed to send request for metric: '%s': %v", metricName, err)
+		return testResult
+	}
+	defer resp.Body.Close()
+
+	var response struct {
+		Entities []struct {
+			KeyAttributes struct {
+				Type         string `json:"Type"`
+				ResourceType string `json:"ResourceType"`
+				Identifier   string `json:"Identifier"`
+			} `json:"KeyAttributes"`
+		} `json:"Entities"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		log.Printf("Failed to decode response for metric: '%s': %v", metricName, err)
+		return testResult
+	}
+
+	if len(response.Entities) != 1 {
+		log.Printf("Response does not contain the correct number of entities for metric '%s'", metricName)
+		return testResult
+	}
+
+	entity := response.Entities[0]
+	if entity.KeyAttributes.Identifier != env.InstanceId ||
+		entity.KeyAttributes.ResourceType != instanceStoreEntityResourceType ||
+		entity.KeyAttributes.Type != instanceStoreEntityType {
+
+		log.Printf("Entity mismatch for metric '%s':\n"+
+			"Expected:\n"+
+			"  Type: %s\n"+
+			"  ResourceType: %s\n"+
+			"  InstanceId: %s\n"+
+			"Got:\n"+
+			"  Type: %s\n"+
+			"  ResourceType: %s\n"+
+			"  InstanceId: %s",
+			metricName,
+			instanceStoreEntityType,
+			instanceStoreEntityResourceType,
+			env.InstanceId,
+			entity.KeyAttributes.Type,
+			entity.KeyAttributes.ResourceType,
+			entity.KeyAttributes.Identifier)
+		return testResult
+	}
+
+	testResult.Status = status.SUCCESSFUL
+	return testResult
+}

--- a/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -128,10 +128,13 @@ func getEc2TestRunners(env *environment.MetaData) []*test_runner.TestRunner {
 			{TestRunner: &JMXKafkaTestRunner{BaseTestRunner: test_runner.BaseTestRunner{DimensionFactory: factory}, env: env}},
 		}
 
-		// Only add the Disk IO EBS test if not running on SELinux
+		// Only add the Disk IO EBS and Instance Store test if not running on SELinux
 		runningOnSELinux, _ := common.SELinuxEnforced()
 		if !runningOnSELinux {
-			ec2TestRunners = append(ec2TestRunners, &test_runner.TestRunner{TestRunner: &DiskIOEBSTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}})
+			ec2TestRunners = append(ec2TestRunners,
+				&test_runner.TestRunner{TestRunner: &DiskIOEBSTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+				&test_runner.TestRunner{TestRunner: &DiskIOInstanceStoreTestRunner{test_runner.BaseTestRunner{DimensionFactory: factory}}},
+			)
 		}
 	}
 	return ec2TestRunners

--- a/util/common/nvme_util_unix.go
+++ b/util/common/nvme_util_unix.go
@@ -32,3 +32,24 @@ func GetAnyNvmeVolumeID() (string, error) {
 
 	return "", fmt.Errorf("could not find an nvme device")
 }
+
+// GetAnyInstanceStoreSerialID returns the serial ID of the first NVMe instance store device found.
+func GetAnyInstanceStoreSerialID() (string, error) {
+	entries, err := os.ReadDir(sysClassNvmeDirPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read NVMe devices: %v", err)
+	}
+
+	for _, entry := range entries {
+		data, err := os.ReadFile(fmt.Sprintf("%s/%s/serial", sysClassNvmeDirPath, entry.Name()))
+		if err != nil {
+			continue // skip devices we can't read
+		}
+		serial := strings.TrimSpace(string(data))
+		if serial != "" {
+			return serial, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find any NVMe instance store device")
+}

--- a/util/common/nvme_util_unix.go
+++ b/util/common/nvme_util_unix.go
@@ -41,11 +41,22 @@ func GetAnyInstanceStoreSerialID() (string, error) {
 	}
 
 	for _, entry := range entries {
-		data, err := os.ReadFile(fmt.Sprintf("%s/%s/serial", sysClassNvmeDirPath, entry.Name()))
+		modelPath := fmt.Sprintf("%s/%s/model", sysClassNvmeDirPath, entry.Name())
+		modelData, err := os.ReadFile(modelPath)
 		if err != nil {
-			continue // skip devices we can't read
+			continue // skip if can't read model
 		}
-		serial := strings.TrimSpace(string(data))
+		model := strings.TrimSpace(string(modelData))
+		if model != "Amazon EC2 NVMe Instance Storage" {
+			continue // skip if not the instance storage model
+		}
+
+		serialPath := fmt.Sprintf("%s/%s/serial", sysClassNvmeDirPath, entry.Name())
+		serialData, err := os.ReadFile(serialPath)
+		if err != nil {
+			continue // skip if can't read serial
+		}
+		serial := strings.TrimSpace(string(serialData))
 		if serial != "" {
 			return serial, nil
 		}


### PR DESCRIPTION
# Description of the issue
Currently we only have integration tests for EBS metric and nothing for Instance Store metrics.

# Description of changes
This change adds integration test for Instance store metrics following a similar pattern of the ebs integration test. 

# Tests
Testing in a test instance with instance store metrics available:

<img width="1531" height="521" alt="Screenshot 2025-08-28 at 11 03 06 AM" src="https://github.com/user-attachments/assets/31da03a7-59a3-4278-923c-7796ad5c2777" />

