### PR TITLE
Update EKS E2E K8s version from 1.31 to 1.33

### DIFF
--- a/terraform/eks/e2e/variables.tf
+++ b/terraform/eks/e2e/variables.tf
@@ -8,7 +8,7 @@ variable "region" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.31"
+  default = "1.33"
 }
 
 variable "cluster_name" {


### PR DESCRIPTION
# Description of the issue
Our EKS E2E tests are failing due to the use of a deprecated version of K8s (1.31): https://github.com/aws/amazon-cloudwatch-agent/actions/runs/17558347538/job/49870400100.

# Description of changes
- Updates default `k8s_version` to `1.33`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
