### PR TITLE
Better error logging for EKS CI test failures

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -344,7 +344,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 		{
 			testDir:      "./test/ebscsi",
 			terraformDir: "terraform/eks/daemon/ebs",
-			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
+			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
 		},
 	},
 	"eks_deployment": {

--- a/test/metric/container_insights_util.go
+++ b/test/metric/container_insights_util.go
@@ -47,7 +47,7 @@ func ValidateMetrics(env *environment.MetaData, metricFilter string, expectedDim
 			log.Printf("  Expected metric: %s", metricName)
 		}
 	}
-	
+
 	dimsToMetrics := getMetricsInClusterDimension(env, metricFilter)
 	log.Printf("Found %d dimension groups", len(dimsToMetrics))
 	for _, dtm := range dimsToMetrics {
@@ -80,10 +80,10 @@ func ValidateMetrics(env *environment.MetaData, metricFilter string, expectedDim
 			// this is to prevent panic with rand.Intn when metrics are not yet ready in a cluster
 			if _, ok := actual[m]; !ok {
 				results = append(results, status.TestResult{
-					Name:   dims,
+					Name:   m + "/" + dims,
 					Status: status.FAILED,
 				})
-				log.Printf("ValidateMetrics failed with missing metric: %s", m)
+				log.Printf("ValidateMetrics failed with missing metric: %s, dimensions: %s", m, dims)
 				continue
 			}
 			// pick a random dimension set to test metric data OR test all dimension sets which might be overkill
@@ -250,7 +250,7 @@ func ValidateLogs(env *environment.MetaData) status.TestResult {
 					//log.Printf("eksClusterType is: %s", eksClusterType.Type)
 					jsonSchema, ok := eks_resources.EksClusterValidationMap[eksClusterType.Type]
 					if !ok {
-						return "", errors.New("invalid cluster type provided")
+						return "", errors.New("invalid type provided: " + eksClusterType.Type)
 					}
 					return jsonSchema, nil
 				}),
@@ -362,7 +362,7 @@ func ValidateNeuronCoreUtilizationValuesLogs(env *environment.MetaData) status.T
 				coreNumStr := strings.TrimPrefix(coreKey, core)
 				expectedValue, err := strconv.Atoi(coreNumStr)
 				if err != nil || math.Round(actualValue) != float64(expectedValue) {
-					log.Printf("Core utilization validation failed: expected %s:%d, got %v", 
+					log.Printf("Core utilization validation failed: expected %s:%d, got %v",
 						coreKey, expectedValue, actualValue)
 					testFailed = true
 				}


### PR DESCRIPTION
# Description of changes
Minor logging improvement for failed tests. Prior to this change, the summary at the bottom would print the Dimensions key, but the detailed error logging further up would print the metric name - making it hard to correlate the two.
With the change, we now print both the metrics and the dimensions in both places.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Before change:
```
ValidateMetrics failed with missing metric: container_filesystem_usage
ValidateMetrics failed with missing metric: container_filesystem_available
ValidateMetrics failed with missing metric: container_filesystem_utilization
...
module.windows.null_resource.validator (local-exec): ClusterName        Failed
module.windows.null_resource.validator (local-exec): ClusterName        Failed
module.windows.null_resource.validator (local-exec): ClusterName        Failed
```

After change:
```
ValidateMetrics failed with missing metric: container_filesystem_usage, dimensions: ClusterName
ValidateMetrics failed with missing metric: container_filesystem_available, dimensions: ClusterName
ValidateMetrics failed with missing metric: container_filesystem_utilization, dimensions: ClusterName
...
module.windows.null_resource.validator (local-exec): container_filesystem_usage/ClusterName             Failed
module.windows.null_resource.validator (local-exec): container_filesystem_available/ClusterName         Failed
module.windows.null_resource.validator (local-exec): container_filesystem_utilization/ClusterName       Failed
```