### PR TITLE
Update CloudWatch Agent installation template to use latest AL2023 AMI.

### DIFF
--- a/test/cloudformation/resources/AmazonCloudWatchAgent/inline/amazon_linux.template
+++ b/test/cloudformation/resources/AmazonCloudWatchAgent/inline/amazon_linux.template
@@ -23,8 +23,8 @@ Parameters:
     ConstraintDescription: must be a valid EC2 instance type.
   InstanceAMI:
     Description: Managed AMI ID for EC2 Instance
-    Type : String
-    Default: ami-04e914639d0cca79a
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
   IAMRole:
     Description: EC2 attached IAM role
     Type: String


### PR DESCRIPTION
# Description of the issue
The current Cloudformation tests deploy a template that uses a fixed, old version of AL2023.

# Description of changes
- Updated the template to use SSM to retrieve the latest version of the AL2023 AMI.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Deployed the Cloudformation stack and got the following value for `InstanceAMI`:
<img width="867" height="132" alt="Screenshot 2025-09-17 at 8 01 17 PM" src="https://github.com/user-attachments/assets/b7ec6bd7-e16d-472a-b0ed-ef6db78bcf17" />

**OLD**
```
{
    "Images": [
        {
            "Architecture": "x86_64",
            "CreationDate": "2023-05-01T19:14:55.000Z",
            "ImageId": "ami-04e914639d0cca79a",
            "ImageLocation": "amazon/al2023-ami-2023.0.20230503.0-kernel-6.1-x86_64",
            "ImageType": "machine",
            "Public": true,
            "OwnerId": "137112412989",
            "PlatformDetails": "Linux/UNIX",
            "UsageOperation": "RunInstances",
            "State": "available",
            "BlockDeviceMappings": [
                {
                    "DeviceName": "/dev/xvda",
                    "Ebs": {
                        "DeleteOnTermination": true,
                        "Iops": 3000,
                        "SnapshotId": "snap-0f090a34b0d130a4c",
                        "VolumeSize": 8,
                        "VolumeType": "gp3",
                        "Throughput": 125,
                        "Encrypted": false
                    }
                }
            ],
            "Description": "Amazon Linux 2023 AMI 2023.0.20230503.0 x86_64 HVM kernel-6.1",
            "EnaSupport": true,
            "Hypervisor": "xen",
            "ImageOwnerAlias": "amazon",
            "Name": "al2023-ami-2023.0.20230503.0-kernel-6.1-x86_64",
            "RootDeviceName": "/dev/xvda",
            "RootDeviceType": "ebs",
            "SriovNetSupport": "simple",
            "VirtualizationType": "hvm",
            "BootMode": "uefi-preferred",
            "DeprecationTime": "2023-07-30T19:15:00.000Z",
            "ImdsSupport": "v2.0"
        }
    ]
}
```

**NEW**
```
{
    "Images": [
        {
            "Architecture": "x86_64",
            "CreationDate": "2025-09-10T19:06:25.000Z",
            "ImageId": "ami-06a974f9b8a97ecf2",
            "ImageLocation": "amazon/al2023-ami-2023.8.20250915.0-kernel-6.1-x86_64",
            "ImageType": "machine",
            "Public": true,
            "OwnerId": "137112412989",
            "PlatformDetails": "Linux/UNIX",
            "UsageOperation": "RunInstances",
            "State": "available",
            "BlockDeviceMappings": [
                {
                    "DeviceName": "/dev/xvda",
                    "Ebs": {
                        "DeleteOnTermination": true,
                        "Iops": 3000,
                        "SnapshotId": "snap-0b73f125bfeb0f927",
                        "VolumeSize": 8,
                        "VolumeType": "gp3",
                        "Throughput": 125,
                        "Encrypted": false
                    }
                }
            ],
            "Description": "Amazon Linux 2023 AMI 2023.8.20250915.0 x86_64 HVM kernel-6.1",
            "EnaSupport": true,
            "Hypervisor": "xen",
            "ImageOwnerAlias": "amazon",
            "Name": "al2023-ami-2023.8.20250915.0-kernel-6.1-x86_64",
            "RootDeviceName": "/dev/xvda",
            "RootDeviceType": "ebs",
            "SriovNetSupport": "simple",
            "VirtualizationType": "hvm",
            "BootMode": "uefi-preferred",
            "DeprecationTime": "2025-12-09T19:06:00.000Z",
            "ImdsSupport": "v2.0"
        }
    ]
}
```

**Workflow**
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/17840832075/job/50729666852