### PR TITLE
Add test case for OTLP with appsignals

### DIFF
--- a/test/otlp/agent_configs/appsignals_config.json
+++ b/test/otlp/agent_configs/appsignals_config.json
@@ -1,0 +1,40 @@
+{
+  "agent": {
+    "debug": true
+  },
+  "traces": {
+    "traces_collected": {
+      "application_signals": {},
+      "otlp": {
+        "http_endpoint": "127.0.0.1:4318",
+        "grpc_endpoint": "127.0.0.1:4317"
+      }
+    }
+  },
+  "metrics": {
+    "namespace": "CWAgent/OTLP",
+    "metrics_collected": {
+      "otlp": {
+        "http_endpoint": "127.0.0.1:4318",
+        "grpc_endpoint": "127.0.0.1:4317"
+      }
+    },
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}"
+    },
+    "aggregation_dimensions": [
+      [
+        "InstanceId"
+      ]
+    ]
+  },
+  "logs": {
+    "metrics_collected": {
+      "application_signals": {},
+      "otlp": {
+        "http_endpoint": "127.0.0.1:4318",
+        "grpc_endpoint": "127.0.0.1:4317"
+      }
+    }
+  }
+}

--- a/test/otlp/resources/otlp_logs.json
+++ b/test/otlp/resources/otlp_logs.json
@@ -46,7 +46,7 @@
                       {
                         "key": "test.type",
                         "value": {
-                          "stringValue": "otlp_integration_test"
+                          "stringValue": "otlp_integration_logs_test"
                         }
                       }
                     ]
@@ -73,7 +73,7 @@
                       {
                         "key": "test.type",
                         "value": {
-                          "stringValue": "otlp_integration_test"
+                          "stringValue": "otlp_integration_logs_test"
                         }
                       }
                     ]

--- a/test/otlp/resources/otlp_logs.json
+++ b/test/otlp/resources/otlp_logs.json
@@ -46,7 +46,7 @@
                       {
                         "key": "test.type",
                         "value": {
-                          "stringValue": "otlp_integration_logs_test"
+                          "stringValue": "otlp_logs_$TEST_TYPE"
                         }
                       }
                     ]
@@ -73,7 +73,7 @@
                       {
                         "key": "test.type",
                         "value": {
-                          "stringValue": "otlp_integration_logs_test"
+                          "stringValue": "otlp_logs_$TEST_TYPE"
                         }
                       }
                     ]

--- a/test/otlp/resources/otlp_metrics.json
+++ b/test/otlp/resources/otlp_metrics.json
@@ -40,7 +40,7 @@
                       {
                         "key": "test.type",
                         "value": {
-                          "stringValue": "otlp_integration_test"
+                          "stringValue": "otlp_metrics_$TEST_TYPE"
                         }
                       }
                     ]
@@ -61,7 +61,7 @@
                       {
                         "key": "test.type",
                         "value": {
-                          "stringValue": "otlp_integration_test"
+                          "stringValue": "otlp_metrics_$TEST_TYPE"
                         }
                       }
                     ]

--- a/test/otlp/resources/otlp_pusher.sh
+++ b/test/otlp/resources/otlp_pusher.sh
@@ -5,7 +5,10 @@ if [ -z "$INSTANCE_ID" ]; then
     exit 1
 fi
 
-echo "Starting OTLP data generation with INSTANCE_ID: $INSTANCE_ID"
+if [ -z "$TEST_TYPE" ]; then
+    echo "Error: TEST_TYPE environment variable is not set"
+    exit 1
+fi
 
 COUNTER=0
 SEQUENCE=0
@@ -22,6 +25,7 @@ while true; do
         -e "s/START_TIME_NANO/$START_TIME_NANO/g" \
         -e "s/COUNTER_VALUE/$COUNTER/g" \
         -e "s/GAUGE_VALUE/$((RANDOM % 100))/g" \
+        -e "s/\$TEST_TYPE/$TEST_TYPE/g" \
         -e "s/\$INSTANCE_ID/$INSTANCE_ID/g" > otlp_metrics_temp.json
 
     curl -s -X POST http://127.0.0.1:4318/v1/metrics \
@@ -34,6 +38,7 @@ while true; do
         -e "s/START_TIME_NANO/$START_TIME_NANO/g" \
         -e "s/COUNTER_VALUE/$((COUNTER + 2))/g" \
         -e "s/GAUGE_VALUE/$((RANDOM % 100))/g" \
+        -e "s/\$TEST_TYPE/$TEST_TYPE/g" \
         -e "s/\$INSTANCE_ID/$INSTANCE_ID/g" > otlp_logs_temp.json
 
     curl -s -X POST http://127.0.0.1:4318/v1/metrics \


### PR DESCRIPTION
# Description of changes
- Add new agent configuration with OTLP logs + application signals to make sure logs and metrics are working as expected 
- Update OTLP test validations to use `testType` (currently `shared` for shared OTLP receiver across signals and `appsignals` for OTLP logs receiver along with `application_signals`)

NOTE: OTLP test does not use TestSuite that other test packages use since the test target is limited to EC2 with 3 scenarios (shared, appsignals and traces-only). We might consider enhance with Suite model when there are more test scenarios to cover such as computeType and OSes. 

# Tests
```
[...trimmed]
logs result: Successful
    otlp_test.go:230: test runner passed for appsignals
2025/09/19 18:41:49 Running OTLP
[...trimmed]
    otlp_test.go:230: test runner passed for shared
    otlp_test.go:261: Sanity check: number of test cases:1
=== RUN   TestOTLP/WithOTLP/Simple
2025/09/19 18:44:51 Copy File agent_configs/default_traces.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
2025/09/19 18:44:51 File agent_configs/default_traces.json abs path /home/ec2-user/otlp/amazon-cloudwatch-agent-test/test/otlp/agent_configs/default_traces.json
2025/09/19 18:44:51 File : agent_configs/default_traces.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
2025/09/19 18:44:51 Testing all EC2 plugins
2025/09/19 18:44:51 Testing all EC2 plugins
2025/09/19 18:44:51 Starting agent with command sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json
2025/09/19 18:44:52 Agent has started
2025/09/19 18:48:13 Agent is stopped
    otlp_test.go:272: For WithOTLP/Simple , Test Cases Generated 36 | Test Cases Ended: 36
    otlp_test.go:272: Agent has been running for 3m21.422583807s
--- PASS: TestOTLP (575.62s)
    --- PASS: TestOTLP/WithOTLP/Simple (211.66s)
PASS
ok  	github.com/aws/amazon-cloudwatch-agent-test/test/otlp	575.643s
```
