### PR TITLE
Update EKS E2E AMI version from AL2 to AL2023

### DIFF
--- a/terraform/eks/e2e/variables.tf
+++ b/terraform/eks/e2e/variables.tf
@@ -23,7 +23,7 @@ variable "nodes" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {


### PR DESCRIPTION
# Description of the issue
Our EKS E2E tests are failing due to the use of the AL2 AMI with K8s 1.33: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/17558347538/job/49870400100.

# Description of changes
- Updates default `ami_type` to `AL2023_x86_64_STANDARD`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
