### PR TITLE
Add RHEL10 OS support

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -174,5 +174,5 @@
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",
     "family": "linux"
-  },
+  }
 ]

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -163,5 +163,16 @@
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",
     "family": "linux"
-  }
+  },
+  {
+    "os": "rhel10",
+    "username": "ec2-user",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-rhel10*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
 ]

--- a/test/metric_value_benchmark/net_test.go
+++ b/test/metric_value_benchmark/net_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
 )
 
 type NetTestRunner struct {
@@ -35,10 +34,6 @@ func (m *NetTestRunner) Validate() status.TestGroupResult {
 }
 
 func (m *NetTestRunner) SetupBeforeAgentRun() error {
-	err := common.RunCommands([]string{"sudo systemctl restart docker"})
-	if err != nil {
-		return err
-	}
 	return m.SetUpConfig()
 }
 

--- a/test/metric_value_benchmark/net_test.go
+++ b/test/metric_value_benchmark/net_test.go
@@ -6,6 +6,9 @@
 package metric_value_benchmark
 
 import (
+	"os"
+	"strings"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric"
@@ -35,9 +38,12 @@ func (m *NetTestRunner) Validate() status.TestGroupResult {
 }
 
 func (m *NetTestRunner) SetupBeforeAgentRun() error {
-	err := common.RunCommands([]string{"sudo systemctl restart docker"})
-	if err != nil {
-		return err
+	networkInterface := getNetworkInterface()
+	if networkInterface == "docker0" {
+		err := common.RunCommands([]string{"sudo systemctl restart docker"})
+		if err != nil {
+			return err
+		}
 	}
 	return m.SetUpConfig()
 }
@@ -56,6 +62,14 @@ func (m *NetTestRunner) GetMeasuredMetrics() []string {
 		"net_err_out", "net_packets_sent", "net_packets_recv"}
 }
 
+func getNetworkInterface() string {
+	if data, err := os.ReadFile("/etc/redhat-release"); err == nil {
+		if strings.Contains(string(data), "Red Hat Enterprise Linux release 10") {
+			return "ens5"
+		}
+	}
+	return "docker0"
+}
 func (m *NetTestRunner) validateNetMetric(metricName string) status.TestResult {
 	testResult := status.TestResult{
 		Name:   metricName,
@@ -65,7 +79,7 @@ func (m *NetTestRunner) validateNetMetric(metricName string) status.TestResult {
 	dims, failed := m.DimensionFactory.GetDimensions([]dimension.Instruction{
 		{
 			Key:   "interface",
-			Value: dimension.ExpectedDimensionValue{aws.String("docker0")},
+			Value: dimension.ExpectedDimensionValue{aws.String(getNetworkInterface())},
 		},
 		{
 			Key:   "InstanceId",

--- a/test/metric_value_benchmark/net_test.go
+++ b/test/metric_value_benchmark/net_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
-	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
 )
 
 type NetTestRunner struct {
@@ -35,10 +34,10 @@ func (m *NetTestRunner) Validate() status.TestGroupResult {
 }
 
 func (m *NetTestRunner) SetupBeforeAgentRun() error {
-	err := common.RunCommands([]string{"ping -c 10 127.0.0.1 > /dev/null 2>&1 &"})
-	if err != nil {
-		return err
-	}
+	// err := common.RunCommands([]string{"ping -c 10 127.0.0.1 > /dev/null 2>&1 &"})
+	// if err != nil {
+	// 	return err
+	// }
 	return m.SetUpConfig()
 }
 
@@ -65,7 +64,7 @@ func (m *NetTestRunner) validateNetMetric(metricName string) status.TestResult {
 	dims, failed := m.DimensionFactory.GetDimensions([]dimension.Instruction{
 		{
 			Key:   "interface",
-			Value: dimension.ExpectedDimensionValue{aws.String("lo")},
+			Value: dimension.ExpectedDimensionValue{aws.String("eth0")},
 		},
 		{
 			Key:   "InstanceId",

--- a/test/metric_value_benchmark/net_test.go
+++ b/test/metric_value_benchmark/net_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
 )
 
 type NetTestRunner struct {
@@ -34,10 +35,10 @@ func (m *NetTestRunner) Validate() status.TestGroupResult {
 }
 
 func (m *NetTestRunner) SetupBeforeAgentRun() error {
-	// err := common.RunCommands([]string{"ping -c 10 127.0.0.1 > /dev/null 2>&1 &"})
-	// if err != nil {
-	// 	return err
-	// }
+	err := common.RunCommands([]string{"sudo systemctl restart docker"})
+	if err != nil {
+		return err
+	}
 	return m.SetUpConfig()
 }
 
@@ -64,7 +65,7 @@ func (m *NetTestRunner) validateNetMetric(metricName string) status.TestResult {
 	dims, failed := m.DimensionFactory.GetDimensions([]dimension.Instruction{
 		{
 			Key:   "interface",
-			Value: dimension.ExpectedDimensionValue{aws.String("eth0")},
+			Value: dimension.ExpectedDimensionValue{aws.String("docker0")},
 		},
 		{
 			Key:   "InstanceId",

--- a/test/metric_value_benchmark/net_test.go
+++ b/test/metric_value_benchmark/net_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
 )
 
 type NetTestRunner struct {
@@ -34,6 +35,10 @@ func (m *NetTestRunner) Validate() status.TestGroupResult {
 }
 
 func (m *NetTestRunner) SetupBeforeAgentRun() error {
+	err := common.RunCommands([]string{"ping -c 10 127.0.0.1 > /dev/null 2>&1 &"})
+	if err != nil {
+		return err
+	}
 	return m.SetUpConfig()
 }
 
@@ -60,7 +65,7 @@ func (m *NetTestRunner) validateNetMetric(metricName string) status.TestResult {
 	dims, failed := m.DimensionFactory.GetDimensions([]dimension.Instruction{
 		{
 			Key:   "interface",
-			Value: dimension.ExpectedDimensionValue{aws.String("docker0")},
+			Value: dimension.ExpectedDimensionValue{aws.String("lo")},
 		},
 		{
 			Key:   "InstanceId",


### PR DESCRIPTION
# Description of the issue
Add support for RHEL10.

# Description of changes
We verify support for RHEL10 by including the OS in our suite of testing.

> Red Hat removed the Docker container engine and the docker command from RHEL 10. 

https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html-single/building_running_and_managing_containers/index#running-containers-without-docker

As a result, we use the `ens5` network interface instead of the `docker0` network interface for our RHEL10 network tests.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 

# Tests
Integration test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/18047091319
