### PR TITLE
Add support for Ubuntu 25

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -33,6 +33,17 @@
     "family": "linux"
   },
   {
+    "os": "ubuntu-25",
+    "username": "ubuntu",
+    "instanceType":"t3.medium",
+    "installAgentCommand": "go run ./install/install_agent.go deb",
+    "ami": "cloudwatch-agent-integration-test-ubuntu-25*",
+    "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.deb",
+    "family": "linux"
+  },
+  {
     "os": "debian-12",
     "username": "admin",
     "instanceType": "c6g.large",


### PR DESCRIPTION
# Description of the issue
Add support for Ubuntu 25.

# Description of changes
We verify support for Ubuntu 25 by including the OS in our suite of testing.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 

# Tests
Integration test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/18148334626
