### PR TITLE
Add support for Alma 10/Rocky 10/RHEL 9 + remove EOL OSes

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -1,16 +1,5 @@
 [
   {
-    "os": "ubuntu-20.04",
-    "username": "ubuntu",
-    "instanceType":"t3a.medium",
-    "installAgentCommand": "go run ./install/install_agent.go deb",
-    "ami": "cloudwatch-agent-integration-test-ubuntu*",
-    "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
-    "arc": "amd64",
-    "binaryName": "amazon-cloudwatch-agent.deb",
-    "family": "linux"
-  },
-  {
     "os": "ubuntu-22.04",
     "username": "ubuntu",
     "instanceType":"t3a.medium",
@@ -154,6 +143,17 @@
     "family": "linux"
   },
   {
+    "os": "rocky-linux-10",
+    "username": "rocky",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-rocky-linux-10*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
+  {
     "os": "alma-linux-8",
     "username": "ec2-user",
     "instanceType":"t3a.medium",
@@ -170,6 +170,28 @@
     "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-alma-linux-9*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
+  {
+    "os": "alma-linux-10",
+    "username": "ec2-user",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-alma-linux-10*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
+  {
+    "os": "rhel9",
+    "username": "ec2-user",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-rhel9*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",


### PR DESCRIPTION
# Description of the issue
Add support for Alma 10/Rocky 10/RHEL 9 + remove EOL OSes

# Description of changes
Update the test matrix to include the new OSes and remove the ones we no longer support

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 

# Tests
Integ test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/18205029671
