### PR TITLE
Use t3a.medium in integ tests

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -46,7 +46,7 @@
   {
     "os": "al2",
     "username": "ec2-user",
-    "instanceType":"m7g.medium",
+    "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-al2*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
@@ -57,7 +57,7 @@
   {
     "os": "al2",
     "username": "ec2-user",
-    "instanceType":"t3a.medium",
+    "instanceType":"m7g.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-arm64-al2*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
@@ -79,7 +79,7 @@
   {
     "os": "al2023",
     "username": "ec2-user",
-    "instanceType":"t3a.medium",
+    "instanceType":"m6g.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-aarch64-al2023*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
@@ -90,7 +90,7 @@
   {
     "os": "ol8",
     "username": "ec2-user",
-    "instanceType":"m6g.medium",
+    "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-ol8*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -35,7 +35,7 @@
   {
     "os": "debian-12",
     "username": "admin",
-    "instanceType": "t3a.medium",
+    "instanceType": "c6g.large",
     "installAgentCommand": "go run ./install/install_agent.go deb",
     "ami": "cloudwatch-agent-integration-test-debian-12-arm64*",
     "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
@@ -46,7 +46,7 @@
   {
     "os": "al2",
     "username": "ec2-user",
-    "instanceType":"t3a.medium",
+    "instanceType":"m7g.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-al2*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
@@ -90,7 +90,7 @@
   {
     "os": "ol8",
     "username": "ec2-user",
-    "instanceType":"t3a.medium",
+    "instanceType":"m6g.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-ol8*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -13,7 +13,7 @@
   {
     "os": "ubuntu-24",
     "username": "ubuntu",
-    "instanceType":"t3.medium",
+    "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go deb",
     "ami": "cloudwatch-agent-integration-test-ubuntu-24*",
     "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
@@ -24,7 +24,7 @@
   {
     "os": "ubuntu-25",
     "username": "ubuntu",
-    "instanceType":"t3.medium",
+    "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go deb",
     "ami": "cloudwatch-agent-integration-test-ubuntu-25*",
     "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
@@ -35,7 +35,7 @@
   {
     "os": "debian-12",
     "username": "admin",
-    "instanceType": "c6g.large",
+    "instanceType": "t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go deb",
     "ami": "cloudwatch-agent-integration-test-debian-12-arm64*",
     "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
@@ -57,7 +57,7 @@
   {
     "os": "al2",
     "username": "ec2-user",
-    "instanceType":"m7g.medium",
+    "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-arm64-al2*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
@@ -79,7 +79,7 @@
   {
     "os": "al2023",
     "username": "ec2-user",
-    "instanceType":"m6g.medium",
+    "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-aarch64-al2023*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -1,16 +1,5 @@
 [
   {
-    "os": "ubuntu-20.04",
-    "username": "ubuntu",
-    "instanceType":"t3a.medium",
-    "installAgentCommand": "go run ./install/install_agent.go deb",
-    "ami": "cloudwatch-agent-integration-test-ubuntu*",
-    "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
-    "arc": "amd64",
-    "binaryName": "amazon-cloudwatch-agent.deb",
-    "family": "linux"
-  },
-  {
     "os": "ubuntu-22.04",
     "username": "ubuntu",
     "instanceType":"t3a.medium",
@@ -154,6 +143,17 @@
     "family": "linux"
   },
   {
+    "os": "rocky-linux-10",
+    "username": "rocky",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-rocky-linux-10*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
+  {
     "os": "alma-linux-8",
     "username": "ec2-user",
     "instanceType":"t3a.medium",
@@ -170,6 +170,28 @@
     "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
     "ami": "cloudwatch-agent-integration-test-alma-linux-9*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
+  {
+    "os": "alma-linux-10",
+    "username": "ec2-user",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-alma-linux-10*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
+  {
+    "os": "rhel9",
+    "username": "ec2-user",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-rhel9*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",


### PR DESCRIPTION
# Description of changes
For testing we use both t3 and t3a instances. These are both x86 instances but with different processors. According to [docs](https://aws.amazon.com/ec2/instance-types/t3/), they are identical but t3a is ~10% cheaper. We will now use the t3a.medium instance type where we were previously using the t3.medium type. 

Note: The debian12 and some of the al2 and al2023 tests are unchanged to not use the t3a.medium instance type due to being more resource-intensive. These tests failed when run on a t3a.medium.  

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 

# Tests
Integ test: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/18225099540
