### PR TITLE
Fix OTLP Export Testing issues by removing test runs for itar and china regions

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -444,6 +444,8 @@ type partition struct {
 	// testConfigOverrides allows partition-specific test configurations
 	// key is testDir, value is the override config
 	testConfigOverrides map[string]testConfig
+	// excludedTestDirs allows excluding specific test directories from a partition
+	excludedTestDirs map[string]struct{}
 }
 
 var partitionTests = map[string]partition{
@@ -456,6 +458,11 @@ var partitionTests = map[string]partition{
 		configName: "_itar",
 		tests:      []string{testTypeKeyEc2Linux},
 		ami:        []string{"cloudwatch-agent-integration-test-aarch64-al2023*"},
+		excludedTestDirs: map[string]struct{}{
+			"./test/otlp_export/hostmetrics": {},
+			"./test/otlp_export/statsd":      {},
+			"./test/otlp_export/collectd":    {},
+		},
 		testConfigOverrides: map[string]testConfig{
 			"./test/metric_value_benchmark": {
 				// Exclude DiskIOInstanceStore and DiskIOEBS tests - custom AMI doesn't support NVMe instance store metrics
@@ -471,6 +478,11 @@ var partitionTests = map[string]partition{
 		configName: "_china",
 		tests:      []string{testTypeKeyEc2Linux},
 		ami:        []string{"cloudwatch-agent-integration-test-aarch64-al2023*"},
+		excludedTestDirs: map[string]struct{}{
+			"./test/otlp_export/hostmetrics": {},
+			"./test/otlp_export/statsd":      {},
+			"./test/otlp_export/collectd":    {},
+		},
 		testConfigOverrides: map[string]testConfig{
 			"./test/metric_value_benchmark": {
 				// Exclude DiskIOInstanceStore and DiskIOEBS tests - custom AMI doesn't support NVMe instance store metrics
@@ -498,7 +510,7 @@ func main() {
 			if len(partition.tests) != 0 && !slices.Contains(partition.tests, testType) {
 				continue
 			}
-			testMatrix := genMatrix(testType, testConfigs, partition.ami, partition.testConfigOverrides)
+			testMatrix := genMatrix(testType, testConfigs, partition.ami, partition.testConfigOverrides, partition.excludedTestDirs)
 			writeTestMatrixFile(testType+partition.configName, testMatrix)
 		}
 	}
@@ -528,7 +540,7 @@ func generateTestName(testType string, test_directory string) string {
 
 	return strings.Join(cleaned, "_")
 }
-func genMatrix(testType string, testConfigs []testConfig, ami []string, overrides map[string]testConfig) []matrixRow {
+func genMatrix(testType string, testConfigs []testConfig, ami []string, overrides map[string]testConfig, excludedTestDirs map[string]struct{}) []matrixRow {
 	openTestMatrix, err := os.Open(fmt.Sprintf("generator/resources/%v_test_matrix.json", testType))
 
 	if err != nil {
@@ -548,6 +560,13 @@ func genMatrix(testType string, testConfigs []testConfig, ami []string, override
 	testMatrixComplete := make([]matrixRow, 0, len(testMatrix))
 	for _, test := range testMatrix {
 		for _, testConfig := range testConfigs {
+			// Skip test dirs excluded for this partition
+			if excludedTestDirs != nil {
+				if _, excluded := excludedTestDirs[testConfig.testDir]; excluded {
+					continue
+				}
+			}
+
 			// Apply partition-specific overrides if available
 			if overrides != nil {
 				if override, ok := overrides[testConfig.testDir]; ok {

--- a/test/otlp_export/otlpvalidation/validate.go
+++ b/test/otlp_export/otlpvalidation/validate.go
@@ -14,22 +14,44 @@ import (
 )
 
 func ValidateOtlpMetrics(testName string, region string, metrics []string) status.TestGroupResult {
-	results := make([]status.TestResult, 0, len(metrics)+1)
-	successCount := 0
-	for _, m := range metrics {
-		promql := fmt.Sprintf(`{__name__="%s"}`, m)
-		resp, err := awsservice.QueryOtlpMetricsWithRetry(region, promql, 10, 30*time.Second)
-		if err != nil {
-			results = append(results, status.TestResult{Name: m, Status: status.FAILED, Reason: err})
-			continue
+	const maxRetries = 10
+	const retryInterval = 30 * time.Second
+
+	// Track which metrics have been validated
+	validated := make(map[string]bool, len(metrics))
+	var lastFailures []string
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			time.Sleep(retryInterval)
 		}
-		if len(resp.Data.Result) == 0 {
-			results = append(results, status.TestResult{Name: m, Status: status.FAILED, Reason: fmt.Errorf("no results for %s", m)})
-			continue
+		lastFailures = nil
+		for _, m := range metrics {
+			if validated[m] {
+				continue
+			}
+			promql := fmt.Sprintf(`{__name__="%s"}`, m)
+			resp, err := awsservice.QueryOtlpMetrics(region, promql)
+			if err != nil || len(resp.Data.Result) == 0 {
+				lastFailures = append(lastFailures, m)
+				continue
+			}
+			validated[m] = true
 		}
-		results = append(results, status.TestResult{Name: m, Status: status.SUCCESSFUL})
-		successCount++
+		if len(lastFailures) == 0 {
+			break
+		}
 	}
+
+	results := make([]status.TestResult, 0, len(metrics)+1)
+	for _, m := range metrics {
+		if validated[m] {
+			results = append(results, status.TestResult{Name: m, Status: status.SUCCESSFUL})
+		} else {
+			results = append(results, status.TestResult{Name: m, Status: status.FAILED, Reason: fmt.Errorf("metric %s not found after %d retries", m, maxRetries)})
+		}
+	}
+	successCount := len(validated)
 	if successCount != len(metrics) {
 		results = append(results, status.TestResult{
 			Name:   "MetricCountCheck",

--- a/test/otlp_export/otlpvalidation/validate.go
+++ b/test/otlp_export/otlpvalidation/validate.go
@@ -14,18 +14,16 @@ import (
 )
 
 func ValidateOtlpMetrics(testName string, region string, metrics []string) status.TestGroupResult {
-	const maxRetries = 10
-	const retryInterval = 30 * time.Second
+	const maxRetries = 5
+	const retryInterval = 20 * time.Second
 
 	// Track which metrics have been validated
 	validated := make(map[string]bool, len(metrics))
-	var lastFailures []string
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
 			time.Sleep(retryInterval)
 		}
-		lastFailures = nil
 		for _, m := range metrics {
 			if validated[m] {
 				continue
@@ -33,12 +31,11 @@ func ValidateOtlpMetrics(testName string, region string, metrics []string) statu
 			promql := fmt.Sprintf(`{__name__="%s"}`, m)
 			resp, err := awsservice.QueryOtlpMetrics(region, promql)
 			if err != nil || len(resp.Data.Result) == 0 {
-				lastFailures = append(lastFailures, m)
 				continue
 			}
 			validated[m] = true
 		}
-		if len(lastFailures) == 0 {
+		if len(validated) == len(metrics) {
 			break
 		}
 	}

--- a/util/awsservice/otlpmetricsquery.go
+++ b/util/awsservice/otlpmetricsquery.go
@@ -90,19 +90,3 @@ func QueryOtlpMetrics(region string, promql string) (PrometheusResponse, error) 
 	return resp, nil
 }
 
-func QueryOtlpMetricsWithRetry(region string, promql string, retries int, retryInterval time.Duration) (PrometheusResponse, error) {
-	var lastErr error
-	for i := 0; i < retries; i++ {
-		resp, err := QueryOtlpMetrics(region, promql)
-		if err == nil && resp.Status == "success" && len(resp.Data.Result) > 0 {
-			return resp, nil
-		}
-		if err != nil {
-			lastErr = err
-		} else {
-			lastErr = fmt.Errorf("otlp query unsuccessful: status=%s, results=%d, error=%s", resp.Status, len(resp.Data.Result), resp.Error)
-		}
-		time.Sleep(retryInterval)
-	}
-	return PrometheusResponse{}, fmt.Errorf("otlp query failed after %d retries: %w", retries, lastErr)
-}


### PR DESCRIPTION
# Description of the issue

OTLP export integration tests fail in GovCloud (ITAR) and China regions because the Prometheus query endpoint (
monitoring.{region}.amazonaws.com/api/v1/query) is not available there. Failing tests also ran for over 1hr 45min due to the retry mechanism
repeatedly hitting unreachable endpoints.

Related: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/24576087565/job/71862186868

# Description of changes

1. Exclude OTLP export test directories from ITAR and China partitions in the test matrix generator using a new excludedTestDirs field. OTLP tests now only run in commercial regions.

2. Simplify retry logic in ValidateOtlpMetrics — use a single batch retry loop with a validated map instead of per-metric retries. Reduce max wait from ~4.5 min to ~1.5 min (5 retries × 20s).

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

Triggered integration-test.yml with build_run_id=24577672344, build_sha=d9fe51dae8b5445dc0131c3049f16085fcec0e07, and test_repo_branch=otlp-testing to verify OTLP tests pass in commercial regions and are excluded from ITAR/China matrices.

https://github.com/aws/amazon-cloudwatch-agent/actions/runs/24681107696/job/72178680476