### PR TITLE
Add OTEL MetricsV2 standard cluster integration tests

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -422,6 +422,11 @@ var testTypeToTestConfig = map[string][]testConfig{
 			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
 			wip:          true,
 		},
+		{
+			testDir:      "./test/otel/standard",
+			terraformDir: "terraform/eks/daemon/otel",
+			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
+		},
 	},
 	"eks_deployment": {
 		{testDir: "./test/metric_value_benchmark"},

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.35.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.47.2
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.44.2
+	github.com/aws/aws-sdk-go-v2/service/sts v1.26.2
 	github.com/aws/aws-sdk-go-v2/service/xray v1.23.2
 	github.com/aws/aws-xray-sdk-go v1.8.3
 	github.com/cenkalti/backoff/v4 v4.2.1
@@ -63,7 +64,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.16.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.18.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.2 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.26.2 // indirect
 	github.com/aws/smithy-go v1.18.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect

--- a/terraform/eks/daemon/otel/.gitignore
+++ b/terraform/eks/daemon/otel/.gitignore
@@ -1,0 +1,3 @@
+*.tfstate*
+.terraform/
+helm-charts/

--- a/terraform/eks/daemon/otel/main.tf
+++ b/terraform/eks/daemon/otel/main.tf
@@ -1,0 +1,242 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+module "common" {
+  source             = "../../../common"
+  cwagent_image_repo = var.cwagent_image_repo
+  cwagent_image_tag  = var.cwagent_image_tag
+}
+
+module "basic_components" {
+  source = "../../../basic_components"
+  region = var.region
+}
+
+locals {
+  aws_eks = "aws eks --region ${var.region}"
+}
+
+resource "aws_eks_cluster" "this" {
+  name     = "cwagent-eks-integ-${module.common.testing_id}"
+  role_arn = module.basic_components.role_arn
+  version  = var.k8s_version
+  vpc_config {
+    subnet_ids         = module.basic_components.public_subnet_ids
+    security_group_ids = [module.basic_components.security_group]
+  }
+}
+
+# EKS Node Group — 2x t3.medium with node-color=blue label
+resource "aws_eks_node_group" "this" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_group_name = "cwagent-otel-integ-node-${module.common.testing_id}"
+  node_role_arn   = aws_iam_role.node_role.arn
+  subnet_ids      = module.basic_components.public_subnet_ids
+
+  scaling_config {
+    desired_size = 2
+    max_size     = 2
+    min_size     = 2
+  }
+
+  ami_type       = var.ami_type
+  capacity_type  = "ON_DEMAND"
+  disk_size      = 20
+  instance_types = [var.instance_type]
+
+  labels = {
+    "ci-test.example.com/node-color" = "blue"
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.node_AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.node_AmazonEKSWorkerNodePolicy,
+  ]
+}
+
+# EKS Node IAM Role
+resource "aws_iam_role" "node_role" {
+  name = "cwagent-otel-eks-Worker-Role-${module.common.testing_id}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node_role.name
+}
+
+
+# Pod Identity IAM Role
+resource "aws_iam_role" "pod_identity_role" {
+  name = "cwagent-otel-pod-identity-${module.common.testing_id}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "pods.eks.amazonaws.com" }
+      Action    = ["sts:AssumeRole", "sts:TagSession"]
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "pod_identity_CloudWatchAgentServerPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+  role       = aws_iam_role.pod_identity_role.name
+}
+
+# --- EKS Addon: Pod Identity agent ---
+
+resource "aws_eks_addon" "pod_identity_agent" {
+  depends_on   = [aws_eks_node_group.this]
+  cluster_name = aws_eks_cluster.this.name
+  addon_name   = "eks-pod-identity-agent"
+}
+
+# --- Update kubeconfig ---
+
+resource "null_resource" "kubectl" {
+  depends_on = [aws_eks_cluster.this, aws_eks_node_group.this]
+  provisioner "local-exec" {
+    command = "${local.aws_eks} update-kubeconfig --name ${aws_eks_cluster.this.name}"
+  }
+}
+
+# --- Helm chart install ---
+
+data "external" "clone_helm_chart" {
+  program = ["bash", "-c", <<-EOT
+    rm -rf ./helm-charts
+    git clone -b ${var.helm_chart_branch} https://github.com/aws-observability/helm-charts.git ./helm-charts
+    echo '{"status":"ready"}'
+  EOT
+  ]
+}
+
+resource "helm_release" "aws_observability" {
+  name             = "amazon-cloudwatch-observability"
+  chart            = "./helm-charts/charts/amazon-cloudwatch-observability"
+  namespace        = "amazon-cloudwatch"
+  create_namespace = true
+
+  set = [
+    { name = "clusterName", value = aws_eks_cluster.this.name },
+    { name = "region", value = var.region }
+  ]
+
+  depends_on = [
+    aws_eks_addon.pod_identity_agent,
+    null_resource.kubectl,
+    data.external.clone_helm_chart,
+  ]
+}
+
+# --- Pod Identity association (after Helm creates the service account) ---
+
+resource "aws_eks_pod_identity_association" "cloudwatch_agent" {
+  depends_on      = [helm_release.aws_observability]
+  cluster_name    = aws_eks_cluster.this.name
+  namespace       = "amazon-cloudwatch"
+  service_account = "cloudwatch-agent"
+  role_arn        = aws_iam_role.pod_identity_role.arn
+}
+
+# --- Patch agent image (both DaemonSet and cluster-scraper) ---
+
+resource "null_resource" "update_image" {
+  depends_on = [helm_release.aws_observability, null_resource.kubectl]
+  triggers   = { timestamp = timestamp() }
+  provisioner "local-exec" {
+    command = <<-EOT
+      sleep 30
+      kubectl -n amazon-cloudwatch patch AmazonCloudWatchAgent cloudwatch-agent --type='json' \
+        -p='[{"op": "replace", "path": "/spec/image", "value": "${var.cwagent_image_repo}:${var.cwagent_image_tag}"}]'
+      kubectl -n amazon-cloudwatch patch AmazonCloudWatchAgent cloudwatch-agent-cluster-scraper --type='json' \
+        -p='[{"op": "replace", "path": "/spec/image", "value": "${var.cwagent_image_repo}:${var.cwagent_image_tag}"}]' 2>/dev/null || true
+      sleep 10
+    EOT
+  }
+}
+
+# --- Restart pods to pick up Pod Identity + new image ---
+
+resource "null_resource" "restart_pods" {
+  depends_on = [aws_eks_pod_identity_association.cloudwatch_agent, null_resource.update_image]
+  triggers   = { timestamp = timestamp() }
+  provisioner "local-exec" {
+    command = <<-EOT
+      kubectl -n amazon-cloudwatch rollout restart daemonset/cloudwatch-agent
+      kubectl -n amazon-cloudwatch rollout restart deployment/cloudwatch-agent-cluster-scraper 2>/dev/null || true
+      kubectl -n amazon-cloudwatch rollout status daemonset/cloudwatch-agent --timeout=120s
+      kubectl -n amazon-cloudwatch rollout status deployment/cloudwatch-agent-cluster-scraper --timeout=120s 2>/dev/null || true
+    EOT
+  }
+}
+
+# --- Test workload: nginx ---
+
+resource "kubernetes_deployment_v1" "nginx_test" {
+  depends_on = [aws_eks_node_group.this]
+  metadata {
+    name      = "nginx-test"
+    namespace = "default"
+  }
+  spec {
+    replicas = 1
+    selector { match_labels = { app = "nginx-test" } }
+    template {
+      metadata { labels = { app = "nginx-test" } }
+      spec {
+        container {
+          name  = "nginx"
+          image = "public.ecr.aws/nginx/nginx:latest"
+          port { container_port = 80 }
+        }
+      }
+    }
+  }
+}
+
+# --- Test runner ---
+
+resource "null_resource" "validator" {
+  depends_on = [
+    null_resource.restart_pods,
+    kubernetes_deployment_v1.nginx_test,
+  ]
+
+  triggers = { always_run = timestamp() }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "Running OTEL standard cluster integration tests"
+      cd ../../../..
+
+      echo "Waiting 3 minutes for metrics to propagate..."
+      sleep 180
+
+      go test -tags integration -timeout 1h -v ${var.test_dir} \
+        -eksClusterName=${aws_eks_cluster.this.name} \
+        -computeType=EKS \
+        -eksDeploymentStrategy=DAEMON \
+        -region=${var.region}
+    EOT
+  }
+}

--- a/terraform/eks/daemon/otel/providers.tf
+++ b/terraform/eks/daemon/otel/providers.tf
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+provider "aws" {
+  region = var.region
+}
+
+provider "kubernetes" {
+  host                   = aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority.0.data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.this.name]
+  }
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = aws_eks_cluster.this.endpoint
+    cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority.0.data)
+    exec = {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.this.name]
+    }
+  }
+}

--- a/terraform/eks/daemon/otel/variables.tf
+++ b/terraform/eks/daemon/otel/variables.tf
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "test_dir" {
+  type    = string
+  default = "./test/otel/standard"
+}
+
+variable "cwagent_image_repo" {
+  type    = string
+  default = "public.ecr.aws/cloudwatch-agent/cloudwatch-agent"
+}
+
+variable "cwagent_image_tag" {
+  type    = string
+  default = "latest"
+}
+
+variable "helm_chart_branch" {
+  type    = string
+  default = "main"
+}
+
+variable "k8s_version" {
+  type    = string
+  default = "1.35"
+}
+
+variable "ami_type" {
+  type    = string
+  default = "AL2023_x86_64_STANDARD"
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3.medium"
+}

--- a/test/otel/standard/cadvisor_test.go
+++ b/test/otel/standard/cadvisor_test.go
@@ -1,0 +1,201 @@
+//go:build integration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package standard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/util/otelmetrics"
+)
+
+var cadvisorMetricNamesList = metricNames(cadvisorMetrics)
+
+func TestCadvisorInstrumentationSource(t *testing.T) {
+	for _, name := range cadvisorMetricNamesList {
+		t.Run(name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), name)
+			require.NoError(t, err, "querying %s", name)
+			require.NotEmpty(t, results, "%s not available", name)
+			for _, r := range results {
+				v, ok := r.Labels.Instrumentation["@name"]
+				require.True(t, ok, "%s missing @instrumentation.@name", name)
+				require.Equal(t, "github.com/google/cadvisor", v, "%s instrumentation", name)
+			}
+		})
+	}
+}
+
+func TestCadvisorInstrumentationConsistent(t *testing.T) {
+	for _, name := range cadvisorMetricNamesList {
+		t.Run(name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), name)
+			require.NoError(t, err, "querying %s", name)
+			require.NotEmpty(t, results, "%s not available", name)
+			names := make(map[string]struct{})
+			for _, r := range results {
+				if n, ok := r.Labels.Instrumentation["@name"]; ok {
+					names[n] = struct{}{}
+				}
+			}
+			require.Equal(t, 1, len(names), "%s has %d distinct instrumentation names", name, len(names))
+		})
+	}
+}
+
+func TestCadvisorPodName(t *testing.T) {
+	for _, name := range cadvisorMetricNamesList {
+		t.Run(name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), name)
+			require.NoError(t, err, "querying %s", name)
+			require.NotEmpty(t, results, "%s not available", name)
+			for _, r := range results {
+				pod := r.Labels.Resource["k8s.pod.name"]
+				require.True(t, pod != "", "%s missing k8s.pod.name", name)
+			}
+		})
+	}
+}
+
+func TestCadvisorNamespace(t *testing.T) {
+	for _, name := range cadvisorMetricNamesList {
+		t.Run(name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), name)
+			require.NoError(t, err, "querying %s", name)
+			require.NotEmpty(t, results, "%s not available", name)
+			for _, r := range results {
+				ns := r.Labels.Resource["k8s.namespace.name"]
+				require.True(t, ns != "", "%s missing k8s.namespace.name", name)
+			}
+		})
+	}
+}
+
+func TestCadvisorContainerName(t *testing.T) {
+	for _, md := range cadvisorMetrics {
+		if md.Scope != otelmetrics.ScopeContainer {
+			continue
+		}
+		t.Run(md.Name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), md.Name)
+			require.NoError(t, err, "querying %s", md.Name)
+			require.NotEmpty(t, results, "%s not available", md.Name)
+			hasContainer := 0
+			for _, r := range results {
+				if cn, ok := r.Labels.Resource["k8s.container.name"]; ok {
+					require.True(t, cn != "", "%s empty k8s.container.name", md.Name)
+					hasContainer++
+				}
+			}
+			require.True(t, hasContainer > 0, "%s no results with k8s.container.name", md.Name)
+		})
+	}
+}
+
+func TestCadvisorExpectedLabels(t *testing.T) {
+	for _, md := range cadvisorMetrics {
+		if len(md.ExpectedLabels) == 0 {
+			continue
+		}
+		t.Run(md.Name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), md.Name)
+			require.NoError(t, err, "querying %s", md.Name)
+			require.NotEmpty(t, results, "%s not available", md.Name)
+			for _, r := range results {
+				for _, label := range md.ExpectedLabels {
+					_, ok := r.Labels.Datapoint[label]
+					require.True(t, ok, "%s missing expected label '%s'", md.Name, label)
+				}
+			}
+		})
+	}
+}
+
+func TestCadvisorPodLabelsStrict(t *testing.T) {
+	for _, name := range cadvisorMetricNamesList {
+		t.Run(name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), name)
+			require.NoError(t, err, "querying %s", name)
+			require.NotEmpty(t, results, "%s not available", name)
+			for _, r := range results {
+				require.True(t, r.Labels.Resource["k8s.pod.name"] != "", "%s missing pod", name)
+				require.True(t, r.Labels.Resource["k8s.namespace.name"] != "", "%s missing ns", name)
+				require.True(t, r.Labels.Resource["k8s.node.name"] != "", "%s missing node", name)
+			}
+		})
+	}
+}
+
+func TestCadvisorNginxWorkloadLabels(t *testing.T) {
+	for _, name := range cadvisorMetricNamesList {
+		t.Run(name, func(t *testing.T) {
+			promql := fmt.Sprintf(`%s{"@resource.k8s.cluster.name"="%s","@resource.k8s.pod.name"=~"nginx-test.*"}`,
+				name, cfg.ClusterName)
+			nginx, err := client.Query(context.Background(), promql)
+			require.NoError(t, err, "querying %s for nginx-test", name)
+			require.True(t, len(nginx) > 0, "No %s from nginx-test pods", name)
+			for _, r := range nginx {
+				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.workload.name"], "%s workload name", name)
+				require.Equal(t, "Deployment", r.Labels.Resource["k8s.workload.type"], "%s workload type", name)
+			}
+		})
+	}
+}
+
+func TestCadvisorHasRawPromotedKeys(t *testing.T) {
+	for _, name := range cadvisorMetricNamesList {
+		t.Run(name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), name)
+			require.NoError(t, err, "querying %s", name)
+			require.NotEmpty(t, results, "%s not available", name)
+			rawKeys := []string{"pod", "namespace"}
+			if !strings.Contains(name, "network") {
+				rawKeys = append(rawKeys, "container")
+			}
+			for _, key := range rawKeys {
+				found := false
+				for _, r := range results {
+					if v, ok := r.Labels.Datapoint[key]; ok && v != "" {
+						found = true
+						break
+					}
+				}
+				require.True(t, found, "%s missing raw '%s' at datapoint scope", name, key)
+			}
+		})
+	}
+}
+
+func TestCadvisorNoPodSandboxMetrics(t *testing.T) {
+	for _, name := range cadvisorMetricNamesList {
+		t.Run(name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), name)
+			require.NoError(t, err, "querying %s", name)
+			require.NotEmpty(t, results, "%s not available", name)
+			for _, r := range results {
+				require.True(t, r.Labels.Resource["k8s.container.name"] != "POD", "%s has POD container", name)
+				require.True(t, r.Labels.Datapoint["container"] != "POD", "%s has POD datapoint", name)
+			}
+		})
+	}
+}
+
+func TestCadvisorNodeGroupCoverage(t *testing.T) {
+	for _, ng := range clusterNodeGroups {
+		t.Run(ng.Description+"/"+ng.InstanceType, func(t *testing.T) {
+			promql := fmt.Sprintf(
+				`container_memory_working_set_bytes{"@resource.k8s.cluster.name"="%s","@resource.host.type"="%s"}`,
+				otelmetrics.EscapePromQLValue(cfg.ClusterName), ng.InstanceType)
+			results, err := client.Query(context.Background(), promql)
+			require.NoError(t, err, "querying cadvisor on %s", ng.Description)
+			require.True(t, len(results) > 0, "cadvisor missing from %s (%s)", ng.Description, ng.InstanceType)
+		})
+	}
+}

--- a/test/otel/standard/control_plane_test.go
+++ b/test/otel/standard/control_plane_test.go
@@ -1,0 +1,208 @@
+//go:build integration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package standard
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// TestControlPlaneInstrumentation — instrumentation source for control plane metrics.
+// ---------------------------------------------------------------------------
+
+func TestControlPlaneInstrumentation(t *testing.T) {
+	for _, metricName := range metricNames(controlPlaneMetrics) {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available (control plane not scraped?)", metricName)
+			for _, r := range results {
+				name, ok := r.Labels.Instrumentation["@name"]
+				require.True(t, ok, "%s missing @instrumentation.@name", metricName)
+				require.Equal(t, scopePrometheus, name, "%s instrumentation name", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestAPIServerComponentLabel — apiserver metrics must have k8s.component.name=apiserver.
+// ---------------------------------------------------------------------------
+
+func TestAPIServerComponentLabel(t *testing.T) {
+	for _, metricName := range metricNames(controlPlaneMetrics) {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available (apiserver not scraped?)", metricName)
+			for _, r := range results {
+				comp, ok := r.Labels.Resource["k8s.component.name"]
+				require.True(t, ok, "%s missing @resource.k8s.component.name", metricName)
+				require.Equal(t, "apiserver", comp, "%s k8s.component.name", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestControlPlaneExpectedLabels — expected datapoint labels present.
+// ---------------------------------------------------------------------------
+
+func TestControlPlaneExpectedLabels(t *testing.T) {
+	for _, md := range controlPlaneMetrics {
+		if len(md.ExpectedLabels) == 0 {
+			continue
+		}
+		for _, label := range md.ExpectedLabels {
+			t.Run(md.Name+"/"+label, func(t *testing.T) {
+				results, err := queryCache.Get(context.Background(), md.Name)
+				require.NoError(t, err, "querying %s", md.Name)
+				require.NotEmpty(t, results, "%s not available (control plane not scraped?)", md.Name)
+				for _, r := range results {
+					_, ok := r.Labels.Datapoint[label]
+					require.True(t, ok, "%s missing expected label '%s'", md.Name, label)
+				}
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestControlPlaneClusterIdentity — @resource.k8s.cluster.name present.
+// ---------------------------------------------------------------------------
+
+func TestControlPlaneClusterIdentity(t *testing.T) {
+	for _, metricName := range metricNames(controlPlaneMetrics) {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available (control plane not scraped?)", metricName)
+			for _, r := range results {
+				require.Equal(t, cfg.ClusterName, r.Labels.Resource["k8s.cluster.name"],
+					"%s cluster name", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestControlPlaneCloudDetection — cloud.* from resourcedetection.
+// ---------------------------------------------------------------------------
+
+func TestControlPlaneCloudDetection(t *testing.T) {
+	for _, metricName := range metricNames(controlPlaneMetrics) {
+		t.Run(metricName+"/provider", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available (control plane not scraped?)", metricName)
+			for _, r := range results {
+				require.Equal(t, "aws", r.Labels.Resource["cloud.provider"], "%s cloud.provider", metricName)
+			}
+		})
+		t.Run(metricName+"/region", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available (control plane not scraped?)", metricName)
+			for _, r := range results {
+				region, ok := r.Labels.Resource["cloud.region"]
+				require.True(t, ok, "%s missing @resource.cloud.region", metricName)
+				require.True(t, region != "", "%s has empty cloud.region", metricName)
+			}
+		})
+		t.Run(metricName+"/account_id", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available (control plane not scraped?)", metricName)
+			for _, r := range results {
+				acctID, ok := r.Labels.Resource["cloud.account.id"]
+				require.True(t, ok, "%s missing @resource.cloud.account.id", metricName)
+				require.Equal(t, 12, len(acctID), "%s cloud.account.id length", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestControlPlaneInstrumentationVersion — @instrumentation.@version present.
+// ---------------------------------------------------------------------------
+
+func TestControlPlaneInstrumentationVersion(t *testing.T) {
+	for _, metricName := range metricNames(controlPlaneMetrics) {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available (control plane not scraped?)", metricName)
+			for _, r := range results {
+				version, ok := r.Labels.Instrumentation["@version"]
+				require.True(t, ok, "%s missing @instrumentation.@version", metricName)
+				require.True(t, version != "", "%s has empty @instrumentation.@version", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestControlPlaneNoNodeLabels — must NOT have k8s.node.name or k8s.node.uid.
+// ---------------------------------------------------------------------------
+
+func TestControlPlaneNoNodeLabels(t *testing.T) {
+	for _, metricName := range metricNames(controlPlaneMetrics) {
+		t.Run(metricName+"/no_node_name", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available (control plane not scraped?)", metricName)
+			for _, r := range results {
+				_, hasNode := r.Labels.Resource["k8s.node.name"]
+				require.True(t, !hasNode,
+					"%s control plane metric should not have k8s.node.name but got: %s",
+					metricName, r.Labels.Resource["k8s.node.name"])
+			}
+		})
+		t.Run(metricName+"/no_node_uid", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available (control plane not scraped?)", metricName)
+			for _, r := range results {
+				_, hasUID := r.Labels.Resource["k8s.node.uid"]
+				require.True(t, !hasUID,
+					"%s control plane metric should not have k8s.node.uid but got: %s",
+					metricName, r.Labels.Resource["k8s.node.uid"])
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestControlPlaneMultipleInstances — confirm per-node scraping, not load balancer.
+// ---------------------------------------------------------------------------
+
+func TestControlPlaneMultipleInstances(t *testing.T) {
+	metricName := "apiserver_current_inflight_requests"
+	results, err := queryCache.Get(context.Background(), metricName)
+	require.NoError(t, err, "querying %s", metricName)
+	require.NotEmpty(t, results, "%s not available (apiserver not scraped?)", metricName)
+
+	instances := make(map[string]struct{})
+	for _, r := range results {
+		if v, ok := r.Labels.Resource["service.instance.id"]; ok && v != "" {
+			instances[v] = struct{}{}
+		}
+	}
+
+	keys := make([]string, 0, len(instances))
+	for k := range instances {
+		keys = append(keys, k)
+	}
+	t.Logf("found %d results from %d distinct API server instance(s): %v",
+		len(results), len(instances), keys)
+
+	require.True(t, len(instances) >= 2,
+		"expected metrics from >= 2 distinct API server instances, got %d: %v",
+		len(instances), keys)
+}

--- a/test/otel/standard/dedup_test.go
+++ b/test/otel/standard/dedup_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+// Deduplication tests validate that metrics are not duplicated by the batch
+// processor. A known bug causes the batch processor to split resource-identical
+// metrics when one batch has @schema_url set and the other doesn't, producing
+// duplicate series in CloudWatch.
+
+package standard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNodeExporterNoDuplicateSeries queries node_cpu_seconds_total for a single
+// (node, cpu, mode) combination and asserts exactly 1 series is returned.
+func TestNodeExporterNoDuplicateSeries(t *testing.T) {
+	ctx := context.Background()
+	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(cfg.ClusterName)
+
+	promql := fmt.Sprintf(
+		`node_cpu_seconds_total{"@resource.k8s.cluster.name"="%s","@resource.host.type"="%s"}`,
+		escaped, clusterHostTypes[0],
+	)
+	results, err := client.Query(ctx, promql)
+	require.NoError(t, err, "querying node_cpu_seconds_total")
+	require.NotEmpty(t, results, "node_cpu_seconds_total not available")
+
+	r := results[0]
+	pinNode := r.Labels.Resource["k8s.node.name"]
+	pinCPU := r.Labels.Datapoint["cpu"]
+	pinMode := r.Labels.Datapoint["mode"]
+	require.True(t, pinNode != "" && pinCPU != "" && pinMode != "",
+		"Could not find node_cpu_seconds_total result with node+cpu+mode")
+
+	promql = fmt.Sprintf(
+		`node_cpu_seconds_total{"@resource.k8s.cluster.name"="%s","@resource.k8s.node.name"="%s",cpu="%s",mode="%s"}`,
+		escaped, pinNode, pinCPU, pinMode,
+	)
+	pinned, err := client.Query(ctx, promql)
+	require.NoError(t, err, "querying pinned node_cpu_seconds_total")
+	require.NotEmpty(t, pinned, "pinned node_cpu_seconds_total returned 0 results")
+	require.Equal(t, 1, len(pinned),
+		"Expected exactly 1 series for node_cpu_seconds_total{node=%s,cpu=%s,mode=%s}, got %d — possible @schema_url duplication",
+		pinNode, pinCPU, pinMode, len(pinned))
+}
+
+// TestCadvisorNoDuplicateSeries queries container_memory_working_set_bytes for a
+// single (node, pod, container) combination and asserts exactly 1 series.
+func TestCadvisorNoDuplicateSeries(t *testing.T) {
+	ctx := context.Background()
+	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(cfg.ClusterName)
+
+	promql := fmt.Sprintf(
+		`container_memory_working_set_bytes{"@resource.k8s.cluster.name"="%s","@resource.k8s.pod.name"=~"nginx-test.*"}`,
+		escaped,
+	)
+	results, err := client.Query(ctx, promql)
+	require.NoError(t, err, "querying container_memory_working_set_bytes for nginx-test")
+	require.NotEmpty(t, results, "container_memory_working_set_bytes not available for nginx-test pods")
+
+	var pinNode, pinPod, pinContainer string
+	for _, r := range results {
+		node := r.Labels.Resource["k8s.node.name"]
+		pod := r.Labels.Resource["k8s.pod.name"]
+		cn := r.Labels.Resource["k8s.container.name"]
+		if node != "" && pod != "" && cn != "" {
+			pinNode = node
+			pinPod = pod
+			pinContainer = cn
+			break
+		}
+	}
+	require.True(t, pinPod != "", "Could not find container_memory_working_set_bytes result from nginx-test pod")
+
+	promql = fmt.Sprintf(
+		`container_memory_working_set_bytes{"@resource.k8s.cluster.name"="%s","@resource.k8s.node.name"="%s","@resource.k8s.pod.name"="%s","@resource.k8s.container.name"="%s"}`,
+		escaped, pinNode, pinPod, pinContainer,
+	)
+	pinned, err := client.Query(ctx, promql)
+	require.NoError(t, err, "querying pinned container_memory_working_set_bytes")
+	require.NotEmpty(t, pinned, "pinned container_memory_working_set_bytes returned 0 results")
+	require.Equal(t, 1, len(pinned),
+		"Expected exactly 1 series for container_memory_working_set_bytes{node=%s,pod=%s,container=%s}, got %d — possible @schema_url duplication",
+		pinNode, pinPod, pinContainer, len(pinned))
+}
+
+// TestNodeExporterNoSchemaUrlLabel validates that node_exporter metrics do NOT
+// have @resource.@schema_url as a label.
+func TestNodeExporterNoSchemaUrlLabel(t *testing.T) {
+	for _, metricName := range nodeExporterMetricNames {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				_, has := r.Labels.Resource["@schema_url"]
+				require.True(t, !has,
+					"%s has @resource.@schema_url which causes series duplication (node: %s)",
+					metricName, r.Labels.Resource["k8s.node.name"])
+			}
+		})
+	}
+}
+
+// TestKubeletstatsNoDuplicateSeries queries k8s.node.cpu.utilization for a single
+// node and asserts exactly 1 series is returned.
+func TestKubeletstatsNoDuplicateSeries(t *testing.T) {
+	ctx := context.Background()
+	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(cfg.ClusterName)
+
+	results, err := queryCache.Get(ctx, "k8s.node.cpu.utilization")
+	require.NoError(t, err, "querying k8s.node.cpu.utilization")
+	require.NotEmpty(t, results, "k8s.node.cpu.utilization not available")
+
+	r := results[0]
+	pinNode := r.Labels.Resource["k8s.node.name"]
+	require.True(t, pinNode != "", "Could not find k8s.node.cpu.utilization result with k8s.node.name")
+
+	promql := fmt.Sprintf(
+		`{"__name__"="k8s.node.cpu.utilization","@resource.k8s.cluster.name"="%s","@resource.k8s.node.name"="%s"}`,
+		escaped, pinNode,
+	)
+	pinned, err := client.Query(ctx, promql)
+	require.NoError(t, err, "querying pinned k8s.node.cpu.utilization")
+	require.NotEmpty(t, pinned, "pinned k8s.node.cpu.utilization returned 0 results")
+	require.Equal(t, 1, len(pinned),
+		"Expected exactly 1 series for k8s.node.cpu.utilization{node=%s}, got %d — possible @schema_url duplication",
+		pinNode, len(pinned))
+}

--- a/test/otel/standard/host_validation_test.go
+++ b/test/otel/standard/host_validation_test.go
@@ -1,0 +1,651 @@
+//go:build integration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+// Package standard — host attribute validation tests cross-check that
+// resourcedetection attributes (host.id, host.type, host.name, cloud.*)
+// are correct for the node each metric came from, not just present.
+// Covers DaemonSet metrics (local resourcedetection) and KSM node-scoped
+// metrics (nodemetadataenricher via Lease cache).
+package standard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// TestHostTypeMatchesNodeGroup — host.type must match the expected EC2
+// instance type for the node group.
+// ---------------------------------------------------------------------------
+
+func TestHostTypeMatchesNodeGroup(t *testing.T) {
+	// Build set of valid instance types from clusterNodeGroups.
+	validTypes := make(map[string]bool, len(clusterNodeGroups))
+	for _, ng := range clusterNodeGroups {
+		validTypes[ng.InstanceType] = true
+	}
+	for _, metricName := range hostEnrichedMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				hostType := r.Labels.Resource["host.type"]
+				if hostType == "" {
+					continue
+				}
+				require.True(t, validTypes[hostType],
+					"%s host.type=%q not in expected node groups %v (node: %s)",
+					metricName, hostType, validTypes,
+					r.Labels.Resource["k8s.node.name"])
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestHostNameMatchesNodeName — on EKS, host.name (EC2 private DNS) should
+// match k8s.node.name.
+// ---------------------------------------------------------------------------
+
+func TestHostNameMatchesNodeName(t *testing.T) {
+	for _, metricName := range hostEnrichedMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			matchCount := 0
+			for _, r := range results {
+				hostName := r.Labels.Resource["host.name"]
+				nodeName := r.Labels.Resource["k8s.node.name"]
+				if hostName == "" || nodeName == "" {
+					continue
+				}
+				matchCount++
+				require.Equal(t, nodeName, hostName,
+					"%s host.name should match k8s.node.name", metricName)
+			}
+			require.True(t, matchCount > 0,
+				"%s: no results had both host.name and k8s.node.name — enrichment may have failed entirely", metricName)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestUniqueHostIdPerNode — each distinct k8s.node.name must have a distinct
+// host.id.
+// ---------------------------------------------------------------------------
+
+func TestUniqueHostIdPerNode(t *testing.T) {
+	results, err := queryCache.Get(context.Background(), "node_cpu_seconds_total")
+	require.NoError(t, err, "querying node_cpu_seconds_total")
+	require.NotEmpty(t, results, "node_cpu_seconds_total not available")
+
+	nodeToHostID := make(map[string]string)
+	hostIDToNode := make(map[string]string)
+	for _, r := range results {
+		node := r.Labels.Resource["k8s.node.name"]
+		hostID := r.Labels.Resource["host.id"]
+		if node == "" || hostID == "" {
+			continue
+		}
+		if existing, seen := nodeToHostID[node]; seen {
+			require.Equal(t, existing, hostID,
+				fmt.Sprintf("node %s has inconsistent host.id", node))
+			continue
+		}
+		if otherNode, taken := hostIDToNode[hostID]; taken {
+			t.Fatalf("host.id %s is shared by nodes %s and %s — resourcedetection is returning the same instance ID for different nodes",
+				hostID, otherNode, node)
+		}
+		nodeToHostID[node] = hostID
+		hostIDToNode[hostID] = node
+	}
+	require.True(t, len(nodeToHostID) >= 2,
+		"Expected at least 2 distinct nodes, got %d", len(nodeToHostID))
+}
+
+// ---------------------------------------------------------------------------
+// TestCloudRegionMatchesConfig — cloud.region must match the configured region.
+// ---------------------------------------------------------------------------
+
+func TestCloudRegionMatchesConfig(t *testing.T) {
+	for _, metricName := range hostEnrichedMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				region := r.Labels.Resource["cloud.region"]
+				if region == "" {
+					continue
+				}
+				require.Equal(t, cfg.Region, region,
+					"%s cloud.region", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCloudAccountMatchesConfig — cloud.account.id must match the test account.
+// ---------------------------------------------------------------------------
+
+func TestCloudAccountMatchesConfig(t *testing.T) {
+	for _, metricName := range hostEnrichedMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				acct := r.Labels.Resource["cloud.account.id"]
+				if acct == "" {
+					continue
+				}
+				require.Equal(t, cfg.AccountID, acct,
+					"%s cloud.account.id", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCloudAvailabilityZonePresent — cloud.availability_zone must be present
+// and start with the region prefix.
+// ---------------------------------------------------------------------------
+
+func TestCloudAvailabilityZonePresent(t *testing.T) {
+	for _, metricName := range hostEnrichedMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				az := r.Labels.Resource["cloud.availability_zone"]
+				require.True(t, az != "", "%s missing cloud.availability_zone", metricName)
+				require.True(t, strings.HasPrefix(az, cfg.Region),
+					"%s cloud.availability_zone=%s should start with region %s",
+					metricName, az, cfg.Region)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCloudProviderIsAWS — cloud.provider must be "aws".
+// ---------------------------------------------------------------------------
+
+func TestCloudProviderIsAWS(t *testing.T) {
+	for _, metricName := range hostEnrichedMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				provider := r.Labels.Resource["cloud.provider"]
+				require.Equal(t, "aws", provider, "%s cloud.provider", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCloudPlatformIsEKS — cloud.platform must be "aws_eks".
+// ---------------------------------------------------------------------------
+
+func TestCloudPlatformIsEKS(t *testing.T) {
+	for _, metricName := range hostEnrichedMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				platform := r.Labels.Resource["cloud.platform"]
+				require.True(t, platform == "aws_eks" || platform == "aws_ec2",
+					"%s cloud.platform=%q, want aws_eks or aws_ec2", metricName, platform)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCloudResourceIdIsEKSArn — cloud.resource_id must be an EKS cluster ARN.
+// ---------------------------------------------------------------------------
+
+func TestCloudResourceIdIsEKSArn(t *testing.T) {
+	expectedPrefix := fmt.Sprintf("arn:aws:eks:%s:", cfg.Region)
+	expectedSuffix := fmt.Sprintf(":cluster/%s", cfg.ClusterName)
+	for _, metricName := range hostEnrichedMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				arn := r.Labels.Resource["cloud.resource_id"]
+				require.True(t, arn != "", "%s missing cloud.resource_id", metricName)
+				require.True(t, strings.HasPrefix(arn, expectedPrefix),
+					"%s cloud.resource_id=%s should start with %s", metricName, arn, expectedPrefix)
+				require.True(t, strings.HasSuffix(arn, expectedSuffix),
+					"%s cloud.resource_id=%s should end with %s", metricName, arn, expectedSuffix)
+			}
+		})
+	}
+}
+
+// ===========================================================================
+// K8s Ground Truth Validation Tests
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// TestPodScheduledOnCorrectNode — verify the pod is actually scheduled on
+// the node reported in the metric.
+// ---------------------------------------------------------------------------
+
+func TestPodScheduledOnCorrectNode(t *testing.T) {
+	gt := getGroundTruth(t)
+	for _, metricName := range podScopedMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				podName := r.Labels.Resource["k8s.pod.name"]
+				nodeName := r.Labels.Resource["k8s.node.name"]
+				if podName == "" || nodeName == "" {
+					continue
+				}
+				ns := r.Labels.Resource["k8s.namespace.name"]
+				pod, found := gt.lookupPod(podName, ns)
+				if !found {
+					continue
+				}
+				if pod.Spec.NodeName != nodeName {
+					t.Errorf("%s pod %s: metric says node=%s, K8s API says node=%s",
+						metricName, podName, nodeName, pod.Spec.NodeName)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestHostIdMatchesProviderID — verify host.id matches the EC2 instance ID
+// parsed from the node's spec.providerID.
+// ---------------------------------------------------------------------------
+
+func TestHostIdMatchesProviderID(t *testing.T) {
+	gt := getGroundTruth(t)
+	for _, metricName := range hostEnrichedMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				nodeName := r.Labels.Resource["k8s.node.name"]
+				hostID := r.Labels.Resource["host.id"]
+				if nodeName == "" || hostID == "" {
+					continue
+				}
+				node, found := gt.nodes[nodeName]
+				if !found {
+					continue
+				}
+				instanceID, err := parseInstanceIDFromProviderID(node.Spec.ProviderID)
+				if err != nil {
+					t.Errorf("%s node %s: unexpected provider ID format: %v",
+						metricName, nodeName, err)
+					continue
+				}
+				if instanceID != hostID {
+					t.Errorf("%s node %s: metric host.id=%s, provider ID instance=%s",
+						metricName, nodeName, hostID, instanceID)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestNodeUidMatchesKubernetesAPI — verify k8s.node.uid matches the K8s API.
+// ---------------------------------------------------------------------------
+
+func TestNodeUidMatchesKubernetesAPI(t *testing.T) {
+	gt := getGroundTruth(t)
+	for _, metricName := range hostEnrichedMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				nodeName := r.Labels.Resource["k8s.node.name"]
+				nodeUID := r.Labels.Resource["k8s.node.uid"]
+				if nodeName == "" || nodeUID == "" {
+					continue
+				}
+				node, found := gt.nodes[nodeName]
+				if !found {
+					continue
+				}
+				if string(node.UID) != nodeUID {
+					t.Errorf("%s node %s: metric k8s.node.uid=%s, K8s API uid=%s",
+						metricName, nodeName, nodeUID, string(node.UID))
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestContainerExistsInPodSpec — verify the container actually exists in the
+// pod spec.
+// ---------------------------------------------------------------------------
+
+func TestContainerExistsInPodSpec(t *testing.T) {
+	gt := getGroundTruth(t)
+	for _, metricName := range podScopedMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				podName := r.Labels.Resource["k8s.pod.name"]
+				containerName := r.Labels.Resource["k8s.container.name"]
+				if podName == "" || containerName == "" {
+					continue
+				}
+				ns := r.Labels.Resource["k8s.namespace.name"]
+				pod, found := gt.lookupPod(podName, ns)
+				if !found {
+					continue
+				}
+				exists := false
+				for _, c := range pod.Spec.Containers {
+					if c.Name == containerName {
+						exists = true
+						break
+					}
+				}
+				if !exists {
+					for _, c := range pod.Spec.InitContainers {
+						if c.Name == containerName {
+							exists = true
+							break
+						}
+					}
+				}
+				if !exists {
+					t.Errorf("%s pod %s: container %q not found in pod spec",
+						metricName, podName, containerName)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestPodNamespaceMatchesKubernetesAPI — verify the namespace matches the
+// K8s API.
+// ---------------------------------------------------------------------------
+
+func TestPodNamespaceMatchesKubernetesAPI(t *testing.T) {
+	gt := getGroundTruth(t)
+	for _, metricName := range daemonsetMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				podName := r.Labels.Resource["k8s.pod.name"]
+				ns := r.Labels.Resource["k8s.namespace.name"]
+				if podName == "" || ns == "" {
+					continue
+				}
+				pod, found := gt.lookupPod(podName, ns)
+				if !found {
+					continue
+				}
+				if pod.Namespace != ns {
+					t.Errorf("%s pod %s: metric namespace=%s, K8s API namespace=%s",
+						metricName, podName, ns, pod.Namespace)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestNodeLabelsMatchKubernetesAPI — verify k8s.node.label.* resource
+// attributes match the actual node labels from the K8s API.
+// ---------------------------------------------------------------------------
+
+func TestNodeLabelsMatchKubernetesAPI(t *testing.T) {
+	gt := getGroundTruth(t)
+	const labelPrefix = "k8s.node.label."
+	for _, metricName := range hostEnrichedMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				nodeName := r.Labels.Resource["k8s.node.name"]
+				if nodeName == "" {
+					continue
+				}
+				node, found := gt.nodes[nodeName]
+				if !found {
+					continue
+				}
+				for attrKey, attrVal := range r.Labels.Resource {
+					if !strings.HasPrefix(attrKey, labelPrefix) {
+						continue
+					}
+					labelKey := strings.TrimPrefix(attrKey, labelPrefix)
+					k8sVal, exists := node.Labels[labelKey]
+					if !exists {
+						t.Errorf("%s node %s: metric has label %s=%s but K8s node has no label %s",
+							metricName, nodeName, attrKey, attrVal, labelKey)
+						continue
+					}
+					if k8sVal != attrVal {
+						t.Errorf("%s node %s: label %s metric=%s, K8s API=%s",
+							metricName, nodeName, labelKey, attrVal, k8sVal)
+					}
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestDeploymentOwnerMatchesKubernetesAPI — verify the pod's owner chain
+// includes a ReplicaSet named <deployment>-<hash>.
+// ---------------------------------------------------------------------------
+
+func TestDeploymentOwnerMatchesKubernetesAPI(t *testing.T) {
+	gt := getGroundTruth(t)
+	for _, metricName := range daemonsetMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				podName := r.Labels.Resource["k8s.pod.name"]
+				deployName := r.Labels.Resource["k8s.deployment.name"]
+				if podName == "" || deployName == "" {
+					continue
+				}
+				ns := r.Labels.Resource["k8s.namespace.name"]
+				pod, found := gt.lookupPod(podName, ns)
+				if !found {
+					continue
+				}
+				if len(pod.OwnerReferences) == 0 {
+					continue
+				}
+				var rsName string
+				for _, ref := range pod.OwnerReferences {
+					if ref.Kind == "ReplicaSet" {
+						rsName = ref.Name
+						break
+					}
+				}
+				if rsName == "" {
+					continue
+				}
+				expectedPrefix := deployName + "-"
+				if !strings.HasPrefix(rsName, expectedPrefix) {
+					t.Errorf("%s pod %s: deployment=%s but ReplicaSet owner=%s (expected prefix %s)",
+						metricName, podName, deployName, rsName, expectedPrefix)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestStatefulSetOwnerMatchesKubernetesAPI — verify the pod's ownerReferences
+// include a StatefulSet with the expected name.
+// ---------------------------------------------------------------------------
+
+func TestStatefulSetOwnerMatchesKubernetesAPI(t *testing.T) {
+	gt := getGroundTruth(t)
+	for _, metricName := range daemonsetMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				podName := r.Labels.Resource["k8s.pod.name"]
+				stsName := r.Labels.Resource["k8s.statefulset.name"]
+				if podName == "" || stsName == "" {
+					continue
+				}
+				ns := r.Labels.Resource["k8s.namespace.name"]
+				pod, found := gt.lookupPod(podName, ns)
+				if !found {
+					continue
+				}
+				var ownerSts string
+				for _, ref := range pod.OwnerReferences {
+					if ref.Kind == "StatefulSet" {
+						ownerSts = ref.Name
+						break
+					}
+				}
+				require.True(t, ownerSts != "",
+					"%s pod %s: has k8s.statefulset.name=%s but no StatefulSet ownerReference",
+					metricName, podName, stsName)
+				require.Equal(t, stsName, ownerSts,
+					"%s pod %s: k8s.statefulset.name=%s but ownerReference=%s",
+					metricName, podName, stsName, ownerSts)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestDaemonSetOwnerMatchesKubernetesAPI — verify the pod's ownerReferences
+// include a DaemonSet with the expected name.
+// ---------------------------------------------------------------------------
+
+func TestDaemonSetOwnerMatchesKubernetesAPI(t *testing.T) {
+	gt := getGroundTruth(t)
+	for _, metricName := range daemonsetMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				podName := r.Labels.Resource["k8s.pod.name"]
+				dsName := r.Labels.Resource["k8s.daemonset.name"]
+				if podName == "" || dsName == "" {
+					continue
+				}
+				ns := r.Labels.Resource["k8s.namespace.name"]
+				pod, found := gt.lookupPod(podName, ns)
+				if !found {
+					continue
+				}
+				var ownerDS string
+				for _, ref := range pod.OwnerReferences {
+					if ref.Kind == "DaemonSet" {
+						ownerDS = ref.Name
+						break
+					}
+				}
+				require.True(t, ownerDS != "",
+					"%s pod %s: has k8s.daemonset.name=%s but no DaemonSet ownerReference",
+					metricName, podName, dsName)
+				require.Equal(t, dsName, ownerDS,
+					"%s pod %s: k8s.daemonset.name=%s but ownerReference=%s",
+					metricName, podName, dsName, ownerDS)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestJobOwnerMatchesKubernetesAPI — verify the pod's ownerReferences
+// include a Job with the expected name.
+// ---------------------------------------------------------------------------
+
+func TestJobOwnerMatchesKubernetesAPI(t *testing.T) {
+	gt := getGroundTruth(t)
+	for _, metricName := range daemonsetMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				podName := r.Labels.Resource["k8s.pod.name"]
+				jobName := r.Labels.Resource["k8s.job.name"]
+				if podName == "" || jobName == "" {
+					continue
+				}
+				ns := r.Labels.Resource["k8s.namespace.name"]
+				pod, found := gt.lookupPod(podName, ns)
+				if !found {
+					continue
+				}
+				var ownerJob string
+				for _, ref := range pod.OwnerReferences {
+					if ref.Kind == "Job" {
+						ownerJob = ref.Name
+						break
+					}
+				}
+				require.True(t, ownerJob != "",
+					"%s pod %s: has k8s.job.name=%s but no Job ownerReference",
+					metricName, podName, jobName)
+				require.Equal(t, jobName, ownerJob,
+					"%s pod %s: k8s.job.name=%s but ownerReference=%s",
+					metricName, podName, jobName, ownerJob)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestAllNodeGroupsPresent — every expected instance type must have at least
+// one node reporting metrics.
+// ---------------------------------------------------------------------------
+
+func TestAllNodeGroupsPresent(t *testing.T) {
+	for _, ng := range clusterNodeGroups {
+		t.Run(ng.Description+"/"+ng.InstanceType, func(t *testing.T) {
+			results, err := queryCache.GetWithFilter(context.Background(), "node_load1", map[string]string{
+				"@resource.host.type": ng.InstanceType,
+			})
+			require.NoError(t, err, "querying node_load1 on %s", ng.Description)
+			require.True(t, len(results) > 0,
+				"no metrics from %s nodes (%s) — node group may have been deleted",
+				ng.Description, ng.InstanceType)
+		})
+	}
+}

--- a/test/otel/standard/k8s_helpers_test.go
+++ b/test/otel/standard/k8s_helpers_test.go
@@ -1,0 +1,163 @@
+//go:build integration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package standard
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// k8sGroundTruth holds node and pod data fetched from the Kubernetes API.
+type k8sGroundTruth struct {
+	nodes map[string]corev1.Node // keyed by metadata.name
+	pods  map[string]corev1.Pod  // keyed by "namespace/name"
+}
+
+var (
+	groundTruth     *k8sGroundTruth
+	groundTruthOnce sync.Once
+	groundTruthErr  error
+)
+
+// getGroundTruth returns the shared ground truth, initializing it on first call.
+func getGroundTruth(t *testing.T) *k8sGroundTruth {
+	t.Helper()
+	groundTruthOnce.Do(func() {
+		groundTruth, groundTruthErr = buildGroundTruth()
+	})
+	if groundTruthErr != nil {
+		t.Fatalf("failed to build K8s ground truth: %v", groundTruthErr)
+	}
+	return groundTruth
+}
+
+func buildGroundTruth() (*k8sGroundTruth, error) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+	}
+
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("building kubeconfig: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("creating K8s clientset: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	nodeList, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing nodes: %w", err)
+	}
+	if len(nodeList.Items) == 0 {
+		return nil, fmt.Errorf("K8s API returned 0 nodes")
+	}
+
+	podList, err := clientset.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing pods: %w", err)
+	}
+
+	gt := &k8sGroundTruth{
+		nodes: make(map[string]corev1.Node, len(nodeList.Items)),
+		pods:  make(map[string]corev1.Pod, len(podList.Items)),
+	}
+	for _, n := range nodeList.Items {
+		gt.nodes[n.Name] = n
+	}
+	for _, p := range podList.Items {
+		gt.pods[p.Namespace+"/"+p.Name] = p
+	}
+	return gt, nil
+}
+
+// imageTagFromPod finds a pod by namespace+label and returns the image tag of its first container.
+func imageTagFromPod(t *testing.T, gt *k8sGroundTruth, namespace, labelKey, labelValue string) string {
+	t.Helper()
+	for _, p := range gt.pods {
+		if p.Namespace != namespace {
+			continue
+		}
+		if v, ok := p.Labels[labelKey]; ok && v == labelValue {
+			if len(p.Spec.Containers) > 0 {
+				image := p.Spec.Containers[0].Image
+				if idx := strings.LastIndex(image, ":"); idx != -1 {
+					return image[idx+1:]
+				}
+			}
+		}
+	}
+	t.Logf("WARNING: no pod found with %s=%s in %s", labelKey, labelValue, namespace)
+	return ""
+}
+
+// k8sServerVersion returns the Kubernetes API server version string.
+func k8sServerVersion(t *testing.T) string {
+	t.Helper()
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+	}
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("building kubeconfig: %v", err)
+	}
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		t.Fatalf("creating K8s clientset: %v", err)
+	}
+	sv, err := clientset.Discovery().ServerVersion()
+	if err != nil {
+		t.Fatalf("getting K8s server version: %v", err)
+	}
+	return sv.GitVersion
+}
+
+// lookupPod finds a pod by name and optional namespace. Uses the
+// namespace/name key for O(1) lookup. Otherwise falls back to linear scan.
+func (gt *k8sGroundTruth) lookupPod(podName, namespace string) (corev1.Pod, bool) {
+	if namespace != "" {
+		p, ok := gt.pods[namespace+"/"+podName]
+		return p, ok
+	}
+	for _, p := range gt.pods {
+		if p.Name == podName {
+			return p, true
+		}
+	}
+	return corev1.Pod{}, false
+}
+
+// parseInstanceIDFromProviderID extracts the EC2 instance ID from a
+// Kubernetes node's spec.providerID.
+// Format: "aws:///us-east-1a/i-0abc123def456" → "i-0abc123def456"
+func parseInstanceIDFromProviderID(providerID string) (string, error) {
+	parts := strings.Split(providerID, "/")
+	if len(parts) == 0 {
+		return "", fmt.Errorf("empty provider ID")
+	}
+	instanceID := parts[len(parts)-1]
+	if !strings.HasPrefix(instanceID, "i-") {
+		return "", fmt.Errorf("provider ID %q: last segment %q does not start with 'i-'", providerID, instanceID)
+	}
+	return instanceID, nil
+}

--- a/test/otel/standard/ksm_test.go
+++ b/test/otel/standard/ksm_test.go
@@ -1,0 +1,1248 @@
+//go:build integration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package standard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/util/otelmetrics"
+)
+
+// =============================================================================
+// KSM METRIC BUCKETS
+// =============================================================================
+
+var ksmNodeBucket = []string{
+	"kube_node_info",
+	"kube_node_status_condition",
+	"kube_node_status_allocatable",
+	"kube_node_status_capacity",
+}
+
+var ksmPodBucket = []string{
+	"kube_pod_status_phase",
+}
+
+var ksmContainerBucket = []string{
+	"kube_pod_container_status_running",
+}
+
+var ksmWorkloadBucket = struct {
+	Deployment  []string
+	DaemonSet   []string
+	StatefulSet []string
+	Job         []string
+	CronJob     []string
+}{
+	Deployment:  []string{"kube_deployment_status_replicas", "kube_deployment_status_replicas_ready"},
+	DaemonSet:   []string{"kube_daemonset_status_desired_number_scheduled"},
+	StatefulSet: []string{},
+	Job:         []string{},
+	CronJob:     []string{},
+}
+
+func ksmWorkloadMetrics() []string {
+	var all []string
+	all = append(all, ksmWorkloadBucket.Deployment...)
+	all = append(all, ksmWorkloadBucket.DaemonSet...)
+	all = append(all, ksmWorkloadBucket.StatefulSet...)
+	all = append(all, ksmWorkloadBucket.Job...)
+	all = append(all, ksmWorkloadBucket.CronJob...)
+	return all
+}
+
+var ksmClusterBucket = []string{
+	"kube_namespace_status_phase",
+}
+
+var ksmNodeScopedBucketMetrics = func() []string {
+	var all []string
+	all = append(all, ksmNodeBucket...)
+	all = append(all, ksmPodBucket...)
+	all = append(all, ksmContainerBucket...)
+	return all
+}()
+
+var ksmNonNodeMetrics = func() []string {
+	var all []string
+	all = append(all, ksmWorkloadMetrics()...)
+	all = append(all, ksmClusterBucket...)
+	return all
+}()
+
+func allKSMBucketMetrics() []string {
+	var all []string
+	all = append(all, ksmNodeBucket...)
+	all = append(all, ksmPodBucket...)
+	all = append(all, ksmContainerBucket...)
+	all = append(all, ksmWorkloadMetrics()...)
+	all = append(all, ksmClusterBucket...)
+	return all
+}
+
+// allKSMMetricDefs combines both KSM MetricDefinition slices for ExpectedLabels/Unit tests.
+var allKSMMetricDefs = func() []otelmetrics.MetricDefinition {
+	var all []otelmetrics.MetricDefinition
+	all = append(all, ksmNodeScopedMetrics...)
+	all = append(all, ksmClusterScopedMetrics...)
+	return all
+}()
+
+// parseAZFromProviderID extracts the AZ from a K8s node provider ID.
+// Format: "aws:///us-east-1a/i-0abc123def456" → "us-east-1a"
+func parseAZFromProviderID(providerID string) (string, error) {
+	parts := strings.Split(providerID, "/")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("provider ID %q: not enough segments", providerID)
+	}
+	az := parts[len(parts)-2]
+	if az == "" {
+		return "", fmt.Errorf("provider ID %q: AZ segment is empty", providerID)
+	}
+	return az, nil
+}
+
+// =============================================================================
+// COMMON TESTS (ALL BUCKETS)
+// =============================================================================
+
+func TestKSM_AllBuckets_MetricExists(t *testing.T) {
+	for _, metricName := range allKSMBucketMetrics() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+		})
+	}
+}
+
+func TestKSM_AllBuckets_InstrumentationSource(t *testing.T) {
+	for _, metricName := range allKSMBucketMetrics() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				name, ok := r.Labels.Instrumentation["@name"]
+				require.True(t, ok, "%s missing @instrumentation.@name", metricName)
+				require.Equal(t, "github.com/kubernetes/kube-state-metrics", name, "%s", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_AllBuckets_InstrumentationVersion(t *testing.T) {
+	for _, metricName := range allKSMBucketMetrics() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				version, ok := r.Labels.Instrumentation["@version"]
+				require.True(t, ok, "%s missing @instrumentation.@version", metricName)
+				require.True(t, version != "", "%s has empty @instrumentation.@version", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_AllBuckets_InstrumentationPipeline(t *testing.T) {
+	for _, metricName := range allKSMBucketMetrics() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				pipeline, ok := r.Labels.Instrumentation["cloudwatch.pipeline"]
+				require.True(t, ok, "%s missing @instrumentation.cloudwatch.pipeline", metricName)
+				require.Equal(t, "kube-state-metrics", pipeline, "%s cloudwatch.pipeline", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_AllBuckets_ClusterName(t *testing.T) {
+	for _, metricName := range allKSMBucketMetrics() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				require.Equal(t, cfg.ClusterName, r.Labels.Resource["k8s.cluster.name"], "%s", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_AllBuckets_NoComponentLabel(t *testing.T) {
+	for _, metricName := range allKSMBucketMetrics() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				_, has := r.Labels.Resource["k8s.component.name"]
+				require.True(t, !has, "%s should not have k8s.component.name", metricName)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// BUCKET 1: NODE METRICS
+// =============================================================================
+
+func TestKSM_NodeBucket_HasNodeName(t *testing.T) {
+	for _, metricName := range ksmNodeBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				val, ok := r.Labels.Resource["k8s.node.name"]
+				require.True(t, ok, "%s missing k8s.node.name", metricName)
+				require.True(t, val != "", "%s has empty k8s.node.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_NodeBucket_HasHostAttributes(t *testing.T) {
+	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
+	for _, metricName := range ksmNodeBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				for _, attr := range hostAttrs {
+					val, ok := r.Labels.Resource[attr]
+					require.True(t, ok, "%s missing %s", metricName, attr)
+					require.True(t, val != "", "%s has empty %s", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_NodeBucket_HostImageIDStartsWithAMI(t *testing.T) {
+	for _, metricName := range ksmNodeBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				imageID := r.Labels.Resource["host.image.id"]
+				require.True(t, strings.HasPrefix(imageID, "ami-"),
+					"%s host.image.id=%s should start with ami-", metricName, imageID)
+			}
+		})
+	}
+}
+
+func TestKSM_NodeBucket_AZMatchesProviderID(t *testing.T) {
+	gt := getGroundTruth(t)
+	for _, metricName := range ksmNodeBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				nodeName := r.Labels.Resource["k8s.node.name"]
+				az := r.Labels.Resource["cloud.availability_zone"]
+				if nodeName == "" || az == "" {
+					continue
+				}
+				node, found := gt.nodes[nodeName]
+				if !found {
+					continue
+				}
+				expectedAZ, err := parseAZFromProviderID(node.Spec.ProviderID)
+				if err != nil {
+					continue
+				}
+				require.Equal(t, expectedAZ, az, "%s node %s AZ mismatch", metricName, nodeName)
+			}
+		})
+	}
+}
+
+func TestKSM_NodeBucket_HasNodeLabels(t *testing.T) {
+	for _, metricName := range ksmNodeBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			hasNodeLabel := false
+			for _, r := range results {
+				for key := range r.Labels.Resource {
+					if strings.HasPrefix(key, "k8s.node.label.") {
+						hasNodeLabel = true
+						break
+					}
+				}
+				if hasNodeLabel {
+					break
+				}
+			}
+			require.True(t, hasNodeLabel, "%s should have k8s.node.label.* attributes", metricName)
+		})
+	}
+}
+
+func TestKSM_NodeBucket_NoPodAttributes(t *testing.T) {
+	for _, metricName := range ksmNodeBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				_, has := r.Labels.Resource["k8s.pod.name"]
+				require.True(t, !has, "%s should not have k8s.pod.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_NodeBucket_NoWorkloadIdentity(t *testing.T) {
+	for _, metricName := range ksmNodeBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				_, hasName := r.Labels.Resource["k8s.workload.name"]
+				require.True(t, !hasName, "%s should not have k8s.workload.name", metricName)
+				_, hasType := r.Labels.Resource["k8s.workload.type"]
+				require.True(t, !hasType, "%s should not have k8s.workload.type", metricName)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// BUCKET 2: POD METRICS
+// =============================================================================
+
+func TestKSM_PodBucket_HasPodIdentity(t *testing.T) {
+	requiredAttrs := []string{"k8s.pod.name", "k8s.namespace.name", "k8s.pod.uid"}
+	for _, metricName := range ksmPodBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				for _, attr := range requiredAttrs {
+					val, ok := r.Labels.Resource[attr]
+					require.True(t, ok, "%s missing %s", metricName, attr)
+					require.True(t, val != "", "%s has empty %s", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_PodBucket_HasNodeName(t *testing.T) {
+	for _, metricName := range ksmPodBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			hasNodeName := false
+			for _, r := range results {
+				if val, ok := r.Labels.Resource["k8s.node.name"]; ok && val != "" {
+					hasNodeName = true
+					break
+				}
+			}
+			require.True(t, hasNodeName, "%s should have k8s.node.name on at least some results", metricName)
+		})
+	}
+}
+
+func TestKSM_PodBucket_HasHostAttributes(t *testing.T) {
+	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
+	for _, metricName := range ksmPodBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			hasHost := false
+			for _, r := range results {
+				if _, ok := r.Labels.Resource["host.id"]; ok {
+					hasHost = true
+					for _, attr := range hostAttrs {
+						val := r.Labels.Resource[attr]
+						require.True(t, val != "", "%s has empty %s", metricName, attr)
+					}
+				}
+			}
+			require.True(t, hasHost, "%s should have host.* on at least some results", metricName)
+		})
+	}
+}
+
+func TestKSM_PodBucket_HasCloudAZ(t *testing.T) {
+	for _, metricName := range ksmPodBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			hasAZ := false
+			for _, r := range results {
+				if az, ok := r.Labels.Resource["cloud.availability_zone"]; ok && az != "" {
+					hasAZ = true
+					break
+				}
+			}
+			require.True(t, hasAZ, "%s should have cloud.availability_zone on at least some results", metricName)
+		})
+	}
+}
+
+func TestKSM_PodBucket_HasWorkloadIdentity(t *testing.T) {
+	for _, metricName := range ksmPodBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			workloadCount := 0
+			for _, r := range results {
+				if wn, ok := r.Labels.Resource["k8s.workload.name"]; ok && wn != "" {
+					workloadCount++
+					wt := r.Labels.Resource["k8s.workload.type"]
+					require.True(t, wt != "", "%s has k8s.workload.name but empty k8s.workload.type", metricName)
+				}
+			}
+			require.True(t, workloadCount > 0, "%s should have k8s.workload.* on at least some results", metricName)
+		})
+	}
+}
+
+func TestKSM_PodBucket_HasSpecificWorkloadTypeAttr(t *testing.T) {
+	workloadAttrs := []string{
+		"k8s.deployment.name", "k8s.statefulset.name", "k8s.daemonset.name",
+		"k8s.replicaset.name", "k8s.job.name", "k8s.cronjob.name",
+	}
+	for _, metricName := range ksmPodBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			hasSpecific := false
+			for _, r := range results {
+				for _, attr := range workloadAttrs {
+					if val, ok := r.Labels.Resource[attr]; ok && val != "" {
+						hasSpecific = true
+						break
+					}
+				}
+				if hasSpecific {
+					break
+				}
+			}
+			require.True(t, hasSpecific, "%s should have k8s.<workload>.name on at least some results", metricName)
+		})
+	}
+}
+
+func TestKSM_PodBucket_NginxDeploymentName(t *testing.T) {
+	for _, metricName := range ksmPodBucket {
+		t.Run(metricName, func(t *testing.T) {
+			ctx := context.Background()
+			promql := fmt.Sprintf(`%s{"@resource.k8s.cluster.name"="%s","@resource.k8s.pod.name"=~"nginx-test.*"}`,
+				metricName, cfg.ClusterName)
+			results, err := client.Query(ctx, promql)
+			require.NoError(t, err, "querying %s for nginx-test", metricName)
+			require.True(t, len(results) > 0, "No %s results from nginx-test pods", metricName)
+			for _, r := range results {
+				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.deployment.name"],
+					"%s nginx-test pod k8s.deployment.name", metricName)
+				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.workload.name"],
+					"%s nginx-test pod k8s.workload.name", metricName)
+				require.Equal(t, "Deployment", r.Labels.Resource["k8s.workload.type"],
+					"%s nginx-test pod k8s.workload.type", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_PodBucket_HasNodeLabels(t *testing.T) {
+	for _, metricName := range ksmPodBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			hasNodeLabel := false
+			for _, r := range results {
+				for key := range r.Labels.Resource {
+					if strings.HasPrefix(key, "k8s.node.label.") {
+						hasNodeLabel = true
+						break
+					}
+				}
+				if hasNodeLabel {
+					break
+				}
+			}
+			require.True(t, hasNodeLabel, "%s should have k8s.node.label.* on at least some results", metricName)
+		})
+	}
+}
+
+func TestKSM_PodBucket_HasPodLabels(t *testing.T) {
+	for _, metricName := range ksmPodBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			hasPodLabel := false
+			for _, r := range results {
+				for key := range r.Labels.Resource {
+					if strings.HasPrefix(key, "k8s.pod.label.") {
+						hasPodLabel = true
+						break
+					}
+				}
+				if hasPodLabel {
+					break
+				}
+			}
+			require.True(t, hasPodLabel, "%s should have k8s.pod.label.* on at least some results", metricName)
+		})
+	}
+}
+
+func TestKSM_PodBucket_HasRawGroupByLabels(t *testing.T) {
+	rawKeys := []string{"pod", "namespace", "uid"}
+	for _, metricName := range ksmPodBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				for _, key := range rawKeys {
+					val, has := r.Labels.Datapoint[key]
+					require.True(t, has, "%s missing raw '%s' label at datapoint scope", metricName, key)
+					require.True(t, val != "", "%s has empty raw '%s' label at datapoint scope", metricName, key)
+				}
+			}
+		})
+	}
+}
+
+// =============================================================================
+// BUCKET 3: CONTAINER METRICS
+// =============================================================================
+
+func TestKSM_ContainerBucket_HasRawGroupByLabels(t *testing.T) {
+	rawKeys := []string{"pod", "namespace", "uid", "container"}
+	for _, metricName := range ksmContainerBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				for _, key := range rawKeys {
+					val, has := r.Labels.Datapoint[key]
+					require.True(t, has, "%s missing raw '%s' label at datapoint scope", metricName, key)
+					require.True(t, val != "", "%s has empty raw '%s' label at datapoint scope", metricName, key)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_ContainerBucket_HasContainerName(t *testing.T) {
+	for _, metricName := range ksmContainerBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				val, ok := r.Labels.Resource["k8s.container.name"]
+				require.True(t, ok, "%s missing k8s.container.name", metricName)
+				require.True(t, val != "", "%s has empty k8s.container.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_ContainerBucket_HasPodIdentity(t *testing.T) {
+	requiredAttrs := []string{"k8s.pod.name", "k8s.namespace.name"}
+	for _, metricName := range ksmContainerBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				for _, attr := range requiredAttrs {
+					val, ok := r.Labels.Resource[attr]
+					require.True(t, ok, "%s missing %s", metricName, attr)
+					require.True(t, val != "", "%s has empty %s", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_ContainerBucket_HasHostAttributes(t *testing.T) {
+	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
+	for _, metricName := range ksmContainerBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			hasHost := false
+			for _, r := range results {
+				if _, ok := r.Labels.Resource["host.id"]; ok {
+					hasHost = true
+					for _, attr := range hostAttrs {
+						val := r.Labels.Resource[attr]
+						require.True(t, val != "", "%s has empty %s", metricName, attr)
+					}
+				}
+			}
+			require.True(t, hasHost, "%s should have host.* attributes", metricName)
+		})
+	}
+}
+
+func TestKSM_ContainerBucket_HasCloudAZ(t *testing.T) {
+	for _, metricName := range ksmContainerBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			hasAZ := false
+			for _, r := range results {
+				if az, ok := r.Labels.Resource["cloud.availability_zone"]; ok && az != "" {
+					hasAZ = true
+					break
+				}
+			}
+			require.True(t, hasAZ, "%s should have cloud.availability_zone on at least some results", metricName)
+		})
+	}
+}
+
+func TestKSM_ContainerBucket_HasNodeLabels(t *testing.T) {
+	for _, metricName := range ksmContainerBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			hasNodeLabel := false
+			for _, r := range results {
+				for key := range r.Labels.Resource {
+					if strings.HasPrefix(key, "k8s.node.label.") {
+						hasNodeLabel = true
+						break
+					}
+				}
+				if hasNodeLabel {
+					break
+				}
+			}
+			require.True(t, hasNodeLabel, "%s should have k8s.node.label.* on at least some results", metricName)
+		})
+	}
+}
+
+func TestKSM_ContainerBucket_HasRawContainerLabel(t *testing.T) {
+	for _, metricName := range ksmContainerBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				val, has := r.Labels.Datapoint["container"]
+				require.True(t, has, "%s missing raw 'container' label at datapoint scope", metricName)
+				require.True(t, val != "", "%s has empty raw 'container' label", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_ContainerBucket_HasNodeName(t *testing.T) {
+	for _, metricName := range ksmContainerBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			hasNodeName := false
+			for _, r := range results {
+				if val, ok := r.Labels.Resource["k8s.node.name"]; ok && val != "" {
+					hasNodeName = true
+					break
+				}
+			}
+			require.True(t, hasNodeName, "%s should have k8s.node.name on at least some results", metricName)
+		})
+	}
+}
+
+func TestKSM_ContainerBucket_HasPodLabels(t *testing.T) {
+	for _, metricName := range ksmContainerBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			hasPodLabel := false
+			for _, r := range results {
+				for key := range r.Labels.Resource {
+					if strings.HasPrefix(key, "k8s.pod.label.") {
+						hasPodLabel = true
+						break
+					}
+				}
+				if hasPodLabel {
+					break
+				}
+			}
+			require.True(t, hasPodLabel, "%s should have k8s.pod.label.* on at least some results", metricName)
+		})
+	}
+}
+
+func TestKSM_ContainerBucket_HasWorkloadIdentity(t *testing.T) {
+	for _, metricName := range ksmContainerBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			workloadCount := 0
+			for _, r := range results {
+				if wn, ok := r.Labels.Resource["k8s.workload.name"]; ok && wn != "" {
+					workloadCount++
+					wt := r.Labels.Resource["k8s.workload.type"]
+					require.True(t, wt != "", "%s has k8s.workload.name but empty k8s.workload.type", metricName)
+				}
+			}
+			require.True(t, workloadCount > 0, "%s should have k8s.workload.* on at least some results", metricName)
+		})
+	}
+}
+
+func TestKSM_ContainerBucket_HasSpecificWorkloadTypeAttr(t *testing.T) {
+	workloadAttrs := []string{
+		"k8s.deployment.name", "k8s.statefulset.name", "k8s.daemonset.name",
+		"k8s.replicaset.name", "k8s.job.name", "k8s.cronjob.name",
+	}
+	for _, metricName := range ksmContainerBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			hasSpecific := false
+			for _, r := range results {
+				for _, attr := range workloadAttrs {
+					if val, ok := r.Labels.Resource[attr]; ok && val != "" {
+						hasSpecific = true
+						break
+					}
+				}
+				if hasSpecific {
+					break
+				}
+			}
+			require.True(t, hasSpecific, "%s should have k8s.<workload>.name on at least some results", metricName)
+		})
+	}
+}
+
+func TestKSM_ContainerBucket_NginxDeploymentName(t *testing.T) {
+	for _, metricName := range ksmContainerBucket {
+		t.Run(metricName, func(t *testing.T) {
+			ctx := context.Background()
+			promql := fmt.Sprintf(`%s{"@resource.k8s.cluster.name"="%s","@resource.k8s.pod.name"=~"nginx-test.*"}`,
+				metricName, cfg.ClusterName)
+			results, err := client.Query(ctx, promql)
+			require.NoError(t, err, "querying %s for nginx-test", metricName)
+			require.True(t, len(results) > 0, "No %s results from nginx-test pods", metricName)
+			for _, r := range results {
+				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.deployment.name"],
+					"%s nginx-test container k8s.deployment.name", metricName)
+				require.Equal(t, "nginx", r.Labels.Resource["k8s.container.name"],
+					"%s nginx-test container k8s.container.name", metricName)
+				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.workload.name"],
+					"%s nginx-test container k8s.workload.name", metricName)
+				require.Equal(t, "Deployment", r.Labels.Resource["k8s.workload.type"],
+					"%s nginx-test container k8s.workload.type", metricName)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// BUCKET 4: WORKLOAD METRICS
+// =============================================================================
+
+// --- Deployment ---
+
+func TestKSM_WorkloadBucket_Deployment_HasDeploymentName(t *testing.T) {
+	for _, metricName := range ksmWorkloadBucket.Deployment {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				val, ok := r.Labels.Resource["k8s.deployment.name"]
+				require.True(t, ok, "%s missing k8s.deployment.name", metricName)
+				require.True(t, val != "", "%s has empty k8s.deployment.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Deployment_HasNamespace(t *testing.T) {
+	for _, metricName := range ksmWorkloadBucket.Deployment {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				val, ok := r.Labels.Resource["k8s.namespace.name"]
+				require.True(t, ok, "%s missing k8s.namespace.name", metricName)
+				require.True(t, val != "", "%s has empty k8s.namespace.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Deployment_HasWorkloadIdentity(t *testing.T) {
+	for _, metricName := range ksmWorkloadBucket.Deployment {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				wn := r.Labels.Resource["k8s.workload.name"]
+				wt := r.Labels.Resource["k8s.workload.type"]
+				require.True(t, wn != "", "%s missing k8s.workload.name", metricName)
+				require.Equal(t, "Deployment", wt, "%s k8s.workload.type", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Deployment_NoNodeName(t *testing.T) {
+	for _, metricName := range ksmWorkloadBucket.Deployment {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				_, has := r.Labels.Resource["k8s.node.name"]
+				require.True(t, !has, "%s should NOT have k8s.node.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Deployment_NoHostAttributes(t *testing.T) {
+	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
+	for _, metricName := range ksmWorkloadBucket.Deployment {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				for _, attr := range hostAttrs {
+					_, has := r.Labels.Resource[attr]
+					require.True(t, !has, "%s should NOT have %s", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Deployment_NoCrossContamination(t *testing.T) {
+	wrongAttrs := []string{"k8s.statefulset.name", "k8s.daemonset.name", "k8s.job.name", "k8s.cronjob.name"}
+	for _, metricName := range ksmWorkloadBucket.Deployment {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				for _, attr := range wrongAttrs {
+					_, has := r.Labels.Resource[attr]
+					require.True(t, !has, "%s should NOT have %s", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Deployment_HasRawDeploymentLabel(t *testing.T) {
+	for _, metricName := range ksmWorkloadBucket.Deployment {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				val, has := r.Labels.Datapoint["deployment"]
+				require.True(t, has, "%s missing raw 'deployment' label at datapoint scope", metricName)
+				require.True(t, val != "", "%s has empty raw 'deployment' label", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Deployment_NoNodeLabels(t *testing.T) {
+	for _, metricName := range ksmWorkloadBucket.Deployment {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				for key := range r.Labels.Resource {
+					if strings.HasPrefix(key, "k8s.node.label.") {
+						t.Fatalf("%s should NOT have node labels, found %s", metricName, key)
+					}
+				}
+			}
+		})
+	}
+}
+
+// --- DaemonSet ---
+
+func TestKSM_WorkloadBucket_DaemonSet_HasDaemonSetName(t *testing.T) {
+	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				val, ok := r.Labels.Resource["k8s.daemonset.name"]
+				require.True(t, ok, "%s missing k8s.daemonset.name", metricName)
+				require.True(t, val != "", "%s has empty k8s.daemonset.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_DaemonSet_HasNamespace(t *testing.T) {
+	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				val, ok := r.Labels.Resource["k8s.namespace.name"]
+				require.True(t, ok, "%s missing k8s.namespace.name", metricName)
+				require.True(t, val != "", "%s has empty k8s.namespace.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_DaemonSet_HasWorkloadIdentity(t *testing.T) {
+	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				wn := r.Labels.Resource["k8s.workload.name"]
+				wt := r.Labels.Resource["k8s.workload.type"]
+				require.True(t, wn != "", "%s missing k8s.workload.name", metricName)
+				require.Equal(t, "DaemonSet", wt, "%s k8s.workload.type", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_DaemonSet_NoNodeName(t *testing.T) {
+	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				_, has := r.Labels.Resource["k8s.node.name"]
+				require.True(t, !has, "%s should NOT have k8s.node.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_DaemonSet_NoCrossContamination(t *testing.T) {
+	wrongAttrs := []string{"k8s.deployment.name", "k8s.statefulset.name", "k8s.job.name", "k8s.cronjob.name"}
+	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				for _, attr := range wrongAttrs {
+					_, has := r.Labels.Resource[attr]
+					require.True(t, !has, "%s should NOT have %s", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_DaemonSet_NoHostAttributes(t *testing.T) {
+	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
+	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				for _, attr := range hostAttrs {
+					_, has := r.Labels.Resource[attr]
+					require.True(t, !has, "%s should NOT have %s (workloads span multiple nodes)", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_DaemonSet_HasRawDaemonSetLabel(t *testing.T) {
+	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				val, has := r.Labels.Datapoint["daemonset"]
+				require.True(t, has, "%s missing raw 'daemonset' label at datapoint scope", metricName)
+				require.True(t, val != "", "%s has empty raw 'daemonset' label", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_DaemonSet_NoNodeLabels(t *testing.T) {
+	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				for key := range r.Labels.Resource {
+					if strings.HasPrefix(key, "k8s.node.label.") {
+						t.Fatalf("%s should NOT have node labels, found %s", metricName, key)
+					}
+				}
+			}
+		})
+	}
+}
+
+// =============================================================================
+// BUCKET 5: CLUSTER-SCOPED METRICS
+// =============================================================================
+
+func TestKSM_ClusterBucket_HasNamespace(t *testing.T) {
+	for _, metricName := range ksmClusterBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				val, ok := r.Labels.Resource["k8s.namespace.name"]
+				require.True(t, ok, "%s missing k8s.namespace.name", metricName)
+				require.True(t, val != "", "%s has empty k8s.namespace.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_ClusterBucket_NoNodeName(t *testing.T) {
+	for _, metricName := range ksmClusterBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				_, has := r.Labels.Resource["k8s.node.name"]
+				require.True(t, !has, "%s should NOT have k8s.node.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_ClusterBucket_NoHostAttributes(t *testing.T) {
+	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
+	for _, metricName := range ksmClusterBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				for _, attr := range hostAttrs {
+					_, has := r.Labels.Resource[attr]
+					require.True(t, !has, "%s should NOT have %s", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_ClusterBucket_NoWorkloadIdentity(t *testing.T) {
+	for _, metricName := range ksmClusterBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				_, has := r.Labels.Resource["k8s.workload.name"]
+				require.True(t, !has, "%s should NOT have k8s.workload.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_ClusterBucket_NoNodeLabels(t *testing.T) {
+	for _, metricName := range ksmClusterBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				for key := range r.Labels.Resource {
+					if strings.HasPrefix(key, "k8s.node.label.") {
+						t.Fatalf("%s should NOT have node labels, found %s", metricName, key)
+					}
+				}
+			}
+		})
+	}
+}
+
+// =============================================================================
+// LEASE VALIDATION
+// =============================================================================
+
+func TestKSM_LeaseExistence(t *testing.T) {
+	gt := getGroundTruth(t)
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, nil)
+	restConfig, err := kubeConfig.ClientConfig()
+	if err != nil {
+		restConfig, err = rest.InClusterConfig()
+		require.NoError(t, err, "no kubeconfig or in-cluster config")
+	}
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	require.NoError(t, err, "creating K8s clientset")
+
+	ctx := context.Background()
+	leases, err := clientset.CoordinationV1().Leases("amazon-cloudwatch").List(ctx, metav1.ListOptions{})
+	require.NoError(t, err, "listing Leases")
+
+	leaseByNode := make(map[string]bool)
+	for _, lease := range leases.Items {
+		if strings.HasPrefix(lease.Name, "cwagent-node-metadata-") {
+			nodeName := strings.TrimPrefix(lease.Name, "cwagent-node-metadata-")
+			leaseByNode[nodeName] = true
+
+			annotations := lease.Annotations
+			for _, key := range []string{
+				"cwagent.amazonaws.com/host.id",
+				"cwagent.amazonaws.com/host.name",
+				"cwagent.amazonaws.com/host.type",
+				"cwagent.amazonaws.com/host.image.id",
+				"cwagent.amazonaws.com/cloud.availability_zone",
+			} {
+				val, ok := annotations[key]
+				require.True(t, ok, "Lease %s missing %s", lease.Name, key)
+				require.True(t, val != "", "Lease %s has empty %s", lease.Name, key)
+			}
+
+			require.True(t, lease.Spec.LeaseDurationSeconds != nil, "Lease %s missing leaseDurationSeconds", lease.Name)
+			require.Equal(t, int32(7200), *lease.Spec.LeaseDurationSeconds, "Lease %s leaseDurationSeconds", lease.Name)
+		}
+	}
+
+	for nodeName := range gt.nodes {
+		require.True(t, leaseByNode[nodeName], "node %s has no cwagent-node-metadata Lease", nodeName)
+	}
+}
+
+// =============================================================================
+// ADDITIONAL COMMON TESTS
+// =============================================================================
+
+func TestKSM_AllBuckets_ExpectedLabels(t *testing.T) {
+	for _, md := range allKSMMetricDefs {
+		if len(md.ExpectedLabels) == 0 {
+			continue
+		}
+		for _, label := range md.ExpectedLabels {
+			t.Run(md.Name+"/"+label, func(t *testing.T) {
+				results, err := queryCache.Get(context.Background(), md.Name)
+				require.NoError(t, err, "querying %s", md.Name)
+				require.NotEmpty(t, results, "%s not found", md.Name)
+				for _, r := range results {
+					_, ok := r.Labels.Datapoint[label]
+					require.True(t, ok, "%s missing expected label '%s'", md.Name, label)
+				}
+			})
+		}
+	}
+}
+
+func TestKSM_AllBuckets_UnitValidation(t *testing.T) {
+	for _, md := range allKSMMetricDefs {
+		if md.Unit == "" {
+			continue
+		}
+		t.Run(md.Name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), md.Name)
+			require.NoError(t, err, "querying %s", md.Name)
+			require.NotEmpty(t, results, "%s not found", md.Name)
+			for _, r := range results {
+				unit, ok := r.Labels.Datapoint["__unit__"]
+				require.True(t, ok, "%s missing __unit__", md.Name)
+				require.Equal(t, md.Unit, unit, "%s unit", md.Name)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_HasRawNamespaceLabel(t *testing.T) {
+	for _, metricName := range ksmWorkloadMetrics() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				val, has := r.Labels.Datapoint["namespace"]
+				require.True(t, has, "%s missing raw 'namespace' label at datapoint scope", metricName)
+				require.True(t, val != "", "%s has empty raw 'namespace' label", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_ClusterBucket_HasRawNamespaceLabel(t *testing.T) {
+	for _, metricName := range ksmClusterBucket {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				val, has := r.Labels.Datapoint["namespace"]
+				require.True(t, has, "%s missing raw 'namespace' label at datapoint scope", metricName)
+				require.True(t, val != "", "%s has empty raw 'namespace' label", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_AllBuckets_NoPodTemplateHash(t *testing.T) {
+	for _, metricName := range allKSMBucketMetrics() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				_, has := r.Labels.Resource["k8s.pod.label.pod-template-hash"]
+				require.True(t, !has, "%s should not have k8s.pod.label.pod-template-hash (removed by awsattributelimit)", metricName)
+			}
+		})
+	}
+}

--- a/test/otel/standard/kubeletstats_test.go
+++ b/test/otel/standard/kubeletstats_test.go
@@ -1,0 +1,257 @@
+//go:build integration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package standard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/util/otelmetrics"
+)
+
+const scopeKubeletstats = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
+
+var kubeletstatsMetricNamesList = metricNames(kubeletstatsMetrics)
+
+func TestKubeletstatsMetricExistence(t *testing.T) {
+	for _, metricName := range kubeletstatsMetricNamesList {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+		})
+	}
+}
+
+func TestKubeletstatsInstrumentationSource(t *testing.T) {
+	for _, metricName := range kubeletstatsMetricNamesList {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				name, ok := r.Labels.Instrumentation["@name"]
+				require.True(t, ok, "%s missing @instrumentation.@name", metricName)
+				require.Equal(t, scopeKubeletstats, name,
+					"%s instrumentation name", metricName)
+			}
+		})
+	}
+}
+
+func TestKubeletstatsClusterIdentity(t *testing.T) {
+	for _, metricName := range kubeletstatsMetricNamesList {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				require.Equal(t, cfg.ClusterName, r.Labels.Resource["k8s.cluster.name"],
+					"%s cluster name", metricName)
+			}
+		})
+	}
+}
+
+func TestKubeletstatsNodeName(t *testing.T) {
+	for _, metricName := range kubeletstatsMetricNamesList {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				node, ok := r.Labels.Resource["k8s.node.name"]
+				require.True(t, ok, "%s missing @resource.k8s.node.name", metricName)
+				require.True(t, node != "", "%s has empty @resource.k8s.node.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKubeletstatsPodName(t *testing.T) {
+	var podAndContainerMetrics []string
+	podAndContainerMetrics = append(podAndContainerMetrics, metricNames(kubeletstatsPodMetrics)...)
+	podAndContainerMetrics = append(podAndContainerMetrics, metricNames(kubeletstatsContainerMetrics)...)
+	for _, metricName := range podAndContainerMetrics {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				pod, ok := r.Labels.Resource["k8s.pod.name"]
+				require.True(t, ok, "%s missing @resource.k8s.pod.name", metricName)
+				require.True(t, pod != "", "%s has empty @resource.k8s.pod.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKubeletstatsNamespace(t *testing.T) {
+	var podAndContainerMetrics []string
+	podAndContainerMetrics = append(podAndContainerMetrics, metricNames(kubeletstatsPodMetrics)...)
+	podAndContainerMetrics = append(podAndContainerMetrics, metricNames(kubeletstatsContainerMetrics)...)
+	for _, metricName := range podAndContainerMetrics {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				ns, ok := r.Labels.Resource["k8s.namespace.name"]
+				require.True(t, ok, "%s missing @resource.k8s.namespace.name", metricName)
+				require.True(t, ns != "", "%s has empty @resource.k8s.namespace.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKubeletstatsContainerName(t *testing.T) {
+	for _, md := range kubeletstatsContainerMetrics {
+		t.Run(md.Name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), md.Name)
+			require.NoError(t, err, "querying %s", md.Name)
+			require.NotEmpty(t, results, "%s not available", md.Name)
+			hasContainer := 0
+			for _, r := range results {
+				if cn, ok := r.Labels.Resource["k8s.container.name"]; ok {
+					require.True(t, cn != "", "%s has empty k8s.container.name", md.Name)
+					hasContainer++
+				}
+			}
+			require.True(t, hasContainer > 0,
+				"%s has no results with k8s.container.name", md.Name)
+		})
+	}
+}
+
+func TestKubeletstatsCloudDetection(t *testing.T) {
+	for _, metricName := range kubeletstatsMetricNamesList {
+		t.Run(metricName+"/provider", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				require.Equal(t, "aws", r.Labels.Resource["cloud.provider"],
+					"%s cloud.provider", metricName)
+			}
+		})
+		t.Run(metricName+"/region", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				region, ok := r.Labels.Resource["cloud.region"]
+				require.True(t, ok, "%s missing @resource.cloud.region", metricName)
+				require.True(t, region != "", "%s has empty cloud.region", metricName)
+			}
+		})
+		t.Run(metricName+"/account_id", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				acctID, ok := r.Labels.Resource["cloud.account.id"]
+				require.True(t, ok, "%s missing @resource.cloud.account.id", metricName)
+				require.Equal(t, 12, len(acctID), "%s cloud.account.id length", metricName)
+			}
+		})
+	}
+}
+
+func TestKubeletstatsHostDetection(t *testing.T) {
+	for _, metricName := range kubeletstatsMetricNamesList {
+		t.Run(metricName+"/host_id", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				hostID, ok := r.Labels.Resource["host.id"]
+				require.True(t, ok, "%s missing @resource.host.id", metricName)
+				require.True(t, strings.HasPrefix(hostID, "i-"),
+					"%s host.id should start with 'i-', got %q", metricName, hostID)
+			}
+		})
+		t.Run(metricName+"/host_name", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				hostName, ok := r.Labels.Resource["host.name"]
+				require.True(t, ok, "%s missing @resource.host.name", metricName)
+				require.True(t, hostName != "", "%s has empty host.name", metricName)
+			}
+		})
+		t.Run(metricName+"/host_type", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				hostType, ok := r.Labels.Resource["host.type"]
+				require.True(t, ok, "%s missing @resource.host.type", metricName)
+				require.True(t, hostType != "", "%s has empty host.type", metricName)
+			}
+		})
+	}
+}
+
+func TestKubeletstatsExpectedLabels(t *testing.T) {
+	for _, md := range kubeletstatsMetrics {
+		if len(md.ExpectedLabels) == 0 {
+			continue
+		}
+		t.Run(md.Name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), md.Name)
+			require.NoError(t, err, "querying %s", md.Name)
+			require.NotEmpty(t, results, "%s not available", md.Name)
+			for _, r := range results {
+				for _, label := range md.ExpectedLabels {
+					_, ok := r.Labels.Datapoint[label]
+					require.True(t, ok, "%s missing expected label '%s' (node: %s, host.type: %s, pod: %s)",
+						md.Name, label,
+						r.Labels.Resource["k8s.node.name"],
+						r.Labels.Resource["host.type"],
+						r.Labels.Resource["k8s.pod.name"])
+				}
+			}
+		})
+	}
+}
+
+func TestKubeletstatsUnitValidation(t *testing.T) {
+	for _, md := range kubeletstatsMetrics {
+		if md.Unit == "" {
+			continue
+		}
+		t.Run(md.Name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), md.Name)
+			require.NoError(t, err, "querying %s", md.Name)
+			require.NotEmpty(t, results, "%s not available", md.Name)
+			for _, r := range results {
+				unit, ok := r.Labels.Datapoint["__unit__"]
+				require.True(t, ok, "%s missing __unit__ label", md.Name)
+				require.Equal(t, md.Unit, unit, "%s unit", md.Name)
+			}
+		})
+	}
+}
+
+func TestKubeletstatsNodeGroupCoverage(t *testing.T) {
+	for _, ng := range clusterNodeGroups {
+		t.Run(ng.Description+"/"+ng.InstanceType, func(t *testing.T) {
+			promql := fmt.Sprintf(
+				`{"__name__"="k8s.node.cpu.utilization","@resource.k8s.cluster.name"="%s","@resource.host.type"="%s"}`,
+				otelmetrics.EscapePromQLValue(cfg.ClusterName), ng.InstanceType)
+			results, err := client.Query(context.Background(), promql)
+			require.NoError(t, err, "querying k8s.node.cpu.utilization on %s", ng.Description)
+			require.True(t, len(results) > 0,
+				"kubeletstats missing from %s nodes (%s) — kubeletstatsreceiver not scraping?",
+				ng.Description, ng.InstanceType)
+		})
+	}
+}

--- a/test/otel/standard/labels_common_test.go
+++ b/test/otel/standard/labels_common_test.go
@@ -1,0 +1,674 @@
+//go:build integration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+// Package standard contains cross-source label decoration tests for the standard cluster.
+package standard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// TestClusterIdentity — every metric must identify the cluster.
+// ---------------------------------------------------------------------------
+
+func TestClusterIdentity(t *testing.T) {
+	for _, metricName := range allMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.True(t, len(results) > 0,
+				"%s returned 0 results when filtering by @resource.k8s.cluster.name=%s",
+				metricName, cfg.ClusterName)
+			for _, r := range results {
+				require.Equal(t, cfg.ClusterName, r.Labels.Resource["k8s.cluster.name"],
+					"%s cluster name", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestAWSLabels — every metric must have @aws.account and @aws.region.
+// ---------------------------------------------------------------------------
+
+func TestAWSLabels(t *testing.T) {
+	for _, metricName := range allMetricNames() {
+		t.Run(metricName+"/account", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				acct, ok := r.Labels.AWS["account"]
+				require.True(t, ok, "%s missing @aws.account", metricName)
+				require.Equal(t, 12, len(acct), "%s @aws.account length", metricName)
+			}
+		})
+		t.Run(metricName+"/region", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				region, ok := r.Labels.AWS["region"]
+				require.True(t, ok, "%s missing @aws.region", metricName)
+				require.True(t, region != "", "%s has empty @aws.region", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestInstrumentationLabels — every metric must have instrumentation scope.
+// ---------------------------------------------------------------------------
+
+func TestInstrumentationLabels(t *testing.T) {
+	for _, metricName := range allMetricNames() {
+		t.Run(metricName+"/name", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				name, ok := r.Labels.Instrumentation["@name"]
+				require.True(t, ok, "%s missing @instrumentation.@name", metricName)
+				require.True(t, name != "", "%s has empty @instrumentation.@name", metricName)
+			}
+		})
+		t.Run(metricName+"/version", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				_, ok := r.Labels.Instrumentation["@version"]
+				require.True(t, ok, "%s missing @instrumentation.@version", metricName)
+			}
+		})
+		t.Run(metricName+"/cloudwatch_source", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				src, ok := r.Labels.Instrumentation["cloudwatch.source"]
+				require.True(t, ok, "%s missing @instrumentation.cloudwatch.source", metricName)
+				require.Equal(t, "cloudwatch-agent", src, "%s @instrumentation.cloudwatch.source", metricName)
+			}
+		})
+		t.Run(metricName+"/cloudwatch_solution", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				sol, ok := r.Labels.Instrumentation["cloudwatch.solution"]
+				require.True(t, ok, "%s missing @instrumentation.cloudwatch.solution", metricName)
+				require.Equal(t, "k8s-otel-container-insights", sol, "%s @instrumentation.cloudwatch.solution", metricName)
+			}
+		})
+		t.Run(metricName+"/cloudwatch_pipeline", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				_, ok := r.Labels.Instrumentation["cloudwatch.pipeline"]
+				require.True(t, ok, "%s missing @instrumentation.cloudwatch.pipeline", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestScopeNameAndVersionPerSource — standard cluster sources only.
+// ---------------------------------------------------------------------------
+
+func TestScopeNameAndVersionPerSource(t *testing.T) {
+	gt := getGroundTruth(t)
+
+	agentVersion := imageTagFromPod(t, gt, "amazon-cloudwatch", "app.kubernetes.io/name", "cloudwatch-agent")
+	if agentVersion == "latest" || agentVersion == "" || len(agentVersion) >= 32 {
+		results, err := queryCache.Get(context.Background(), "container_cpu_usage_seconds_total")
+		if err == nil && len(results) > 0 {
+			agentVersion = results[0].Labels.Instrumentation["@version"]
+		}
+	}
+	nodeExporterVersion := imageTagFromPod(t, gt, "amazon-cloudwatch", "k8s-app", "node-exporter")
+	ksmVersion := imageTagFromPod(t, gt, "amazon-cloudwatch", "app.kubernetes.io/component", "kube-state-metrics")
+	controlPlaneVersion := k8sServerVersion(t)
+
+	t.Logf("agent=%s node_exporter=%s ksm=%s k8s=%s",
+		agentVersion, nodeExporterVersion, ksmVersion, controlPlaneVersion)
+
+	tests := []struct {
+		source, metric, wantName, wantVersion, wantPipeline string
+	}{
+		{"node_exporter", "node_cpu_seconds_total", "github.com/prometheus/node_exporter", nodeExporterVersion, "node-exporter"},
+		{"cadvisor", "container_cpu_usage_seconds_total", "github.com/google/cadvisor", agentVersion, "cadvisor"},
+		{"kubeletstats", "k8s.node.cpu.utilization", scopeKubeletstats, agentVersion, "kubeletstats"},
+		{"control_plane", "apiserver_request_total", scopePrometheus, controlPlaneVersion, "apiserver"},
+		{"kube_state_metrics", "kube_deployment_status_replicas_ready", "github.com/kubernetes/kube-state-metrics", ksmVersion, "kube-state-metrics"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.source+"/name", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), tc.metric)
+			require.NoError(t, err, "querying %s", tc.metric)
+			require.NotEmpty(t, results, "%s not available", tc.metric)
+			require.Equal(t, tc.wantName, results[0].Labels.Instrumentation["@name"], "%s scope name", tc.source)
+		})
+		t.Run(tc.source+"/version", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), tc.metric)
+			require.NoError(t, err, "querying %s", tc.metric)
+			require.NotEmpty(t, results, "%s not available", tc.metric)
+			require.Equal(t, tc.wantVersion, results[0].Labels.Instrumentation["@version"], "%s scope version", tc.source)
+		})
+		t.Run(tc.source+"/pipeline", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), tc.metric)
+			require.NoError(t, err, "querying %s", tc.metric)
+			require.NotEmpty(t, results, "%s not available", tc.metric)
+			pipeline, ok := results[0].Labels.Instrumentation["cloudwatch.pipeline"]
+			require.True(t, ok, "%s missing @instrumentation.cloudwatch.pipeline", tc.source)
+			require.Equal(t, tc.wantPipeline, pipeline, "%s cloudwatch.pipeline", tc.source)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCloudResourceDetection — cloud.* resource attributes from resourcedetection.
+// ---------------------------------------------------------------------------
+
+func TestCloudResourceDetection(t *testing.T) {
+	for _, metricName := range hostEnrichedMetricNames() {
+		t.Run(metricName+"/provider", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				require.Equal(t, "aws", r.Labels.Resource["cloud.provider"], "%s cloud.provider", metricName)
+			}
+		})
+		t.Run(metricName+"/platform", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				platform := r.Labels.Resource["cloud.platform"]
+				require.True(t, platform == "aws_eks" || platform == "aws_ec2",
+					"%s cloud.platform=%q, want aws_eks or aws_ec2", metricName, platform)
+			}
+		})
+		t.Run(metricName+"/region", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				region, ok := r.Labels.Resource["cloud.region"]
+				require.True(t, ok, "%s missing @resource.cloud.region", metricName)
+				require.True(t, region != "", "%s has empty @resource.cloud.region", metricName)
+			}
+		})
+		t.Run(metricName+"/availability_zone", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				az, ok := r.Labels.Resource["cloud.availability_zone"]
+				require.True(t, ok, "%s missing @resource.cloud.availability_zone", metricName)
+				require.True(t, az != "", "%s has empty @resource.cloud.availability_zone", metricName)
+			}
+		})
+		t.Run(metricName+"/account_id", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				acctID, ok := r.Labels.Resource["cloud.account.id"]
+				require.True(t, ok, "%s missing @resource.cloud.account.id", metricName)
+				require.Equal(t, 12, len(acctID), "%s cloud.account.id length", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestHostResourceDetection — host.* resource attributes from resourcedetection.
+// ---------------------------------------------------------------------------
+
+func TestHostResourceDetection(t *testing.T) {
+	for _, metricName := range hostEnrichedMetricNames() {
+		t.Run(metricName+"/host_id", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				hostID, ok := r.Labels.Resource["host.id"]
+				require.True(t, ok, "%s missing @resource.host.id", metricName)
+				require.True(t, strings.HasPrefix(hostID, "i-"),
+					"%s host.id should start with 'i-', got '%s'", metricName, hostID)
+			}
+		})
+		t.Run(metricName+"/host_type", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				hostType, ok := r.Labels.Resource["host.type"]
+				require.True(t, ok, "%s missing @resource.host.type", metricName)
+				require.True(t, hostType != "", "%s has empty @resource.host.type", metricName)
+			}
+		})
+		t.Run(metricName+"/host_name", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				hostName, ok := r.Labels.Resource["host.name"]
+				require.True(t, ok, "%s missing @resource.host.name", metricName)
+				require.True(t, hostName != "", "%s has empty @resource.host.name", metricName)
+			}
+		})
+		t.Run(metricName+"/host_image_id", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				imageID, ok := r.Labels.Resource["host.image.id"]
+				require.True(t, ok, "%s missing @resource.host.image.id", metricName)
+				require.True(t, strings.HasPrefix(imageID, "ami-"),
+					"%s host.image.id should start with 'ami-', got '%s'", metricName, imageID)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestNodeMetricLabels — k8s.node.name on DaemonSet metrics, k8s.node.uid on enriched.
+// ---------------------------------------------------------------------------
+
+func TestNodeMetricLabels(t *testing.T) {
+	for _, metricName := range daemonsetMetricNames() {
+		t.Run(metricName+"/node_name", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				nodeName, ok := r.Labels.Resource["k8s.node.name"]
+				require.True(t, ok, "%s missing @resource.k8s.node.name (host: %s)",
+					metricName, r.Labels.Resource["host.name"])
+				require.True(t, nodeName != "", "%s has empty @resource.k8s.node.name", metricName)
+			}
+		})
+	}
+
+	for _, metricName := range nodeLabelEnrichedNames() {
+		t.Run(metricName+"/node_uid", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				uid, ok := r.Labels.Resource["k8s.node.uid"]
+				require.True(t, ok, "%s missing @resource.k8s.node.uid (node: %s)",
+					metricName, r.Labels.Resource["k8s.node.name"])
+				require.True(t, uid != "", "%s has empty @resource.k8s.node.uid", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestPodMetricLabels — cadvisor strict pod labels.
+// Standard cluster has no device metrics, so only cadvisor section applies.
+// ---------------------------------------------------------------------------
+
+func TestPodMetricLabels(t *testing.T) {
+	for _, metricName := range podScopedCadvisorNames() {
+		t.Run(metricName+"/cadvisor_strict", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				_, hasPod := r.Labels.Resource["k8s.pod.name"]
+				require.True(t, hasPod, "%s missing @resource.k8s.pod.name", metricName)
+				_, hasNS := r.Labels.Resource["k8s.namespace.name"]
+				require.True(t, hasNS, "%s missing @resource.k8s.namespace.name", metricName)
+				_, hasNode := r.Labels.Resource["k8s.node.name"]
+				require.True(t, hasNode, "%s missing @resource.k8s.node.name", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestContainerMetricLabels — container-scoped metrics must have container name.
+// ---------------------------------------------------------------------------
+
+func TestContainerMetricLabels(t *testing.T) {
+	names := containerMetricNames()
+	require.True(t, len(names) > 0, "No container-scoped metrics defined in test suite")
+	for _, metricName := range names {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			hasContainer := 0
+			for _, r := range results {
+				if cn, ok := r.Labels.Resource["k8s.container.name"]; ok {
+					require.True(t, cn != "", "%s has empty k8s.container.name", metricName)
+					hasContainer++
+				} else {
+					_, hasPod := r.Labels.Resource["k8s.pod.name"]
+					require.True(t, hasPod,
+						"%s result without k8s.container.name also missing k8s.pod.name", metricName)
+				}
+			}
+			require.True(t, hasContainer > 0, "%s has no results with k8s.container.name", metricName)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestLabelPreservation — datapoint labels not empty for all metrics.
+// ---------------------------------------------------------------------------
+
+func TestLabelPreservation(t *testing.T) {
+	for _, metricName := range allMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				require.True(t, len(r.Labels.Datapoint) > 0, "%s has empty datapoint labels", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestMetricNamePreservation — metric_name matches query name.
+// ---------------------------------------------------------------------------
+
+func TestMetricNamePreservation(t *testing.T) {
+	for _, metricName := range allMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				require.Equal(t, metricName, r.MetricName, "%s metric name mismatch", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestServiceLabels — service.instance.id for Prometheus-scraped metrics.
+// ---------------------------------------------------------------------------
+
+func TestServiceLabels(t *testing.T) {
+	for _, metricName := range prometheusScrapedNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				svcID, ok := r.Labels.Resource["service.instance.id"]
+				require.True(t, ok, "%s missing @resource.service.instance.id", metricName)
+				require.True(t, svcID != "", "%s has empty @resource.service.instance.id", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestNodeLabelEnrichment — k8s.node.label.* present, NFD labels dropped.
+// ---------------------------------------------------------------------------
+
+func TestNodeLabelEnrichment(t *testing.T) {
+	expectedNodeLabels := []string{
+		"k8s.node.label.kubernetes.io/os",
+		"k8s.node.label.kubernetes.io/arch",
+	}
+
+	for _, metricName := range nodeLabelEnrichedNames() {
+		t.Run(metricName+"/standard_labels", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				// Only check nodes belonging to this cluster's color group.
+				// Attr-limit nodes (white) may have these labels dropped by design.
+				color := r.Labels.Resource[nodeColorLabel]
+				if _, known := nodeColorToInstanceTypes[color]; !known {
+					continue
+				}
+				for _, label := range expectedNodeLabels {
+					_, ok := r.Labels.Resource[label]
+					require.True(t, ok,
+						"%s missing @resource.%s on node %s",
+						metricName, label, r.Labels.Resource["k8s.node.name"])
+				}
+			}
+		})
+
+		t.Run(metricName+"/nfd_labels_dropped", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				var nfdLabels []string
+				for k := range r.Labels.Resource {
+					if strings.Contains(k, "feature.node.kubernetes.io") {
+						nfdLabels = append(nfdLabels, k)
+					}
+				}
+				require.True(t, len(nfdLabels) == 0,
+					"%s has NFD labels that should have been dropped: %v", metricName, nfdLabels)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestWorkloadLabels — standard cluster: node_exporter has no workload,
+// cadvisor nginx-test has Deployment workload.
+// ---------------------------------------------------------------------------
+
+func TestWorkloadLabels(t *testing.T) {
+	// Node-level: node_exporter metrics must NOT have workload labels.
+	for _, metricName := range metricNames(nodeExporterMetrics) {
+		t.Run(metricName+"/no_workload", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				_, hasName := r.Labels.Resource["k8s.workload.name"]
+				require.True(t, !hasName,
+					"%s node-level metric should not have k8s.workload.name but got: %s",
+					metricName, r.Labels.Resource["k8s.workload.name"])
+				_, hasType := r.Labels.Resource["k8s.workload.type"]
+				require.True(t, !hasType,
+					"%s node-level metric should not have k8s.workload.type but got: %s",
+					metricName, r.Labels.Resource["k8s.workload.type"])
+			}
+		})
+	}
+
+	// Cadvisor: nginx-test is a Deployment.
+	for _, metricName := range metricNames(cadvisorMetrics) {
+		t.Run(metricName+"/cadvisor_nginx_workload", func(t *testing.T) {
+			promql := fmt.Sprintf(`%s{"@resource.k8s.cluster.name"="%s","@resource.k8s.pod.name"=~"nginx-test.*"}`,
+				metricName, cfg.ClusterName)
+			results, err := client.Query(context.Background(), promql)
+			require.NoError(t, err, "querying %s for nginx-test", metricName)
+			require.True(t, len(results) > 0, "No %s results from nginx-test pods", metricName)
+			for _, r := range results {
+				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.workload.name"],
+					"%s nginx-test pod k8s.workload.name", metricName)
+				require.Equal(t, "Deployment", r.Labels.Resource["k8s.workload.type"],
+					"%s nginx-test pod k8s.workload.type", metricName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestMetricTypeLabels — metric type metadata labels match expected types.
+// ---------------------------------------------------------------------------
+
+func TestMetricTypeLabels(t *testing.T) {
+	for _, md := range allMetrics {
+		if md.MetricType != "counter" {
+			continue
+		}
+		t.Run(md.Name+"/counter_type", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), md.Name)
+			require.NoError(t, err, "querying %s", md.Name)
+			require.NotEmpty(t, results, "%s not available", md.Name)
+			for _, r := range results {
+				require.Equal(t, "Sum", r.Labels.Datapoint["__type__"], "%s __type__", md.Name)
+				require.Equal(t, "true", r.Labels.Datapoint["__monotonicity__"], "%s __monotonicity__", md.Name)
+				require.Equal(t, "cumulative", r.Labels.Datapoint["__temporality__"], "%s __temporality__", md.Name)
+			}
+		})
+	}
+
+	for _, md := range allMetrics {
+		if md.MetricType != "gauge" {
+			continue
+		}
+		t.Run(md.Name+"/gauge_type", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), md.Name)
+			require.NoError(t, err, "querying %s", md.Name)
+			require.NotEmpty(t, results, "%s not available", md.Name)
+			for _, r := range results {
+				require.Equal(t, "Gauge", r.Labels.Datapoint["__type__"], "%s __type__", md.Name)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestMetricUnitLabels — __unit__ metadata label matches expected unit.
+// ---------------------------------------------------------------------------
+
+func TestMetricUnitLabels(t *testing.T) {
+	for _, md := range allMetrics {
+		if md.Unit == "" {
+			continue
+		}
+		t.Run(md.Name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), md.Name)
+			require.NoError(t, err, "querying %s", md.Name)
+			require.NotEmpty(t, results, "%s not available", md.Name)
+			for _, r := range results {
+				unit, ok := r.Labels.Datapoint["__unit__"]
+				require.True(t, ok, "%s missing __unit__ datapoint label", md.Name)
+				require.Equal(t, md.Unit, unit, "%s __unit__", md.Name)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCustomNodeLabels — custom node label preserved on enriched metrics.
+// Adapted for standard cluster: skips if the label doesn't exist.
+// ---------------------------------------------------------------------------
+
+func TestCustomNodeLabels(t *testing.T) {
+	validColors := map[string]struct{}{
+		"blue": {}, "green": {}, "red": {}, "yellow": {}, "white": {},
+	}
+
+	for _, metricName := range nodeLabelEnrichedNames() {
+		t.Run(metricName+"/color_present", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				color := r.Labels.Resource[nodeColorLabel]
+				if color == "" {
+					continue
+				}
+				_, valid := validColors[color]
+				require.True(t, valid,
+					"%s unexpected node color '%s' (node: %s)",
+					metricName, color, r.Labels.Resource["k8s.node.name"])
+			}
+		})
+	}
+
+	// node_exporter metrics must include at least one result with color=blue.
+	for _, metricName := range metricNames(nodeExporterMetrics) {
+		t.Run(metricName+"/has_blue", func(t *testing.T) {
+			promql := fmt.Sprintf(`%s{"@resource.k8s.cluster.name"="%s","@resource.%s"="blue"}`,
+				metricName, cfg.ClusterName, nodeColorLabel)
+			results, err := client.Query(context.Background(), promql)
+			require.NoError(t, err, "querying %s with blue filter", metricName)
+			require.True(t, len(results) > 0,
+				"%s no results from standard nodes (color=blue)", metricName)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCloudResourceId — cloud.resource_id set to EKS cluster ARN.
+// ---------------------------------------------------------------------------
+
+func TestCloudResourceId(t *testing.T) {
+	expectedPrefix := "arn:aws:eks:"
+	expectedSuffix := ":cluster/" + cfg.ClusterName
+
+	for _, metricName := range allMetricNames() {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				arn, ok := r.Labels.Resource["cloud.resource_id"]
+				require.True(t, ok, "%s missing @resource.cloud.resource_id", metricName)
+				require.True(t, strings.HasPrefix(arn, expectedPrefix),
+					"%s cloud.resource_id should start with %q, got %q", metricName, expectedPrefix, arn)
+				require.True(t, strings.HasSuffix(arn, expectedSuffix),
+					"%s cloud.resource_id should end with %q, got %q", metricName, expectedSuffix, arn)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestScrapeMetadataFiltered — scrape metadata metrics must NOT appear from
+// filtered pipelines.
+// ---------------------------------------------------------------------------
+
+func TestScrapeMetadataFiltered(t *testing.T) {
+	scrapeMetrics := []string{
+		"scrape_duration_seconds",
+		"scrape_samples_scraped",
+		"scrape_samples_post_metric_relabeling",
+		"scrape_series_added",
+		"up",
+	}
+
+	filteredPipelines := map[string]bool{
+		"cadvisor":           true,
+		"apiserver":          true,
+		"kube-state-metrics": true,
+		"node-exporter":      true,
+	}
+
+	for _, metricName := range scrapeMetrics {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.GetUnfiltered(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				pipeline := r.Labels.Instrumentation["cloudwatch.pipeline"]
+				if filteredPipelines[pipeline] {
+					t.Errorf("%s should be filtered from %s pipeline but was present", metricName, pipeline)
+				}
+			}
+		})
+	}
+}

--- a/test/otel/standard/metrics_test.go
+++ b/test/otel/standard/metrics_test.go
@@ -1,0 +1,192 @@
+//go:build integration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package standard
+
+import "github.com/aws/amazon-cloudwatch-agent-test/util/otelmetrics"
+
+// Instance types in the standard cluster.
+var clusterHostTypes = []string{"t3.medium"}
+
+var clusterNodeGroups = []struct {
+	InstanceType string
+	Description  string
+}{
+	{"t3.medium", "standard"},
+}
+
+// --- Metric definitions (standard cluster only) ---
+
+var nodeExporterMetrics = []otelmetrics.MetricDefinition{
+	{Name: "node_cpu_seconds_total", MetricType: "counter", Scope: otelmetrics.ScopeNode, ExpectedLabels: []string{"cpu", "mode"}, Unit: "s"},
+	{Name: "node_memory_MemAvailable_bytes", MetricType: "gauge", Scope: otelmetrics.ScopeNode, Unit: "By"},
+	{Name: "node_filesystem_avail_bytes", MetricType: "gauge", Scope: otelmetrics.ScopeNode, ExpectedLabels: []string{"device", "mountpoint", "fstype"}, Unit: "By"},
+	{Name: "node_network_receive_bytes_total", MetricType: "counter", Scope: otelmetrics.ScopeNode, ExpectedLabels: []string{"device"}, Unit: "By"},
+	{Name: "node_load1", MetricType: "gauge", Scope: otelmetrics.ScopeNode},
+}
+
+var cadvisorMetrics = []otelmetrics.MetricDefinition{
+	{Name: "container_cpu_usage_seconds_total", MetricType: "counter", Scope: otelmetrics.ScopeContainer, ExpectedLabels: []string{"cpu"}, Unit: "s"},
+	{Name: "container_memory_working_set_bytes", MetricType: "gauge", Scope: otelmetrics.ScopeContainer, Unit: "By"},
+	{Name: "container_memory_usage_bytes", MetricType: "gauge", Scope: otelmetrics.ScopeContainer, Unit: "By"},
+	{Name: "container_network_receive_bytes_total", MetricType: "counter", Scope: otelmetrics.ScopePod, ExpectedLabels: []string{"interface"}, Unit: "By"},
+}
+
+var kubeletstatsNodeMetrics = []otelmetrics.MetricDefinition{
+	{Name: "k8s.node.cpu.utilization", MetricType: "gauge", Scope: otelmetrics.ScopeNode, Unit: "1"},
+	{Name: "k8s.node.memory.working_set", MetricType: "gauge", Scope: otelmetrics.ScopeNode, Unit: "By"},
+	{Name: "k8s.node.filesystem.available", MetricType: "gauge", Scope: otelmetrics.ScopeNode, Unit: "By"},
+	{Name: "k8s.node.network.io", MetricType: "counter", Scope: otelmetrics.ScopeNode, ExpectedLabels: []string{"interface", "direction"}, Unit: "By"},
+}
+
+var kubeletstatsPodMetrics = []otelmetrics.MetricDefinition{
+	{Name: "k8s.pod.cpu.utilization", MetricType: "gauge", Scope: otelmetrics.ScopePod, Unit: "1"},
+	{Name: "k8s.pod.memory.working_set", MetricType: "gauge", Scope: otelmetrics.ScopePod, Unit: "By"},
+	{Name: "k8s.pod.network.io", MetricType: "counter", Scope: otelmetrics.ScopePod, ExpectedLabels: []string{"interface", "direction"}, Unit: "By"},
+}
+
+var kubeletstatsContainerMetrics = []otelmetrics.MetricDefinition{
+	{Name: "container.cpu.utilization", MetricType: "gauge", Scope: otelmetrics.ScopeContainer, Unit: "1"},
+	{Name: "container.memory.working_set", MetricType: "gauge", Scope: otelmetrics.ScopeContainer, Unit: "By"},
+	{Name: "container.memory.usage", MetricType: "gauge", Scope: otelmetrics.ScopeContainer, Unit: "By"},
+}
+
+var kubeletstatsMetrics = func() []otelmetrics.MetricDefinition {
+	var all []otelmetrics.MetricDefinition
+	all = append(all, kubeletstatsNodeMetrics...)
+	all = append(all, kubeletstatsPodMetrics...)
+	all = append(all, kubeletstatsContainerMetrics...)
+	return all
+}()
+
+var controlPlaneMetrics = []otelmetrics.MetricDefinition{
+	{Name: "apiserver_request_total", MetricType: "counter", Scope: otelmetrics.ScopeCluster, ExpectedLabels: []string{"verb", "code"}, Unit: "1"},
+	{Name: "apiserver_request_duration_seconds", MetricType: "histogram", Scope: otelmetrics.ScopeCluster, ExpectedLabels: []string{"verb"}, Unit: "s"},
+	{Name: "rest_client_requests_total", MetricType: "counter", Scope: otelmetrics.ScopeCluster, ExpectedLabels: []string{"code", "method"}, Unit: "1"},
+	{Name: "apiserver_current_inflight_requests", MetricType: "gauge", Scope: otelmetrics.ScopeCluster, ExpectedLabels: []string{"request_kind"}},
+}
+
+var ksmNodeScopedMetrics = []otelmetrics.MetricDefinition{
+	{Name: "kube_node_status_condition", MetricType: "gauge", Scope: otelmetrics.ScopeCluster, ExpectedLabels: []string{"condition", "status"}},
+	{Name: "kube_node_info", MetricType: "gauge", Scope: otelmetrics.ScopeCluster},
+	{Name: "kube_node_status_allocatable", MetricType: "gauge", Scope: otelmetrics.ScopeCluster, ExpectedLabels: []string{"resource", "unit"}},
+	{Name: "kube_node_status_capacity", MetricType: "gauge", Scope: otelmetrics.ScopeCluster, ExpectedLabels: []string{"resource", "unit"}},
+	{Name: "kube_pod_status_phase", MetricType: "gauge", Scope: otelmetrics.ScopeCluster, ExpectedLabels: []string{"phase"}},
+	{Name: "kube_pod_container_status_running", MetricType: "gauge", Scope: otelmetrics.ScopeCluster},
+}
+
+var ksmClusterScopedMetrics = []otelmetrics.MetricDefinition{
+	{Name: "kube_deployment_status_replicas_ready", MetricType: "gauge", Scope: otelmetrics.ScopeCluster},
+	{Name: "kube_deployment_status_replicas", MetricType: "gauge", Scope: otelmetrics.ScopeCluster},
+	{Name: "kube_daemonset_status_desired_number_scheduled", MetricType: "gauge", Scope: otelmetrics.ScopeCluster},
+	{Name: "kube_namespace_status_phase", MetricType: "gauge", Scope: otelmetrics.ScopeCluster, ExpectedLabels: []string{"phase"}},
+}
+
+// --- Aggregate slices ---
+
+var daemonsetMetrics = func() []otelmetrics.MetricDefinition {
+	var all []otelmetrics.MetricDefinition
+	all = append(all, nodeExporterMetrics...)
+	all = append(all, cadvisorMetrics...)
+	all = append(all, kubeletstatsMetrics...)
+	return all
+}()
+
+var allMetrics = func() []otelmetrics.MetricDefinition {
+	var all []otelmetrics.MetricDefinition
+	all = append(all, daemonsetMetrics...)
+	all = append(all, controlPlaneMetrics...)
+	all = append(all, ksmNodeScopedMetrics...)
+	all = append(all, ksmClusterScopedMetrics...)
+	return all
+}()
+
+// --- Helper functions ---
+
+func metricNames(defs []otelmetrics.MetricDefinition) []string {
+	names := make([]string, len(defs))
+	for i, d := range defs {
+		names[i] = d.Name
+	}
+	return names
+}
+
+func metricNamesByScope(defs []otelmetrics.MetricDefinition, scope otelmetrics.MetricScope) []string {
+	var names []string
+	for _, d := range defs {
+		if d.Scope == scope {
+			names = append(names, d.Name)
+		}
+	}
+	return names
+}
+
+func daemonsetMetricNames() []string { return metricNames(daemonsetMetrics) }
+func allMetricNames() []string       { return metricNames(allMetrics) }
+
+func nodeMetricNames() []string {
+	return metricNamesByScope(allMetrics, otelmetrics.ScopeNode)
+}
+
+func podMetricNames() []string {
+	var names []string
+	for _, m := range allMetrics {
+		if m.Scope == otelmetrics.ScopePod || m.Scope == otelmetrics.ScopeContainer {
+			names = append(names, m.Name)
+		}
+	}
+	return names
+}
+
+func containerMetricNames() []string {
+	return metricNamesByScope(allMetrics, otelmetrics.ScopeContainer)
+}
+
+func podScopedMetricNames() []string {
+	names := daemonsetMetricNames()
+	names = append(names, ksmPodBucket...)
+	names = append(names, ksmContainerBucket...)
+	return names
+}
+
+func hostEnrichedMetricNames() []string {
+	return daemonsetMetricNames()
+}
+
+// nodeLabelEnrichedNames returns names of metrics that go through k8sattributes/node enrichment.
+func nodeLabelEnrichedNames() []string { return hostEnrichedMetricNames() }
+
+// prometheusScrapedNames returns names of all Prometheus-scraped metrics (excludes kubeletstats).
+func prometheusScrapedNames() []string {
+	var scraped []otelmetrics.MetricDefinition
+	scraped = append(scraped, nodeExporterMetrics...)
+	scraped = append(scraped, cadvisorMetrics...)
+	scraped = append(scraped, controlPlaneMetrics...)
+	return metricNames(scraped)
+}
+
+// podScopedCadvisorNames returns cadvisor metric names with ScopePod or ScopeContainer.
+func podScopedCadvisorNames() []string {
+	var names []string
+	for _, m := range cadvisorMetrics {
+		if m.Scope == otelmetrics.ScopePod || m.Scope == otelmetrics.ScopeContainer {
+			names = append(names, m.Name)
+		}
+	}
+	return names
+}
+
+// Instrumentation scope name constants.
+const scopePrometheus = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+
+// Custom node label used for node-color tests.
+const nodeColorLabel = "k8s.node.label.ci-test.example.com/node-color"
+
+// nodeColorToInstanceTypes maps node-color labels to expected instance types
+// for this cluster. Each cluster type defines only its own colors.
+// Phase 2 clusters add their colors (green=gpu, red=neuron, yellow=efa, white=attr-limit).
+var nodeColorToInstanceTypes = map[string][]string{
+	"blue": {"t3.medium"},
+}

--- a/test/otel/standard/node_exporter_test.go
+++ b/test/otel/standard/node_exporter_test.go
@@ -1,0 +1,164 @@
+//go:build integration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package standard
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/util/otelmetrics"
+)
+
+var nodeExporterMetricNames = metricNames(nodeExporterMetrics)
+
+func TestNodeExporterInstrumentationSource(t *testing.T) {
+	for _, metricName := range nodeExporterMetricNames {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				name, ok := r.Labels.Instrumentation["@name"]
+				require.True(t, ok, "%s missing @instrumentation.@name", metricName)
+				require.Equal(t, "github.com/prometheus/node_exporter", name,
+					"%s instrumentation name", metricName)
+			}
+		})
+	}
+}
+
+func TestNodeExporterInstrumentationConsistent(t *testing.T) {
+	for _, metricName := range nodeExporterMetricNames {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			names := make(map[string]struct{})
+			for _, r := range results {
+				if n, ok := r.Labels.Instrumentation["@name"]; ok {
+					names[n] = struct{}{}
+				}
+			}
+			require.Equal(t, 1, len(names),
+				"%s has multiple instrumentation names: got %d distinct values", metricName, len(names))
+		})
+	}
+}
+
+func TestNodeExporterExpectedLabels(t *testing.T) {
+	for _, md := range nodeExporterMetrics {
+		if len(md.ExpectedLabels) == 0 {
+			continue
+		}
+		t.Run(md.Name, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), md.Name)
+			require.NoError(t, err, "querying %s", md.Name)
+			require.NotEmpty(t, results, "%s not available", md.Name)
+			for _, r := range results {
+				for _, label := range md.ExpectedLabels {
+					_, ok := r.Labels.Datapoint[label]
+					require.True(t, ok, "%s missing expected label '%s' (node: %s, host.type: %s)",
+						md.Name, label,
+						r.Labels.Resource["k8s.node.name"],
+						r.Labels.Resource["host.type"])
+				}
+			}
+		})
+	}
+}
+
+func TestNodeExporterNoPodLabels(t *testing.T) {
+	for _, metricName := range nodeExporterMetricNames {
+		t.Run(metricName+"/no_container_name", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				_, has := r.Labels.Resource["k8s.container.name"]
+				require.True(t, !has,
+					"%s should not have k8s.container.name but got: %s (node: %s)",
+					metricName, r.Labels.Resource["k8s.container.name"], r.Labels.Resource["k8s.node.name"])
+			}
+		})
+		t.Run(metricName+"/no_pod_name", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				_, has := r.Labels.Resource["k8s.pod.name"]
+				require.True(t, !has,
+					"%s should not have k8s.pod.name but got: %s (node: %s)",
+					metricName, r.Labels.Resource["k8s.pod.name"], r.Labels.Resource["k8s.node.name"])
+			}
+		})
+		t.Run(metricName+"/no_namespace", func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				_, has := r.Labels.Resource["k8s.namespace.name"]
+				require.True(t, !has,
+					"%s should not have k8s.namespace.name but got: %s (node: %s)",
+					metricName, r.Labels.Resource["k8s.namespace.name"], r.Labels.Resource["k8s.node.name"])
+			}
+		})
+	}
+}
+
+func TestNodeExporterNoWorkloadLabels(t *testing.T) {
+	for _, metricName := range nodeExporterMetricNames {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				_, hasName := r.Labels.Resource["k8s.workload.name"]
+				require.True(t, !hasName,
+					"%s should not have k8s.workload.name but got: %s (node: %s)",
+					metricName, r.Labels.Resource["k8s.workload.name"], r.Labels.Resource["k8s.node.name"])
+				_, hasType := r.Labels.Resource["k8s.workload.type"]
+				require.True(t, !hasType,
+					"%s should not have k8s.workload.type but got: %s (node: %s)",
+					metricName, r.Labels.Resource["k8s.workload.type"], r.Labels.Resource["k8s.node.name"])
+			}
+		})
+	}
+}
+
+func TestNodeExporterNodeGroupCoverage(t *testing.T) {
+	for _, ng := range clusterNodeGroups {
+		t.Run(ng.Description+"/"+ng.InstanceType, func(t *testing.T) {
+			promql := fmt.Sprintf(
+				`node_load1{"@resource.k8s.cluster.name"="%s","@resource.host.type"="%s"}`,
+				otelmetrics.EscapePromQLValue(cfg.ClusterName), ng.InstanceType)
+			results, err := client.Query(context.Background(), promql)
+			require.NoError(t, err, "querying node_load1 on %s", ng.Description)
+			require.True(t, len(results) > 0,
+				"node_exporter missing from %s nodes (%s) — DaemonSet not scheduling?",
+				ng.Description, ng.InstanceType)
+		})
+	}
+}
+
+func TestNodeExporterHasRawNodeName(t *testing.T) {
+	for _, metricName := range nodeExporterMetricNames {
+		t.Run(metricName, func(t *testing.T) {
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not available", metricName)
+			for _, r := range results {
+				val, has := r.Labels.Datapoint["node_name"]
+				require.True(t, has,
+					"%s should have datapoint 'node_name' (raw label preserved)", metricName)
+				require.True(t, val != "",
+					"%s has empty datapoint 'node_name'", metricName)
+			}
+		})
+	}
+}

--- a/test/otel/standard/resolution_test.go
+++ b/test/otel/standard/resolution_test.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+// Metric resolution tests validate that each metric source is scraped at the
+// expected 30-second interval.
+
+package standard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/util/otelmetrics"
+)
+
+const expectedResolution = 30 * time.Second
+
+var resolutionTestMetrics = []struct {
+	name     string
+	source   string
+	hostType string
+}{
+	{"node_load1", "node_exporter", "t3.medium"},
+	{"container_cpu_usage_seconds_total", "cadvisor", "t3.medium"},
+}
+
+// TestMetricResolution validates that metrics are scraped at ~30s intervals by
+// querying a 5-minute range and checking sample counts.
+func TestMetricResolution(t *testing.T) {
+	end := time.Now()
+	start := end.Add(-5 * time.Minute)
+	step := expectedResolution
+
+	expectedSamples := int(5*time.Minute/expectedResolution) + 1 // 11 for 30s
+	minSamples := expectedSamples / 2
+
+	for _, tm := range resolutionTestMetrics {
+		t.Run(tm.source+"/"+tm.name, func(t *testing.T) {
+			escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(cfg.ClusterName)
+			promql := fmt.Sprintf(`%s{"@resource.k8s.cluster.name"="%s","@resource.host.type"="%s"}`,
+				tm.name, escaped, tm.hostType)
+
+			results, err := client.QueryRange(context.Background(), promql, start, end, step)
+			require.NoError(t, err, "range querying %s", tm.name)
+			require.True(t, len(results) > 0, "No %s range results", tm.name)
+
+			var bestSeries *otelmetrics.RangeResult
+			for i := range results {
+				if bestSeries == nil || len(results[i].Timestamps) > len(bestSeries.Timestamps) {
+					bestSeries = &results[i]
+				}
+			}
+
+			t.Logf("%s: %d samples in 5-minute window (expected ~%d for %v resolution)",
+				tm.name, len(bestSeries.Timestamps), expectedSamples, expectedResolution)
+
+			require.True(t, len(bestSeries.Timestamps) >= minSamples,
+				"%s: got %d samples, expected at least %d for %v resolution",
+				tm.name, len(bestSeries.Timestamps), minSamples, expectedResolution)
+		})
+	}
+}

--- a/test/otel/standard/setup_test.go
+++ b/test/otel/standard/setup_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package standard
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/otelmetrics"
+)
+
+var (
+	cfg        otelmetrics.TestConfig
+	client     *otelmetrics.OtelMetricsClient
+	queryCache *otelmetrics.QueryCache
+)
+
+func TestMain(m *testing.M) {
+	environment.RegisterEnvironmentMetaDataFlags()
+	flag.Parse()
+	env := environment.GetEnvironmentMetaData()
+
+	region := env.Region
+	if region == "" {
+		region = os.Getenv("AWS_REGION")
+	}
+	if region == "" {
+		fmt.Fprintf(os.Stderr, "Region not set\n")
+		os.Exit(1)
+	}
+
+	clusterName := env.EKSClusterName
+	if clusterName == "" {
+		clusterName = os.Getenv("CLUSTER_NAME")
+	}
+	if clusterName == "" {
+		fmt.Fprintf(os.Stderr, "Cluster name not set\n")
+		os.Exit(1)
+	}
+
+	// Auto-detect AccountID via STS
+	ctx := context.Background()
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "AWS config error: %v\n", err)
+		os.Exit(1)
+	}
+	stsClient := sts.NewFromConfig(awsCfg)
+	identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "STS GetCallerIdentity error: %v\n", err)
+		os.Exit(1)
+	}
+
+	cfg = otelmetrics.TestConfig{
+		Region:         region,
+		Endpoint:       fmt.Sprintf("https://monitoring.%s.amazonaws.com", region),
+		Timeout:        30 * time.Second,
+		MaxRetries:     3,
+		ClusterName:    clusterName,
+		AccountID:      *identity.Account,
+		SigningService: "monitoring",
+	}
+
+	client, err = otelmetrics.NewClient(ctx, cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Client error: %v\n", err)
+		os.Exit(1)
+	}
+
+	hostMappings := []otelmetrics.SourceHostMapping{
+		{Source: otelmetrics.SourceNodeExporter, HostTypes: clusterHostTypes},
+		{Source: otelmetrics.SourceCadvisor, HostTypes: clusterHostTypes},
+		{Source: otelmetrics.SourceKubeletstats, HostTypes: clusterHostTypes},
+		{Source: otelmetrics.SourceControlPlane, HostTypes: nil},
+		{Source: otelmetrics.SourceKubeStateMetrics, HostTypes: nil},
+		{Source: otelmetrics.SourceKSMNodeScoped, HostTypes: nil},
+	}
+
+	registry := otelmetrics.NewSourceRegistry(clusterHostTypes, hostMappings,
+		otelmetrics.SourceMapping{Source: otelmetrics.SourceNodeExporter, Metrics: nodeExporterMetrics},
+		otelmetrics.SourceMapping{Source: otelmetrics.SourceCadvisor, Metrics: cadvisorMetrics},
+		otelmetrics.SourceMapping{Source: otelmetrics.SourceKubeletstats, Metrics: kubeletstatsMetrics},
+		otelmetrics.SourceMapping{Source: otelmetrics.SourceControlPlane, Metrics: controlPlaneMetrics},
+		otelmetrics.SourceMapping{Source: otelmetrics.SourceKubeStateMetrics, Metrics: ksmClusterScopedMetrics},
+		otelmetrics.SourceMapping{Source: otelmetrics.SourceKSMNodeScoped, Metrics: ksmNodeScopedMetrics},
+	)
+
+	queryCache = otelmetrics.NewQueryCache(client, cfg.ClusterName,
+		otelmetrics.WithHostTypes(clusterHostTypes),
+		otelmetrics.WithSourceRegistry(registry),
+	)
+
+	os.Exit(m.Run())
+}

--- a/util/otelmetrics/client.go
+++ b/util/otelmetrics/client.go
@@ -1,0 +1,281 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package otelmetrics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+)
+
+// TestConfig holds configuration for the OTEL integration test suite.
+type TestConfig struct {
+	Region         string
+	Endpoint       string
+	Timeout        time.Duration
+	MaxRetries     int
+	ClusterName    string
+	AccountID      string
+	SigningService string
+}
+
+// OtelMetricsClient queries the OTLP PromQL API with SigV4 authentication.
+type OtelMetricsClient struct {
+	httpClient     *http.Client
+	signer         *v4.Signer
+	creds          aws.CredentialsProvider
+	queryURL       string
+	region         string
+	signingService string
+	maxRetries     int
+}
+
+type promqlResponse struct {
+	Status string     `json:"status"`
+	Data   promqlData `json:"data"`
+}
+
+type promqlData struct {
+	ResultType string         `json:"resultType"`
+	Result     []promqlSeries `json:"result"`
+}
+
+type promqlSeries struct {
+	Metric    map[string]string `json:"metric"`
+	Value     []json.RawMessage `json:"value"`
+	Histogram []json.RawMessage `json:"histogram"`
+}
+
+// NewClient creates an OtelMetricsClient from the given config.
+func NewClient(ctx context.Context, config TestConfig) (*OtelMetricsClient, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.Region))
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+	return &OtelMetricsClient{
+		httpClient:     &http.Client{Timeout: config.Timeout},
+		signer:         v4.NewSigner(),
+		creds:          cfg.Credentials,
+		queryURL:       config.Endpoint + "/api/v1/query",
+		region:         config.Region,
+		signingService: config.SigningService,
+		maxRetries:     config.MaxRetries,
+	}, nil
+}
+
+// Query executes a PromQL instant query and returns parsed results.
+func (c *OtelMetricsClient) Query(ctx context.Context, promql string) ([]MetricResult, error) {
+	params := url.Values{"query": {promql}}
+	slog.Debug("querying", "promql", promql)
+
+	raw, err := c.requestWithRetry(ctx, c.queryURL, params)
+	if err != nil {
+		return nil, err
+	}
+	results := c.parseResponse(raw)
+	slog.Debug("query returned", "count", len(results))
+	return results, nil
+}
+
+func (c *OtelMetricsClient) requestWithRetry(ctx context.Context, baseURL string, params url.Values) (*promqlResponse, error) {
+	body, err := c.requestRawWithRetry(ctx, baseURL, params)
+	if err != nil {
+		return nil, err
+	}
+	var result promqlResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parsing JSON: %w", err)
+	}
+	return &result, nil
+}
+
+func (c *OtelMetricsClient) requestRawWithRetry(ctx context.Context, baseURL string, params url.Values) ([]byte, error) {
+	// SHA256 of empty body for GET requests.
+	const emptyPayloadHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	var lastErr error
+	for attempt := 0; attempt < c.maxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"?"+params.Encode(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+
+		creds, err := c.creds.Retrieve(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("retrieving credentials: %w", err)
+		}
+
+		if err := c.signer.SignHTTP(ctx, creds, req, emptyPayloadHash, c.signingService, c.region, time.Now()); err != nil {
+			return nil, fmt.Errorf("signing request: %w", err)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			slog.Warn("request failed", "attempt", attempt+1, "error", err)
+			if attempt < c.maxRetries-1 {
+				time.Sleep(time.Duration(1<<attempt) * time.Second)
+			}
+			continue
+		}
+
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("reading response: %w", readErr)
+		}
+
+		if resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("server error %d: %s", resp.StatusCode, truncate(string(body), 200))
+			slog.Warn("server error, retrying", "status", resp.StatusCode, "attempt", attempt+1)
+			if attempt < c.maxRetries-1 {
+				time.Sleep(time.Duration(1<<attempt) * time.Second)
+			}
+			continue
+		}
+
+		if resp.StatusCode >= 400 {
+			return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, truncate(string(body), 200))
+		}
+
+		return body, nil
+	}
+	return nil, fmt.Errorf("all %d attempts failed: %w", c.maxRetries, lastErr)
+}
+
+func (c *OtelMetricsClient) parseResponse(response *promqlResponse) []MetricResult {
+	var results []MetricResult
+	for _, series := range response.Data.Result {
+		metricName := series.Metric["__name__"]
+		labels := ParseLabels(series.Metric)
+
+		if series.Histogram != nil && len(series.Histogram) >= 1 {
+			var tsFloat float64
+			if err := json.Unmarshal(series.Histogram[0], &tsFloat); err != nil {
+				continue
+			}
+			ts := time.Unix(int64(tsFloat), int64((tsFloat-float64(int64(tsFloat)))*1e9))
+			results = append(results, MetricResult{
+				MetricName:  metricName,
+				Labels:      labels,
+				Timestamp:   ts,
+				IsHistogram: true,
+			})
+			continue
+		}
+
+		if len(series.Value) < 2 {
+			continue
+		}
+
+		var tsFloat float64
+		if err := json.Unmarshal(series.Value[0], &tsFloat); err != nil {
+			continue
+		}
+		var valStr string
+		if err := json.Unmarshal(series.Value[1], &valStr); err != nil {
+			continue
+		}
+		val, err := strconv.ParseFloat(valStr, 64)
+		if err != nil {
+			continue
+		}
+
+		ts := time.Unix(int64(tsFloat), int64((tsFloat-float64(int64(tsFloat)))*1e9))
+		results = append(results, MetricResult{
+			MetricName: metricName,
+			Labels:     labels,
+			Value:      val,
+			Timestamp:  ts,
+		})
+	}
+	return results
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+// RangeResult holds a single time series from a range query.
+type RangeResult struct {
+	Labels     MetricLabels
+	Timestamps []time.Time
+	Values     []float64
+}
+
+type promqlRangeResponse struct {
+	Status string          `json:"status"`
+	Data   promqlRangeData `json:"data"`
+}
+
+type promqlRangeData struct {
+	ResultType string              `json:"resultType"`
+	Result     []promqlRangeSeries `json:"result"`
+}
+
+type promqlRangeSeries struct {
+	Metric map[string]string   `json:"metric"`
+	Values [][]json.RawMessage `json:"values"`
+}
+
+// QueryRange executes a PromQL range query and returns time series with multiple samples.
+func (c *OtelMetricsClient) QueryRange(ctx context.Context, promql string, start, end time.Time, step time.Duration) ([]RangeResult, error) {
+	rangeURL := c.queryURL[:len(c.queryURL)-len("/query")] + "/query_range"
+	params := url.Values{
+		"query": {promql},
+		"start": {fmt.Sprintf("%d", start.Unix())},
+		"end":   {fmt.Sprintf("%d", end.Unix())},
+		"step":  {fmt.Sprintf("%ds", int(step.Seconds()))},
+	}
+
+	rawBytes, err := c.requestRawWithRetry(ctx, rangeURL, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var rangeResp promqlRangeResponse
+	if err := json.Unmarshal(rawBytes, &rangeResp); err != nil {
+		return nil, fmt.Errorf("parsing range response: %w", err)
+	}
+
+	var results []RangeResult
+	for _, series := range rangeResp.Data.Result {
+		labels := ParseLabels(series.Metric)
+		rr := RangeResult{Labels: labels}
+		for _, pair := range series.Values {
+			if len(pair) < 2 {
+				continue
+			}
+			var tsFloat float64
+			if err := json.Unmarshal(pair[0], &tsFloat); err != nil {
+				continue
+			}
+			var valStr string
+			if err := json.Unmarshal(pair[1], &valStr); err != nil {
+				continue
+			}
+			val, err := strconv.ParseFloat(valStr, 64)
+			if err != nil {
+				continue
+			}
+			rr.Timestamps = append(rr.Timestamps, time.Unix(int64(tsFloat), 0))
+			rr.Values = append(rr.Values, val)
+		}
+		results = append(results, rr)
+	}
+	return results, nil
+}

--- a/util/otelmetrics/models.go
+++ b/util/otelmetrics/models.go
@@ -1,0 +1,157 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package otelmetrics
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// MetricScope represents the scope level at which a metric is produced.
+type MetricScope int
+
+const (
+	ScopeNode MetricScope = iota
+	ScopePod
+	ScopeContainer
+	ScopeCluster
+)
+
+func (s MetricScope) String() string {
+	switch s {
+	case ScopeNode:
+		return "node"
+	case ScopePod:
+		return "pod"
+	case ScopeContainer:
+		return "container"
+	case ScopeCluster:
+		return "cluster"
+	default:
+		return fmt.Sprintf("MetricScope(%d)", int(s))
+	}
+}
+
+// MetricLabels holds parsed OTLP labels grouped by ZIP-0006 scope.
+// Always use NewMetricLabels() to avoid nil map panics.
+type MetricLabels struct {
+	Resource        map[string]string
+	Instrumentation map[string]string
+	Datapoint       map[string]string
+	AWS             map[string]string
+	AWSCloudWatch   map[string]string
+}
+
+// NewMetricLabels returns a MetricLabels with all maps initialized.
+func NewMetricLabels() MetricLabels {
+	return MetricLabels{
+		Resource:        make(map[string]string),
+		Instrumentation: make(map[string]string),
+		Datapoint:       make(map[string]string),
+		AWS:             make(map[string]string),
+		AWSCloudWatch:   make(map[string]string),
+	}
+}
+
+// ParseLabels categorizes raw PromQL label keys into ZIP-0006 scopes.
+//
+// Scope resolution uses longest-prefix matching:
+//  1. @aws.cloudwatch.* → AWSCloudWatch
+//  2. @aws.* → AWS
+//  3. @resource.* → Resource
+//  4. @instrumentation.* → Instrumentation
+//  5. @datapoint.* → Datapoint (explicit)
+//  6. Everything else → Datapoint (implicit default)
+//
+// The __name__ key is excluded from all scopes.
+func ParseLabels(metric map[string]string) MetricLabels {
+	labels := NewMetricLabels()
+	for key, value := range metric {
+		switch {
+		case key == "__name__":
+			continue
+		case strings.HasPrefix(key, "@aws.cloudwatch."):
+			labels.AWSCloudWatch[strings.TrimPrefix(key, "@aws.cloudwatch.")] = value
+		case strings.HasPrefix(key, "@aws."):
+			labels.AWS[strings.TrimPrefix(key, "@aws.")] = value
+		case strings.HasPrefix(key, "@resource."):
+			labels.Resource[strings.TrimPrefix(key, "@resource.")] = value
+		case strings.HasPrefix(key, "@instrumentation."):
+			labels.Instrumentation[strings.TrimPrefix(key, "@instrumentation.")] = value
+		case strings.HasPrefix(key, "@datapoint."):
+			labels.Datapoint[strings.TrimPrefix(key, "@datapoint.")] = value
+		default:
+			labels.Datapoint[key] = value
+		}
+	}
+	return labels
+}
+
+// FormatPromQL formats labels back into a PromQL label selector string.
+func (ml MetricLabels) FormatPromQL() string {
+	var parts []string
+	for key, value := range ml.Resource {
+		parts = append(parts, `"@resource.`+key+`"="`+EscapePromQLValue(value)+`"`)
+	}
+	for key, value := range ml.Instrumentation {
+		parts = append(parts, `"@instrumentation.`+key+`"="`+EscapePromQLValue(value)+`"`)
+	}
+	for key, value := range ml.AWSCloudWatch {
+		parts = append(parts, `"@aws.cloudwatch.`+key+`"="`+EscapePromQLValue(value)+`"`)
+	}
+	for key, value := range ml.AWS {
+		parts = append(parts, `"@aws.`+key+`"="`+EscapePromQLValue(value)+`"`)
+	}
+	for key, value := range ml.Datapoint {
+		parts = append(parts, key+`="`+EscapePromQLValue(value)+`"`)
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+// AllLabels returns all labels as a flat map with full scope prefixes.
+func (ml MetricLabels) AllLabels() map[string]string {
+	result := make(map[string]string)
+	for k, v := range ml.Resource {
+		result["@resource."+k] = v
+	}
+	for k, v := range ml.Instrumentation {
+		result["@instrumentation."+k] = v
+	}
+	for k, v := range ml.AWSCloudWatch {
+		result["@aws.cloudwatch."+k] = v
+	}
+	for k, v := range ml.AWS {
+		result["@aws."+k] = v
+	}
+	for k, v := range ml.Datapoint {
+		result[k] = v
+	}
+	return result
+}
+
+// EscapePromQLValue escapes a string for use as a PromQL label value inside double quotes.
+func EscapePromQLValue(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `"`, `\"`)
+	return value
+}
+
+// MetricResult represents a single metric query result from the OTLP PromQL API.
+type MetricResult struct {
+	MetricName  string
+	Labels      MetricLabels
+	Value       float64
+	Timestamp   time.Time
+	IsHistogram bool
+}
+
+// MetricDefinition describes everything testable about a single metric.
+type MetricDefinition struct {
+	Name           string
+	MetricType     string // "counter", "gauge", "histogram", "summary"
+	Scope          MetricScope
+	ExpectedLabels []string
+	Unit           string // "" if unset
+}

--- a/util/otelmetrics/models_test.go
+++ b/util/otelmetrics/models_test.go
@@ -1,0 +1,122 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package otelmetrics
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseLabelsScopes(t *testing.T) {
+	t.Run("resource_labels", func(t *testing.T) {
+		metric := map[string]string{
+			"__name__": "cpu_usage", "@resource.k8s.cluster.name": "test-cluster",
+			"@resource.k8s.pod.name": "nginx-abc123", "@resource.k8s.namespace.name": "default",
+		}
+		labels := ParseLabels(metric)
+		if labels.Resource["k8s.cluster.name"] != "test-cluster" {
+			t.Fatalf("got %q", labels.Resource["k8s.cluster.name"])
+		}
+		if len(labels.Resource) != 3 {
+			t.Fatalf("expected 3 resource labels, got %d", len(labels.Resource))
+		}
+	})
+	t.Run("aws_cloudwatch_before_aws", func(t *testing.T) {
+		metric := map[string]string{
+			"__name__": "x", "@aws.cloudwatch.namespace": "AWS/EC2", "@aws.region": "us-east-1",
+		}
+		labels := ParseLabels(metric)
+		if labels.AWSCloudWatch["namespace"] != "AWS/EC2" {
+			t.Fatalf("got %q", labels.AWSCloudWatch["namespace"])
+		}
+		if _, ok := labels.AWS["cloudwatch.namespace"]; ok {
+			t.Fatal("cloudwatch.namespace leaked into AWS map")
+		}
+	})
+	t.Run("__name__excluded", func(t *testing.T) {
+		labels := ParseLabels(map[string]string{"__name__": "cpu", "@resource.x": "y"})
+		if _, ok := labels.Datapoint["__name__"]; ok {
+			t.Fatal("__name__ should be excluded")
+		}
+	})
+	t.Run("all_scopes", func(t *testing.T) {
+		metric := map[string]string{
+			"__name__": "m", "@resource.a": "1", "@instrumentation.b": "2",
+			"@aws.c": "3", "@aws.cloudwatch.d": "4", "e": "5",
+		}
+		labels := ParseLabels(metric)
+		if len(labels.Resource) != 1 || len(labels.Instrumentation) != 1 ||
+			len(labels.AWS) != 1 || len(labels.AWSCloudWatch) != 1 || len(labels.Datapoint) != 1 {
+			t.Fatalf("scope counts wrong: R=%d I=%d A=%d AC=%d D=%d",
+				len(labels.Resource), len(labels.Instrumentation),
+				len(labels.AWS), len(labels.AWSCloudWatch), len(labels.Datapoint))
+		}
+	})
+}
+
+func TestFormatPromQL(t *testing.T) {
+	t.Run("scoped_quoted", func(t *testing.T) {
+		labels := NewMetricLabels()
+		labels.Resource["k8s.cluster.name"] = "test"
+		result := labels.FormatPromQL()
+		if !strings.Contains(result, `"@resource.k8s.cluster.name"="test"`) {
+			t.Fatalf("got %q", result)
+		}
+	})
+	t.Run("datapoint_unquoted", func(t *testing.T) {
+		labels := NewMetricLabels()
+		labels.Datapoint["job"] = "node"
+		result := labels.FormatPromQL()
+		if !strings.Contains(result, `job="node"`) {
+			t.Fatalf("got %q", result)
+		}
+	})
+	t.Run("empty", func(t *testing.T) {
+		if got := NewMetricLabels().FormatPromQL(); got != "{}" {
+			t.Fatalf("got %q", got)
+		}
+	})
+}
+
+func TestAllLabels(t *testing.T) {
+	labels := NewMetricLabels()
+	labels.Resource["a"] = "1"
+	labels.AWS["b"] = "2"
+	labels.Datapoint["c"] = "3"
+	flat := labels.AllLabels()
+	if flat["@resource.a"] != "1" || flat["@aws.b"] != "2" || flat["c"] != "3" {
+		t.Fatalf("got %v", flat)
+	}
+}
+
+func TestEscaping(t *testing.T) {
+	if got := EscapePromQLValue(`a"b\c`); got != `a\"b\\c` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestNewMetricLabels(t *testing.T) {
+	labels := NewMetricLabels()
+	if labels.Resource == nil || labels.Instrumentation == nil ||
+		labels.Datapoint == nil || labels.AWS == nil || labels.AWSCloudWatch == nil {
+		t.Fatal("nil map in NewMetricLabels")
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	original := map[string]string{
+		"__name__": "cpu", "@resource.cluster": "c1",
+		"@instrumentation.@name": "x", "@aws.account": "123",
+		"@aws.cloudwatch.ns": "CI", "job": "node",
+	}
+	promql := ParseLabels(original).FormatPromQL()
+	for _, exp := range []string{
+		`"@resource.cluster"="c1"`, `"@instrumentation.@name"="x"`,
+		`"@aws.account"="123"`, `"@aws.cloudwatch.ns"="CI"`, `job="node"`,
+	} {
+		if !strings.Contains(promql, exp) {
+			t.Fatalf("missing %q in %q", exp, promql)
+		}
+	}
+}

--- a/util/otelmetrics/query_cache.go
+++ b/util/otelmetrics/query_cache.go
@@ -1,0 +1,257 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package otelmetrics
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+// DefaultMaxConcurrency is the default number of concurrent in-flight queries.
+const DefaultMaxConcurrency = 3
+
+// promqlEscaper is the shared escaper for PromQL label values.
+var promqlEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+
+func promqlMetricSelector(metricName string) string {
+	if strings.Contains(metricName, ".") {
+		return fmt.Sprintf(`{"__name__"="%s",`, metricName)
+	}
+	return metricName + "{"
+}
+
+type cacheEntry struct {
+	results []MetricResult
+	err     error
+}
+
+// QueryCache provides session-scoped caching of PromQL queries.
+// Each unique metric name is queried exactly once; subsequent calls return cached data.
+// Concurrent requests for the same metric are deduplicated via singleflight.
+type QueryCache struct {
+	mu         sync.RWMutex
+	filtered   map[string]cacheEntry
+	unfiltered map[string]cacheEntry
+	client     *OtelMetricsClient
+	cluster    string
+	hostTypes  []string
+	registry   *SourceRegistry
+	sem        chan struct{}
+	inflight   map[string]chan struct{} // dedup concurrent fetches for same key
+}
+
+// QueryCacheOption configures optional QueryCache behavior.
+type QueryCacheOption func(*QueryCache)
+
+func WithHostTypes(hostTypes []string) QueryCacheOption {
+	return func(qc *QueryCache) { qc.hostTypes = hostTypes }
+}
+
+func WithSourceRegistry(registry *SourceRegistry) QueryCacheOption {
+	return func(qc *QueryCache) { qc.registry = registry }
+}
+
+func WithMaxConcurrency(n int) QueryCacheOption {
+	return func(qc *QueryCache) { qc.sem = make(chan struct{}, n) }
+}
+
+func NewQueryCache(client *OtelMetricsClient, clusterName string, opts ...QueryCacheOption) *QueryCache {
+	qc := &QueryCache{
+		filtered:   make(map[string]cacheEntry),
+		unfiltered: make(map[string]cacheEntry),
+		inflight:   make(map[string]chan struct{}),
+		client:     client,
+		cluster:    clusterName,
+	}
+	for _, opt := range opts {
+		opt(qc)
+	}
+	if qc.sem == nil {
+		qc.sem = make(chan struct{}, DefaultMaxConcurrency)
+	}
+	return qc
+}
+
+// Get returns cached results for a metric filtered by cluster name.
+// Concurrent calls for the same metric are deduplicated.
+func (qc *QueryCache) Get(ctx context.Context, metricName string) ([]MetricResult, error) {
+	// Fast path: cache hit
+	qc.mu.RLock()
+	if entry, ok := qc.filtered[metricName]; ok {
+		qc.mu.RUnlock()
+		return entry.results, entry.err
+	}
+	// Check if another goroutine is already fetching this metric
+	if ch, ok := qc.inflight[metricName]; ok {
+		qc.mu.RUnlock()
+		<-ch // wait for the fetch to complete
+		qc.mu.RLock()
+		entry := qc.filtered[metricName]
+		qc.mu.RUnlock()
+		return entry.results, entry.err
+	}
+	qc.mu.RUnlock()
+
+	// Claim this metric fetch
+	qc.mu.Lock()
+	// Double-check after acquiring write lock
+	if entry, ok := qc.filtered[metricName]; ok {
+		qc.mu.Unlock()
+		return entry.results, entry.err
+	}
+	if ch, ok := qc.inflight[metricName]; ok {
+		qc.mu.Unlock()
+		<-ch
+		qc.mu.RLock()
+		entry := qc.filtered[metricName]
+		qc.mu.RUnlock()
+		return entry.results, entry.err
+	}
+	ch := make(chan struct{})
+	qc.inflight[metricName] = ch
+	qc.mu.Unlock()
+
+	// Fetch without holding any lock
+	entry := qc.fetchFiltered(ctx, metricName)
+
+	// Store and signal waiters
+	qc.mu.Lock()
+	qc.filtered[metricName] = entry
+	delete(qc.inflight, metricName)
+	qc.mu.Unlock()
+	close(ch)
+
+	return entry.results, entry.err
+}
+
+// fetchFiltered performs the actual HTTP query for a filtered metric.
+func (qc *QueryCache) fetchFiltered(ctx context.Context, metricName string) cacheEntry {
+	escaped := promqlEscaper.Replace(qc.cluster)
+	sel := promqlMetricSelector(metricName)
+
+	var results []MetricResult
+	var firstErr error
+
+	var targetHosts []string
+	clusterScopedOnly := false
+
+	if qc.registry != nil {
+		if qc.registry.IsClusterScoped(metricName) {
+			clusterScopedOnly = true
+		} else {
+			targetHosts = qc.registry.HostTypesFor(metricName)
+		}
+	} else if len(qc.hostTypes) > 0 {
+		targetHosts = qc.hostTypes
+	}
+
+	if clusterScopedOnly {
+		promql := fmt.Sprintf(`%s"@resource.k8s.cluster.name"="%s","@resource.host.type"=""}`, sel, escaped)
+		r, err := qc.client.Query(ctx, promql)
+		if err != nil {
+			firstErr = err
+		} else {
+			results = append(results, r...)
+		}
+	} else if len(targetHosts) > 0 {
+		type queryResult struct {
+			results []MetricResult
+			err     error
+		}
+		ch := make(chan queryResult, len(targetHosts))
+		var wg sync.WaitGroup
+
+		for _, ht := range targetHosts {
+			wg.Add(1)
+			go func(hostType string) {
+				defer wg.Done()
+				select {
+				case qc.sem <- struct{}{}:
+					defer func() { <-qc.sem }()
+				case <-ctx.Done():
+					ch <- queryResult{err: ctx.Err()}
+					return
+				}
+				promql := fmt.Sprintf(`%s"@resource.k8s.cluster.name"="%s","@resource.host.type"="%s"}`, sel, escaped, hostType)
+				r, err := qc.client.Query(ctx, promql)
+				ch <- queryResult{results: r, err: err}
+			}(ht)
+		}
+
+		go func() { wg.Wait(); close(ch) }()
+
+		for qr := range ch {
+			if qr.err != nil {
+				if firstErr == nil {
+					firstErr = qr.err
+				}
+				continue
+			}
+			results = append(results, qr.results...)
+		}
+	} else {
+		promql := fmt.Sprintf(`%s"@resource.k8s.cluster.name"="%s"}`, sel, escaped)
+		r, err := qc.client.Query(ctx, promql)
+		results = r
+		firstErr = err
+	}
+
+	if len(results) == 0 && firstErr != nil {
+		slog.Debug("query failed", "metric", metricName, "error", firstErr)
+		return cacheEntry{err: firstErr}
+	}
+	return cacheEntry{results: results}
+}
+
+// GetWithFilter returns results with additional PromQL label filters. Not cached.
+func (qc *QueryCache) GetWithFilter(ctx context.Context, metricName string, extraFilters map[string]string) ([]MetricResult, error) {
+	escaped := promqlEscaper.Replace(qc.cluster)
+	sel := promqlMetricSelector(metricName)
+
+	filters := fmt.Sprintf(`"@resource.k8s.cluster.name"="%s"`, escaped)
+	for key, value := range extraFilters {
+		escapedVal := promqlEscaper.Replace(value)
+		switch {
+		case strings.HasPrefix(key, "~@resource."):
+			filters += fmt.Sprintf(`,"%s"=~"%s"`, strings.TrimPrefix(key, "~"), escapedVal)
+		case strings.HasPrefix(key, "@resource."):
+			filters += fmt.Sprintf(`,"%s"="%s"`, key, escapedVal)
+		case strings.HasPrefix(key, "~"):
+			filters += fmt.Sprintf(`,%s=~"%s"`, strings.TrimPrefix(key, "~"), escapedVal)
+		default:
+			filters += fmt.Sprintf(`,%s="%s"`, key, escapedVal)
+		}
+	}
+
+	return qc.client.Query(ctx, sel+filters+"}")
+}
+
+// GetUnfiltered returns results without cluster filtering. Cached separately.
+func (qc *QueryCache) GetUnfiltered(ctx context.Context, metricName string) ([]MetricResult, error) {
+	qc.mu.RLock()
+	if entry, ok := qc.unfiltered[metricName]; ok {
+		qc.mu.RUnlock()
+		return entry.results, entry.err
+	}
+	qc.mu.RUnlock()
+
+	qc.mu.Lock()
+	if entry, ok := qc.unfiltered[metricName]; ok {
+		qc.mu.Unlock()
+		return entry.results, entry.err
+	}
+	qc.mu.Unlock()
+
+	results, queryErr := qc.client.Query(ctx, metricName)
+	entry := cacheEntry{results: results, err: queryErr}
+
+	qc.mu.Lock()
+	qc.unfiltered[metricName] = entry
+	qc.mu.Unlock()
+
+	return entry.results, entry.err
+}

--- a/util/otelmetrics/source_registry.go
+++ b/util/otelmetrics/source_registry.go
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package otelmetrics
+
+// MetricSource identifies a metric's origin collector/exporter.
+type MetricSource int
+
+const (
+	SourceNodeExporter MetricSource = iota
+	SourceCadvisor
+	SourceKubeletstats
+	SourceDCGM
+	SourceNeuron
+	SourceEFA
+	SourceEBSCSI
+	SourceControlPlane
+	SourceKubeStateMetrics
+	SourceKSMNodeScoped
+)
+
+// SourceMapping pairs a MetricSource with its metric definitions.
+type SourceMapping struct {
+	Source  MetricSource
+	Metrics []MetricDefinition
+}
+
+// SourceHostMapping maps a MetricSource to the host types that produce it.
+// Nil means cluster-scoped (query with host.type="").
+type SourceHostMapping struct {
+	Source    MetricSource
+	HostTypes []string // nil = cluster-scoped
+}
+
+// SourceRegistry maps metric names to their MetricSource and resolves
+// which host types to query for each source.
+type SourceRegistry struct {
+	metricToSource map[string]MetricSource
+	sourceToHosts  map[MetricSource][]string
+	allHostTypes   []string
+}
+
+// NewSourceRegistry builds a registry from metric definitions and host mappings.
+// allHostTypes is the full list of host types in the cluster (fallback for unknown metrics).
+// hostMappings defines which host types produce each source's metrics.
+func NewSourceRegistry(allHostTypes []string, hostMappings []SourceHostMapping, metricMappings ...SourceMapping) *SourceRegistry {
+	sourceToHosts := make(map[MetricSource][]string)
+	for _, hm := range hostMappings {
+		sourceToHosts[hm.Source] = hm.HostTypes
+	}
+
+	metricToSource := make(map[string]MetricSource)
+	for _, m := range metricMappings {
+		for _, md := range m.Metrics {
+			metricToSource[md.Name] = m.Source
+		}
+	}
+
+	return &SourceRegistry{
+		metricToSource: metricToSource,
+		sourceToHosts:  sourceToHosts,
+		allHostTypes:   allHostTypes,
+	}
+}
+
+// HostTypesFor returns the host types that can produce the given metric.
+// Returns nil for cluster-scoped sources. Returns allHostTypes for unknown metrics.
+func (sr *SourceRegistry) HostTypesFor(metricName string) []string {
+	source, ok := sr.metricToSource[metricName]
+	if !ok {
+		return sr.allHostTypes
+	}
+	return sr.sourceToHosts[source]
+}
+
+// IsClusterScoped returns true if the metric comes from a cluster-scoped source.
+func (sr *SourceRegistry) IsClusterScoped(metricName string) bool {
+	source, ok := sr.metricToSource[metricName]
+	if !ok {
+		return false
+	}
+	return source == SourceControlPlane || source == SourceKubeStateMetrics
+}


### PR DESCRIPTION
  Port OTEL integration tests into the agent test framework for the
  standard EKS cluster (2x t3.medium). Tests validate metric correctness
  by querying the CloudWatch PromQL API with SigV4 auth and cross-
  validating against K8s API ground truth.

  Components:
  - util/otelmetrics/: Shared PromQL client library with SigV4 signing, query cache, ZIP-0006 label parsing, and rate limiting
  - terraform/eks/daemon/otel/: Ephemeral EKS cluster with Helm chart (release-6.1.0), Pod Identity, and nginx test workload
  - test/otel/standard/: 145 integration tests covering cadvisor, node_exporter, kubeletstats, KSM, control plane, dedup, resolution, host validation, and cross-source label correctness
  - generator/test_case_generator.go: Added to eks_daemon matrix

  Validated in CI: 145/145 PASS via existing EKSIntegrationTest workflow.

Workflow Run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/24726297813