### PR TITLE
fix(eks): migrate all AMI types from AL2 to AL2023 for K8s 1.33+

### DIFF
--- a/generator/resources/eks_addon_test_matrix.json
+++ b/generator/resources/eks_addon_test_matrix.json
@@ -1,7 +1,7 @@
 [
   {
     "k8sVersion": "1.31",
-    "ami": "AL2_x86_64_GPU",
+    "ami": "AL2023_x86_64_NVIDIA",
     "terraform_dir": "terraform/eks/addon/gpu",
     "test_dir": "./test/gpu",
     "instanceType":"g4dn.xlarge"

--- a/generator/resources/eks_daemon_test_matrix.json
+++ b/generator/resources/eks_daemon_test_matrix.json
@@ -1,13 +1,13 @@
 [
   {
     "k8sVersion": "1.35",
-    "ami": "AL2_x86_64",
+    "ami": "AL2023_x86_64_STANDARD",
     "instanceType":"t3.medium",
     "arc": "amd64"
   },
   {
     "k8sVersion": "1.35",
-    "ami": "AL2_ARM_64",
+    "ami": "AL2023_ARM_64_STANDARD",
     "instanceType":"m6g.large",
     "arc": "arm64"
   }

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -356,7 +356,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 			testDir:      "./test/metric_value_benchmark",
 			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
 			instanceType: "g4dn.xlarge",
-			ami:          "AL2_x86_64_GPU",
+			ami:          "AL2023_x86_64_NVIDIA",
 		},
 		{
 			testDir:      "./test/metric_value_benchmark",
@@ -386,13 +386,13 @@ var testTypeToTestConfig = map[string][]testConfig{
 			testDir: "./test/gpu", terraformDir: "terraform/eks/daemon/gpu",
 			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
 			instanceType: "g4dn.xlarge",
-			ami:          "AL2_x86_64_GPU",
+			ami:          "AL2023_x86_64_NVIDIA",
 		},
 		{
 			testDir: "./test/gpu_high_frequency_metrics", terraformDir: "terraform/eks/daemon/gpu",
 			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
 			instanceType: "g4dn.xlarge",
-			ami:          "AL2_x86_64_GPU",
+			ami:          "AL2023_x86_64_NVIDIA",
 		},
 		{
 			testDir: "./test/awsneuron", terraformDir: "terraform/eks/daemon/awsneuron",

--- a/terraform/eks/addon/gpu/main.tf
+++ b/terraform/eks/addon/gpu/main.tf
@@ -38,6 +38,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-addon-eks-integ-node"
@@ -52,8 +61,12 @@ resource "aws_eks_node_group" "this" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,

--- a/terraform/eks/addon/gpu/variables.tf
+++ b/terraform/eks/addon/gpu/variables.tf
@@ -23,7 +23,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64_GPU"
+  default = "AL2023_x86_64_NVIDIA"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/app_signals/main.tf
+++ b/terraform/eks/daemon/app_signals/main.tf
@@ -35,6 +35,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-eks-integ-node"
@@ -47,10 +56,14 @@ resource "aws_eks_node_group" "this" {
     min_size     = 1
   }
 
-  ami_type       = "AL2_x86_64"
+  ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = ["t3.medium"]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
@@ -373,6 +386,7 @@ resource "kubernetes_daemonset" "service" {
           }
         }
         service_account_name             = "cloudwatch-agent"
+        host_network                     = true
         termination_grace_period_seconds = 60
       }
     }

--- a/terraform/eks/daemon/app_signals/variables.tf
+++ b/terraform/eks/daemon/app_signals/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/awsneuron/main.tf
+++ b/terraform/eks/daemon/awsneuron/main.tf
@@ -35,6 +35,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-eks-integ-node"
@@ -47,10 +56,14 @@ resource "aws_eks_node_group" "this" {
     min_size     = 1
   }
 
-  ami_type       = "AL2_x86_64"
+  ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = ["t3.medium"]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
@@ -672,6 +685,7 @@ resource "kubernetes_daemonset" "service" {
           }
         }
         service_account_name             = "cloudwatch-agent"
+        host_network                     = true
         termination_grace_period_seconds = 60
       }
     }

--- a/terraform/eks/daemon/awsneuron/variables.tf
+++ b/terraform/eks/daemon/awsneuron/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/credentials/pod_identity/main.tf
+++ b/terraform/eks/daemon/credentials/pod_identity/main.tf
@@ -30,6 +30,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-eks-integ-node-${module.common.testing_id}"
@@ -44,8 +53,12 @@ resource "aws_eks_node_group" "this" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,

--- a/terraform/eks/daemon/credentials/pod_identity/variables.tf
+++ b/terraform/eks/daemon/credentials/pod_identity/variables.tf
@@ -18,7 +18,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/ebs/main.tf
+++ b/terraform/eks/daemon/ebs/main.tf
@@ -32,6 +32,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-addon-eks-integ-node-${module.common.testing_id}"
@@ -46,8 +55,12 @@ resource "aws_eks_node_group" "this" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,

--- a/terraform/eks/daemon/ebs/variables.tf
+++ b/terraform/eks/daemon/ebs/variables.tf
@@ -33,7 +33,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/emf/main.tf
+++ b/terraform/eks/daemon/emf/main.tf
@@ -35,6 +35,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-eks-integ-node"
@@ -47,10 +56,14 @@ resource "aws_eks_node_group" "this" {
     min_size     = 1
   }
 
-  ami_type       = "AL2_x86_64"
+  ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = ["t3.medium"]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
@@ -367,6 +380,7 @@ resource "kubernetes_daemonset" "service" {
           }
         }
         service_account_name             = "cloudwatch-agent"
+        host_network                     = true
         termination_grace_period_seconds = 60
       }
     }

--- a/terraform/eks/daemon/emf/variables.tf
+++ b/terraform/eks/daemon/emf/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/entity/main.tf
+++ b/terraform/eks/daemon/entity/main.tf
@@ -30,6 +30,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-eks-integ-node-${module.common.testing_id}"
@@ -44,8 +53,12 @@ resource "aws_eks_node_group" "this" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,

--- a/terraform/eks/daemon/entity/variables.tf
+++ b/terraform/eks/daemon/entity/variables.tf
@@ -18,7 +18,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/fluent/bit/variables.tf
+++ b/terraform/eks/daemon/fluent/bit/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/fluent/common/main.tf
+++ b/terraform/eks/daemon/fluent/common/main.tf
@@ -35,6 +35,15 @@ resource "aws_eks_cluster" "cluster" {
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "node_group" {
   cluster_name    = aws_eks_cluster.cluster.name
   node_group_name = "cwagent-eks-integ-node"
@@ -49,8 +58,12 @@ resource "aws_eks_node_group" "node_group" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
@@ -404,6 +417,7 @@ resource "kubernetes_daemonset" "agent_daemon" {
             path = "/dev/disk/"
           }
         }
+        host_network                     = true
         termination_grace_period_seconds = 60
         service_account_name             = "cloudwatch-agent"
       }

--- a/terraform/eks/daemon/fluent/common/variables.tf
+++ b/terraform/eks/daemon/fluent/common/variables.tf
@@ -29,7 +29,7 @@ variable "k8s_version" {
 // ami_type and instance_type can be used to test ARM node group
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/fluent/d/main.tf
+++ b/terraform/eks/daemon/fluent/d/main.tf
@@ -415,6 +415,7 @@ resource "kubernetes_daemonset" "fluentd_daemon" {
       }
       spec {
         service_account_name             = "fluentd"
+        host_network                     = true
         termination_grace_period_seconds = 30
         init_container {
           name    = "copy-fluentd-config"

--- a/terraform/eks/daemon/fluent/d/variables.tf
+++ b/terraform/eks/daemon/fluent/d/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/fluent/windows/2019/variables.tf
+++ b/terraform/eks/daemon/fluent/windows/2019/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/fluent/windows/2022/variables.tf
+++ b/terraform/eks/daemon/fluent/windows/2022/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/fluent/windows/main.tf
+++ b/terraform/eks/daemon/fluent/windows/main.tf
@@ -113,6 +113,15 @@ EOT
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "node_group" {
   cluster_name    = aws_eks_cluster.cluster.name
   node_group_name = "cwagent-eks-integ-node"
@@ -127,8 +136,12 @@ resource "aws_eks_node_group" "node_group" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
@@ -153,8 +166,12 @@ resource "aws_eks_node_group" "node_group_windows" {
 
   ami_type       = var.windows_ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 50
   instance_types = ["t3.large"]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_CloudWatchAgentServerPolicy,
@@ -492,6 +509,7 @@ resource "kubernetes_daemonset" "agent_daemon" {
             path = "/dev/disk/"
           }
         }
+        host_network                     = true
         termination_grace_period_seconds = 60
         service_account_name             = "cloudwatch-agent"
       }

--- a/terraform/eks/daemon/fluent/windows/variables.tf
+++ b/terraform/eks/daemon/fluent/windows/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/gpu/main.tf
+++ b/terraform/eks/daemon/gpu/main.tf
@@ -35,6 +35,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-eks-integ-node"
@@ -49,8 +58,12 @@ resource "aws_eks_node_group" "this" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
@@ -371,6 +384,7 @@ resource "kubernetes_daemonset" "exporter" {
           }
         }
         service_account_name             = "cloudwatch-agent"
+        host_network                     = true
         termination_grace_period_seconds = 60
       }
     }
@@ -571,6 +585,7 @@ resource "kubernetes_daemonset" "service" {
           }
         }
         service_account_name             = "cloudwatch-agent"
+        host_network                     = true
         termination_grace_period_seconds = 60
       }
     }

--- a/terraform/eks/daemon/gpu/variables.tf
+++ b/terraform/eks/daemon/gpu/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64_GPU"
+  default = "AL2023_x86_64_NVIDIA"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/liscsi/main.tf
+++ b/terraform/eks/daemon/liscsi/main.tf
@@ -31,6 +31,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Group
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-liscsi-eks-integ-node-${module.common.testing_id}"
@@ -45,8 +54,12 @@ resource "aws_eks_node_group" "this" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,

--- a/terraform/eks/daemon/liscsi/variables.tf
+++ b/terraform/eks/daemon/liscsi/variables.tf
@@ -33,7 +33,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/main.tf
+++ b/terraform/eks/daemon/main.tf
@@ -35,6 +35,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-eks-integ-node"
@@ -47,10 +56,14 @@ resource "aws_eks_node_group" "this" {
     min_size     = 1
   }
 
-  ami_type       = "AL2_x86_64"
+  ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = ["t3.medium"]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
@@ -312,6 +325,7 @@ resource "kubernetes_daemonset" "service" {
           }
         }
         service_account_name             = "cloudwatch-agent"
+        host_network                     = true
         termination_grace_period_seconds = 60
       }
     }

--- a/terraform/eks/daemon/otel-attr-limit/main.tf
+++ b/terraform/eks/daemon/otel-attr-limit/main.tf
@@ -58,6 +58,15 @@ resource "aws_eks_cluster" "this" {
 
 # --- 3 Node Groups: low, mid, high ---
 
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "low" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-attr-limit-low-${module.common.testing_id}"
@@ -72,8 +81,12 @@ resource "aws_eks_node_group" "low" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
   labels         = local.low_labels
 
   depends_on = [
@@ -97,8 +110,12 @@ resource "aws_eks_node_group" "mid" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
   labels         = local.mid_labels
 
   depends_on = [
@@ -122,8 +139,12 @@ resource "aws_eks_node_group" "high" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
   labels         = local.high_labels
 
   depends_on = [

--- a/terraform/eks/daemon/otel-ebs-csi/main.tf
+++ b/terraform/eks/daemon/otel-ebs-csi/main.tf
@@ -27,6 +27,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Group — 1x t3.medium with node-color=blue label
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-otel-integ-node-${module.common.testing_id}"
@@ -41,8 +50,12 @@ resource "aws_eks_node_group" "this" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   labels = {
     "ci-test.example.com/node-color" = "blue"

--- a/terraform/eks/daemon/otel-efa/main.tf
+++ b/terraform/eks/daemon/otel-efa/main.tf
@@ -74,7 +74,6 @@ resource "aws_eks_node_group" "standard" {
 
   ami_type       = "AL2023_x86_64_STANDARD"
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = ["t3.medium"]
 
   depends_on = [

--- a/terraform/eks/daemon/otel-gpu/main.tf
+++ b/terraform/eks/daemon/otel-gpu/main.tf
@@ -56,6 +56,15 @@ resource "aws_iam_role_policy_attachment" "node_AmazonEC2ContainerRegistryReadOn
 
 # --- Standard Node Group (for operator, CoreDNS, KSM) ---
 
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "standard" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "standard-${module.common.testing_id}"
@@ -70,8 +79,12 @@ resource "aws_eks_node_group" "standard" {
 
   ami_type       = "AL2023_x86_64_STANDARD"
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = ["t3.medium"]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
@@ -97,8 +110,12 @@ resource "aws_eks_node_group" "gpu_single" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   labels = {
     "nvidia.com/gpu.present"         = "true"
@@ -133,8 +150,12 @@ resource "aws_eks_node_group" "gpu_multi" {
 
   ami_type       = "AL2023_x86_64_NVIDIA"
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = ["g4dn.12xlarge"]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   labels = {
     "nvidia.com/gpu.present"         = "true"

--- a/terraform/eks/daemon/otel-lis-csi/main.tf
+++ b/terraform/eks/daemon/otel-lis-csi/main.tf
@@ -27,6 +27,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Group
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-otel-liscsi-integ-node-${module.common.testing_id}"
@@ -41,8 +50,12 @@ resource "aws_eks_node_group" "this" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,

--- a/terraform/eks/daemon/otel-neuron/main.tf
+++ b/terraform/eks/daemon/otel-neuron/main.tf
@@ -29,6 +29,15 @@ resource "aws_eks_cluster" "this" {
 # --- Node Groups ---
 
 # Standard node group (operator/CoreDNS)
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "standard" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-otel-standard-${module.common.testing_id}"
@@ -43,8 +52,12 @@ resource "aws_eks_node_group" "standard" {
 
   ami_type       = "AL2023_x86_64_STANDARD"
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = ["t3.medium"]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
@@ -68,8 +81,12 @@ resource "aws_eks_node_group" "neuron_workload" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 50
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   labels = {
     "aws.amazon.com/neuron.present"  = "true"
@@ -104,8 +121,12 @@ resource "aws_eks_node_group" "neuron_idle" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 50
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   labels = {
     "aws.amazon.com/neuron.present"  = "true"
@@ -152,8 +173,12 @@ resource "aws_eks_node_group" "neuron_multi_device" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 100
   instance_types = [var.multi_device_instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   labels = {
     "aws.amazon.com/neuron.present"  = "true"

--- a/terraform/eks/daemon/otel/main.tf
+++ b/terraform/eks/daemon/otel/main.tf
@@ -27,6 +27,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Group — 2x t3.medium with node-color=blue label
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-otel-integ-node-${module.common.testing_id}"
@@ -41,8 +50,12 @@ resource "aws_eks_node_group" "this" {
 
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   labels = {
     "ci-test.example.com/node-color" = "blue"

--- a/terraform/eks/daemon/statsd/main.tf
+++ b/terraform/eks/daemon/statsd/main.tf
@@ -35,6 +35,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-eks-integ-node"
@@ -47,10 +56,14 @@ resource "aws_eks_node_group" "this" {
     min_size     = 1
   }
 
-  ami_type       = "AL2_x86_64"
+  ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = ["t3.medium"]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
@@ -361,6 +374,7 @@ resource "kubernetes_daemonset" "service" {
           }
         }
         service_account_name             = "cloudwatch-agent"
+        host_network                     = true
         termination_grace_period_seconds = 60
       }
     }

--- a/terraform/eks/daemon/statsd/variables.tf
+++ b/terraform/eks/daemon/statsd/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/variables.tf
+++ b/terraform/eks/daemon/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/windows/2019/variables.tf
+++ b/terraform/eks/daemon/windows/2019/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/windows/2022/variables.tf
+++ b/terraform/eks/daemon/windows/2022/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/daemon/windows/main.tf
+++ b/terraform/eks/daemon/windows/main.tf
@@ -105,6 +105,15 @@ EOT
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-eks-integ-node"
@@ -117,10 +126,14 @@ resource "aws_eks_node_group" "this" {
     min_size     = 1
   }
 
-  ami_type       = "AL2_x86_64"
+  ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = ["t3.medium"]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
@@ -162,8 +175,12 @@ resource "aws_eks_node_group" "node_group_windows" {
 
   ami_type       = var.windows_ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 50
   instance_types = ["t3.large"]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_CloudWatchAgentServerPolicy,
@@ -408,6 +425,7 @@ resource "kubernetes_daemonset" "service" {
           }
         }
         service_account_name             = "cloudwatch-agent"
+        host_network                     = true
         termination_grace_period_seconds = 60
       }
     }

--- a/terraform/eks/daemon/windows/variables.tf
+++ b/terraform/eks/daemon/windows/variables.tf
@@ -28,7 +28,7 @@ variable "k8s_version" {
 
 variable "ami_type" {
   type    = string
-  default = "AL2_x86_64"
+  default = "AL2023_x86_64_STANDARD"
 }
 
 variable "instance_type" {

--- a/terraform/eks/deployment/main.tf
+++ b/terraform/eks/deployment/main.tf
@@ -35,6 +35,15 @@ resource "aws_eks_cluster" "this" {
 }
 
 # EKS Node Groups
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "cwagent-eks-integ-node"
@@ -49,8 +58,12 @@ resource "aws_eks_node_group" "this" {
 
   ami_type       = var.k8s_version >= "1.33" ? "AL2023_x86_64_STANDARD" : "AL2_x86_64"
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = ["t3.medium"]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,

--- a/terraform/eks/e2e/main.tf
+++ b/terraform/eks/e2e/main.tf
@@ -30,6 +30,15 @@ resource "aws_eks_cluster" "this" {
   }
 }
 
+
+resource "aws_launch_template" "node" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "${local.cluster_name}-node"
@@ -42,8 +51,12 @@ resource "aws_eks_node_group" "this" {
   }
   ami_type       = var.ami_type
   capacity_type  = "ON_DEMAND"
-  disk_size      = 20
   instance_types = [var.instance_type]
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
   depends_on = [
     aws_iam_role_policy_attachment.node_CloudWatchAgentServerPolicy,
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,


### PR DESCRIPTION
# Description of the issue

EKS test clusters use deprecated AL2 AMI types which are no longer supported on K8s 1.33+. Additionally, AL2023 managed node groups default to IMDS hop limit 1, blocking pod IMDS access and breaking Container Insights.

# Description of changes

1. **Migrate AMI types to AL2023:**
   - `AL2_x86_64` → `AL2023_x86_64_STANDARD`
   - `AL2_ARM_64` → `AL2023_ARM_64_STANDARD`
   - `AL2_x86_64_GPU` → `AL2023_x86_64_NVIDIA`
   - Updated in: test matrix JSON, generator, all variables.tf defaults
   - Replaced hardcoded ami_type in main.tf with var.ami_type

2. **Fix IMDS access for pods on AL2023:**
   - Added `aws_launch_template` with `http_put_response_hop_limit = 2`
   - Removed `disk_size` from node groups (incompatible with launch templates)

3. **Add host_network = true to daemonset pod specs:**
   - AL2023 hop limit 1 blocks IMDS from pods without hostNetwork
   - Production helm/add-on already sets hostNetwork; test terraform was missing it

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

https://github.com/aws/amazon-cloudwatch-agent/actions/runs/25810039514