### PR TITLE
Add KSM workload tests: StatefulSet, Job, CronJob, ReplicaSet

### DIFF
--- a/terraform/eks/daemon/otel/main.tf
+++ b/terraform/eks/daemon/otel/main.tf
@@ -83,7 +83,6 @@ resource "aws_iam_role_policy_attachment" "node_AmazonEC2ContainerRegistryReadOn
   role       = aws_iam_role.node_role.name
 }
 
-
 # Pod Identity IAM Role
 resource "aws_iam_role" "pod_identity_role" {
   name = "cwagent-otel-pod-identity-${module.common.testing_id}"
@@ -101,6 +100,7 @@ resource "aws_iam_role_policy_attachment" "pod_identity_CloudWatchAgentServerPol
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
   role       = aws_iam_role.pod_identity_role.name
 }
+
 
 # --- EKS Addon: Pod Identity agent ---
 
@@ -211,6 +211,136 @@ resource "kubernetes_deployment_v1" "nginx_test" {
         }
       }
     }
+  }
+}
+
+# --- KSM test workloads ---
+
+resource "kubernetes_stateful_set_v1" "ksm_statefulset" {
+  depends_on = [aws_eks_node_group.this]
+  metadata {
+    name      = "ksm-test-statefulset"
+    namespace = "default"
+  }
+  spec {
+    replicas     = 1
+    service_name = kubernetes_service_v1.ksm_statefulset_headless.metadata[0].name
+    selector { match_labels = { app = "ksm-test-statefulset" } }
+    template {
+      metadata { labels = { app = "ksm-test-statefulset" } }
+      spec {
+        node_selector = { "ci-test.example.com/node-color" = "blue" }
+        container {
+          name  = "pause"
+          image = "registry.k8s.io/pause:3.9"
+          resources { requests = { cpu = "10m", memory = "16Mi" } }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "ksm_statefulset_headless" {
+  metadata {
+    name      = "ksm-test-statefulset"
+    namespace = "default"
+  }
+  spec {
+    cluster_ip = "None"
+    selector   = { app = "ksm-test-statefulset" }
+    port {
+      port = 80
+      name = "placeholder"
+    }
+  }
+}
+
+resource "kubernetes_cron_job_v1" "ksm_cronjob" {
+  depends_on = [aws_eks_node_group.this]
+  metadata {
+    name      = "ksm-test-cronjob"
+    namespace = "default"
+  }
+  spec {
+    schedule                      = "*/5 * * * *"
+    successful_jobs_history_limit = 1
+    failed_jobs_history_limit     = 1
+    job_template {
+      metadata {}
+      spec {
+        template {
+          metadata { labels = { app = "ksm-test-cronjob" } }
+          spec {
+            node_selector  = { "ci-test.example.com/node-color" = "blue" }
+            restart_policy = "Never"
+            container {
+              name    = "echo"
+              image   = "busybox:1.36"
+              command = ["echo", "ksm-test"]
+              resources { requests = { cpu = "10m", memory = "16Mi" } }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_job_v1" "ksm_job" {
+  depends_on = [aws_eks_node_group.this]
+  metadata {
+    name      = "ksm-test-job"
+    namespace = "default"
+  }
+  spec {
+    ttl_seconds_after_finished = 86400
+    template {
+      metadata { labels = { app = "ksm-test-job" } }
+      spec {
+        node_selector  = { "ci-test.example.com/node-color" = "blue" }
+        restart_policy = "Never"
+        container {
+          name    = "echo"
+          image   = "busybox:1.36"
+          command = ["echo", "ksm-test"]
+          resources { requests = { cpu = "10m", memory = "16Mi" } }
+        }
+      }
+    }
+  }
+}
+
+resource "null_resource" "ksm_replicaset" {
+  depends_on = [aws_eks_node_group.this, null_resource.kubectl]
+  provisioner "local-exec" {
+    command = <<-EOT
+      cat <<'EOF' | kubectl apply -f -
+      apiVersion: apps/v1
+      kind: ReplicaSet
+      metadata:
+        name: ksm-test-replicaset
+        namespace: default
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: ksm-test-replicaset
+        template:
+          metadata:
+            labels:
+              app: ksm-test-replicaset
+          spec:
+            nodeSelector:
+              ci-test.example.com/node-color: blue
+            containers:
+            - name: pause
+              image: registry.k8s.io/pause:3.9
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 16Mi
+      EOF
+    EOT
   }
 }
 

--- a/test/otel/standard/k8s_helpers_test.go
+++ b/test/otel/standard/k8s_helpers_test.go
@@ -82,9 +82,11 @@ func buildGroundTruth() (*k8sGroundTruth, error) {
 		pods:  make(map[string]corev1.Pod, len(podList.Items)),
 	}
 	for _, n := range nodeList.Items {
+		n := n
 		gt.nodes[n.Name] = n
 	}
 	for _, p := range podList.Items {
+		p := p
 		gt.pods[p.Namespace+"/"+p.Name] = p
 	}
 	return gt, nil
@@ -94,6 +96,7 @@ func buildGroundTruth() (*k8sGroundTruth, error) {
 func imageTagFromPod(t *testing.T, gt *k8sGroundTruth, namespace, labelKey, labelValue string) string {
 	t.Helper()
 	for _, p := range gt.pods {
+		p := p
 		if p.Namespace != namespace {
 			continue
 		}
@@ -140,6 +143,7 @@ func (gt *k8sGroundTruth) lookupPod(podName, namespace string) (corev1.Pod, bool
 		return p, ok
 	}
 	for _, p := range gt.pods {
+		p := p
 		if p.Name == podName {
 			return p, true
 		}

--- a/test/otel/standard/ksm_test.go
+++ b/test/otel/standard/ksm_test.go
@@ -48,9 +48,9 @@ var ksmWorkloadBucket = struct {
 }{
 	Deployment:  []string{"kube_deployment_status_replicas", "kube_deployment_status_replicas_ready"},
 	DaemonSet:   []string{"kube_daemonset_status_desired_number_scheduled"},
-	StatefulSet: []string{},
-	Job:         []string{},
-	CronJob:     []string{},
+	StatefulSet: []string{"kube_statefulset_replicas", "kube_statefulset_status_replicas_ready"},
+	Job:         []string{"kube_job_status_active"},
+	CronJob:     []string{"kube_cronjob_status_active"},
 }
 
 func ksmWorkloadMetrics() []string {
@@ -119,8 +119,11 @@ func parseAZFromProviderID(providerID string) (string, error) {
 // =============================================================================
 
 func TestKSM_AllBuckets_MetricExists(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range allKSMBucketMetrics() {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
@@ -129,12 +132,16 @@ func TestKSM_AllBuckets_MetricExists(t *testing.T) {
 }
 
 func TestKSM_AllBuckets_InstrumentationSource(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range allKSMBucketMetrics() {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				name, ok := r.Labels.Instrumentation["@name"]
 				require.True(t, ok, "%s missing @instrumentation.@name", metricName)
 				require.Equal(t, "github.com/kubernetes/kube-state-metrics", name, "%s", metricName)
@@ -144,12 +151,16 @@ func TestKSM_AllBuckets_InstrumentationSource(t *testing.T) {
 }
 
 func TestKSM_AllBuckets_InstrumentationVersion(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range allKSMBucketMetrics() {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				version, ok := r.Labels.Instrumentation["@version"]
 				require.True(t, ok, "%s missing @instrumentation.@version", metricName)
 				require.True(t, version != "", "%s has empty @instrumentation.@version", metricName)
@@ -159,12 +170,16 @@ func TestKSM_AllBuckets_InstrumentationVersion(t *testing.T) {
 }
 
 func TestKSM_AllBuckets_InstrumentationPipeline(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range allKSMBucketMetrics() {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				pipeline, ok := r.Labels.Instrumentation["cloudwatch.pipeline"]
 				require.True(t, ok, "%s missing @instrumentation.cloudwatch.pipeline", metricName)
 				require.Equal(t, "kube-state-metrics", pipeline, "%s cloudwatch.pipeline", metricName)
@@ -174,12 +189,16 @@ func TestKSM_AllBuckets_InstrumentationPipeline(t *testing.T) {
 }
 
 func TestKSM_AllBuckets_ClusterName(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range allKSMBucketMetrics() {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				require.Equal(t, cfg.ClusterName, r.Labels.Resource["k8s.cluster.name"], "%s", metricName)
 			}
 		})
@@ -187,12 +206,16 @@ func TestKSM_AllBuckets_ClusterName(t *testing.T) {
 }
 
 func TestKSM_AllBuckets_NoComponentLabel(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range allKSMBucketMetrics() {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				_, has := r.Labels.Resource["k8s.component.name"]
 				require.True(t, !has, "%s should not have k8s.component.name", metricName)
 			}
@@ -205,12 +228,16 @@ func TestKSM_AllBuckets_NoComponentLabel(t *testing.T) {
 // =============================================================================
 
 func TestKSM_NodeBucket_HasNodeName(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmNodeBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				val, ok := r.Labels.Resource["k8s.node.name"]
 				require.True(t, ok, "%s missing k8s.node.name", metricName)
 				require.True(t, val != "", "%s has empty k8s.node.name", metricName)
@@ -220,14 +247,19 @@ func TestKSM_NodeBucket_HasNodeName(t *testing.T) {
 }
 
 func TestKSM_NodeBucket_HasHostAttributes(t *testing.T) {
+	t.Parallel()
 	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
 	for _, metricName := range ksmNodeBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				for _, attr := range hostAttrs {
+					attr := attr
 					val, ok := r.Labels.Resource[attr]
 					require.True(t, ok, "%s missing %s", metricName, attr)
 					require.True(t, val != "", "%s has empty %s", metricName, attr)
@@ -238,12 +270,16 @@ func TestKSM_NodeBucket_HasHostAttributes(t *testing.T) {
 }
 
 func TestKSM_NodeBucket_HostImageIDStartsWithAMI(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmNodeBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				imageID := r.Labels.Resource["host.image.id"]
 				require.True(t, strings.HasPrefix(imageID, "ami-"),
 					"%s host.image.id=%s should start with ami-", metricName, imageID)
@@ -253,13 +289,17 @@ func TestKSM_NodeBucket_HostImageIDStartsWithAMI(t *testing.T) {
 }
 
 func TestKSM_NodeBucket_AZMatchesProviderID(t *testing.T) {
+	t.Parallel()
 	gt := getGroundTruth(t)
 	for _, metricName := range ksmNodeBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				nodeName := r.Labels.Resource["k8s.node.name"]
 				az := r.Labels.Resource["cloud.availability_zone"]
 				if nodeName == "" || az == "" {
@@ -280,13 +320,17 @@ func TestKSM_NodeBucket_AZMatchesProviderID(t *testing.T) {
 }
 
 func TestKSM_NodeBucket_HasNodeLabels(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmNodeBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			hasNodeLabel := false
 			for _, r := range results {
+				r := r
 				for key := range r.Labels.Resource {
 					if strings.HasPrefix(key, "k8s.node.label.") {
 						hasNodeLabel = true
@@ -303,11 +347,15 @@ func TestKSM_NodeBucket_HasNodeLabels(t *testing.T) {
 }
 
 func TestKSM_NodeBucket_NoPodAttributes(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmNodeBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				_, has := r.Labels.Resource["k8s.pod.name"]
 				require.True(t, !has, "%s should not have k8s.pod.name", metricName)
 			}
@@ -316,11 +364,15 @@ func TestKSM_NodeBucket_NoPodAttributes(t *testing.T) {
 }
 
 func TestKSM_NodeBucket_NoWorkloadIdentity(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmNodeBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				_, hasName := r.Labels.Resource["k8s.workload.name"]
 				require.True(t, !hasName, "%s should not have k8s.workload.name", metricName)
 				_, hasType := r.Labels.Resource["k8s.workload.type"]
@@ -335,14 +387,19 @@ func TestKSM_NodeBucket_NoWorkloadIdentity(t *testing.T) {
 // =============================================================================
 
 func TestKSM_PodBucket_HasPodIdentity(t *testing.T) {
+	t.Parallel()
 	requiredAttrs := []string{"k8s.pod.name", "k8s.namespace.name", "k8s.pod.uid"}
 	for _, metricName := range ksmPodBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				for _, attr := range requiredAttrs {
+					attr := attr
 					val, ok := r.Labels.Resource[attr]
 					require.True(t, ok, "%s missing %s", metricName, attr)
 					require.True(t, val != "", "%s has empty %s", metricName, attr)
@@ -353,13 +410,17 @@ func TestKSM_PodBucket_HasPodIdentity(t *testing.T) {
 }
 
 func TestKSM_PodBucket_HasNodeName(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmPodBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			hasNodeName := false
 			for _, r := range results {
+				r := r
 				if val, ok := r.Labels.Resource["k8s.node.name"]; ok && val != "" {
 					hasNodeName = true
 					break
@@ -371,17 +432,22 @@ func TestKSM_PodBucket_HasNodeName(t *testing.T) {
 }
 
 func TestKSM_PodBucket_HasHostAttributes(t *testing.T) {
+	t.Parallel()
 	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
 	for _, metricName := range ksmPodBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			hasHost := false
 			for _, r := range results {
+				r := r
 				if _, ok := r.Labels.Resource["host.id"]; ok {
 					hasHost = true
 					for _, attr := range hostAttrs {
+						attr := attr
 						val := r.Labels.Resource[attr]
 						require.True(t, val != "", "%s has empty %s", metricName, attr)
 					}
@@ -393,13 +459,17 @@ func TestKSM_PodBucket_HasHostAttributes(t *testing.T) {
 }
 
 func TestKSM_PodBucket_HasCloudAZ(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmPodBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			hasAZ := false
 			for _, r := range results {
+				r := r
 				if az, ok := r.Labels.Resource["cloud.availability_zone"]; ok && az != "" {
 					hasAZ = true
 					break
@@ -411,13 +481,17 @@ func TestKSM_PodBucket_HasCloudAZ(t *testing.T) {
 }
 
 func TestKSM_PodBucket_HasWorkloadIdentity(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmPodBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			workloadCount := 0
 			for _, r := range results {
+				r := r
 				if wn, ok := r.Labels.Resource["k8s.workload.name"]; ok && wn != "" {
 					workloadCount++
 					wt := r.Labels.Resource["k8s.workload.type"]
@@ -430,18 +504,23 @@ func TestKSM_PodBucket_HasWorkloadIdentity(t *testing.T) {
 }
 
 func TestKSM_PodBucket_HasSpecificWorkloadTypeAttr(t *testing.T) {
+	t.Parallel()
 	workloadAttrs := []string{
 		"k8s.deployment.name", "k8s.statefulset.name", "k8s.daemonset.name",
 		"k8s.replicaset.name", "k8s.job.name", "k8s.cronjob.name",
 	}
 	for _, metricName := range ksmPodBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			hasSpecific := false
 			for _, r := range results {
+				r := r
 				for _, attr := range workloadAttrs {
+					attr := attr
 					if val, ok := r.Labels.Resource[attr]; ok && val != "" {
 						hasSpecific = true
 						break
@@ -457,8 +536,11 @@ func TestKSM_PodBucket_HasSpecificWorkloadTypeAttr(t *testing.T) {
 }
 
 func TestKSM_PodBucket_NginxDeploymentName(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmPodBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			promql := fmt.Sprintf(`%s{"@resource.k8s.cluster.name"="%s","@resource.k8s.pod.name"=~"nginx-test.*"}`,
 				metricName, cfg.ClusterName)
@@ -466,25 +548,27 @@ func TestKSM_PodBucket_NginxDeploymentName(t *testing.T) {
 			require.NoError(t, err, "querying %s for nginx-test", metricName)
 			require.True(t, len(results) > 0, "No %s results from nginx-test pods", metricName)
 			for _, r := range results {
-				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.deployment.name"],
-					"%s nginx-test pod k8s.deployment.name", metricName)
-				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.workload.name"],
-					"%s nginx-test pod k8s.workload.name", metricName)
-				require.Equal(t, "Deployment", r.Labels.Resource["k8s.workload.type"],
-					"%s nginx-test pod k8s.workload.type", metricName)
+				r := r
+				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.deployment.name"], "%s nginx-test pod k8s.deployment.name", metricName)
+				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.workload.name"], "%s nginx-test pod k8s.workload.name", metricName)
+				require.Equal(t, "Deployment", r.Labels.Resource["k8s.workload.type"], "%s nginx-test pod k8s.workload.type", metricName)
 			}
 		})
 	}
 }
 
 func TestKSM_PodBucket_HasNodeLabels(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmPodBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			hasNodeLabel := false
 			for _, r := range results {
+				r := r
 				for key := range r.Labels.Resource {
 					if strings.HasPrefix(key, "k8s.node.label.") {
 						hasNodeLabel = true
@@ -501,13 +585,17 @@ func TestKSM_PodBucket_HasNodeLabels(t *testing.T) {
 }
 
 func TestKSM_PodBucket_HasPodLabels(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmPodBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			hasPodLabel := false
 			for _, r := range results {
+				r := r
 				for key := range r.Labels.Resource {
 					if strings.HasPrefix(key, "k8s.pod.label.") {
 						hasPodLabel = true
@@ -524,18 +612,120 @@ func TestKSM_PodBucket_HasPodLabels(t *testing.T) {
 }
 
 func TestKSM_PodBucket_HasRawGroupByLabels(t *testing.T) {
+	t.Parallel()
 	rawKeys := []string{"pod", "namespace", "uid"}
 	for _, metricName := range ksmPodBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				for _, key := range rawKeys {
+					key := key
 					val, has := r.Labels.Datapoint[key]
 					require.True(t, has, "%s missing raw '%s' label at datapoint scope", metricName, key)
 					require.True(t, val != "", "%s has empty raw '%s' label at datapoint scope", metricName, key)
 				}
+			}
+		})
+	}
+}
+
+// Validate k8s.statefulset.name on ksm-test-statefulset pods.
+func TestKSM_PodBucket_StatefulSetPodName(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmPodBucket {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			promql := fmt.Sprintf(`%s{"@resource.k8s.cluster.name"="%s","@resource.k8s.pod.name"=~"ksm-test-statefulset.*"}`,
+				metricName, cfg.ClusterName)
+			results, err := client.Query(context.Background(), promql)
+			require.NoError(t, err, "querying %s for ksm-test-statefulset", metricName)
+			require.True(t, len(results) > 0, "No %s results from ksm-test-statefulset pods", metricName)
+			for _, r := range results {
+				r := r
+				require.Equal(t, "ksm-test-statefulset", r.Labels.Resource["k8s.statefulset.name"], "%s k8s.statefulset.name", metricName)
+				require.Equal(t, "ksm-test-statefulset", r.Labels.Resource["k8s.workload.name"], "%s k8s.workload.name", metricName)
+				require.Equal(t, "StatefulSet", r.Labels.Resource["k8s.workload.type"], "%s k8s.workload.type", metricName)
+			}
+		})
+	}
+}
+
+// Validate k8s.job.name on ksm-test-job pods.
+func TestKSM_PodBucket_JobPodName(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmPodBucket {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			promql := fmt.Sprintf(`%s{"@resource.k8s.cluster.name"="%s","@resource.k8s.pod.name"=~"ksm-test-job.*"}`,
+				metricName, cfg.ClusterName)
+			results, err := client.Query(context.Background(), promql)
+			require.NoError(t, err, "querying %s for ksm-test-job", metricName)
+			require.True(t, len(results) > 0, "No %s results from ksm-test-job pods", metricName)
+			for _, r := range results {
+				r := r
+				val, ok := r.Labels.Resource["k8s.job.name"]
+				require.True(t, ok && val != "", "%s ksm-test-job pod missing k8s.job.name", metricName)
+				require.Equal(t, "Job", r.Labels.Resource["k8s.workload.type"], "%s k8s.workload.type", metricName)
+			}
+		})
+	}
+}
+
+// Validate k8s.cronjob.name on ksm-test-cronjob pods.
+func TestKSM_PodBucket_CronJobPodName(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmPodBucket {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			promql := fmt.Sprintf(`%s{"@resource.k8s.cluster.name"="%s","@resource.k8s.pod.name"=~"ksm-test-cronjob.*"}`,
+				metricName, cfg.ClusterName)
+			results, err := client.Query(context.Background(), promql)
+			require.NoError(t, err, "querying %s for ksm-test-cronjob", metricName)
+			if len(results) == 0 {
+				t.Skipf("No %s results from ksm-test-cronjob pods (may have been cleaned up)", metricName)
+			}
+			for _, r := range results {
+				r := r
+				val, ok := r.Labels.Resource["k8s.cronjob.name"]
+				require.True(t, ok && val != "", "%s ksm-test-cronjob pod missing k8s.cronjob.name", metricName)
+				require.Equal(t, "ksm-test-cronjob", val, "%s k8s.cronjob.name", metricName)
+				wt := r.Labels.Resource["k8s.workload.type"]
+				require.True(t, wt == "Job" || wt == "CronJob",
+					"%s k8s.workload.type: got %s, want Job or CronJob", metricName, wt)
+			}
+		})
+	}
+}
+
+// Validate k8s.replicaset.name on standalone ksm-test-replicaset pods (no Deployment parent).
+func TestKSM_PodBucket_ReplicaSetPodName(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmPodBucket {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			promql := fmt.Sprintf(`%s{"@resource.k8s.cluster.name"="%s","@resource.k8s.pod.name"=~"ksm-test-replicaset.*"}`,
+				metricName, cfg.ClusterName)
+			results, err := client.Query(context.Background(), promql)
+			require.NoError(t, err, "querying %s for ksm-test-replicaset", metricName)
+			require.True(t, len(results) > 0, "No %s results from ksm-test-replicaset pods", metricName)
+			for _, r := range results {
+				r := r
+				val, ok := r.Labels.Resource["k8s.replicaset.name"]
+				require.True(t, ok && val != "", "%s ksm-test-replicaset pod missing k8s.replicaset.name", metricName)
+				require.Equal(t, "ksm-test-replicaset", r.Labels.Resource["k8s.workload.name"], "%s k8s.workload.name", metricName)
+				require.Equal(t, "ReplicaSet", r.Labels.Resource["k8s.workload.type"], "%s k8s.workload.type", metricName)
+				_, hasDeploy := r.Labels.Resource["k8s.deployment.name"]
+				require.True(t, !hasDeploy,
+					"%s standalone ReplicaSet should NOT have k8s.deployment.name", metricName)
 			}
 		})
 	}
@@ -546,14 +736,19 @@ func TestKSM_PodBucket_HasRawGroupByLabels(t *testing.T) {
 // =============================================================================
 
 func TestKSM_ContainerBucket_HasRawGroupByLabels(t *testing.T) {
+	t.Parallel()
 	rawKeys := []string{"pod", "namespace", "uid", "container"}
 	for _, metricName := range ksmContainerBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				for _, key := range rawKeys {
+					key := key
 					val, has := r.Labels.Datapoint[key]
 					require.True(t, has, "%s missing raw '%s' label at datapoint scope", metricName, key)
 					require.True(t, val != "", "%s has empty raw '%s' label at datapoint scope", metricName, key)
@@ -564,12 +759,16 @@ func TestKSM_ContainerBucket_HasRawGroupByLabels(t *testing.T) {
 }
 
 func TestKSM_ContainerBucket_HasContainerName(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmContainerBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				val, ok := r.Labels.Resource["k8s.container.name"]
 				require.True(t, ok, "%s missing k8s.container.name", metricName)
 				require.True(t, val != "", "%s has empty k8s.container.name", metricName)
@@ -579,14 +778,19 @@ func TestKSM_ContainerBucket_HasContainerName(t *testing.T) {
 }
 
 func TestKSM_ContainerBucket_HasPodIdentity(t *testing.T) {
+	t.Parallel()
 	requiredAttrs := []string{"k8s.pod.name", "k8s.namespace.name"}
 	for _, metricName := range ksmContainerBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				for _, attr := range requiredAttrs {
+					attr := attr
 					val, ok := r.Labels.Resource[attr]
 					require.True(t, ok, "%s missing %s", metricName, attr)
 					require.True(t, val != "", "%s has empty %s", metricName, attr)
@@ -597,17 +801,22 @@ func TestKSM_ContainerBucket_HasPodIdentity(t *testing.T) {
 }
 
 func TestKSM_ContainerBucket_HasHostAttributes(t *testing.T) {
+	t.Parallel()
 	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
 	for _, metricName := range ksmContainerBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			hasHost := false
 			for _, r := range results {
+				r := r
 				if _, ok := r.Labels.Resource["host.id"]; ok {
 					hasHost = true
 					for _, attr := range hostAttrs {
+						attr := attr
 						val := r.Labels.Resource[attr]
 						require.True(t, val != "", "%s has empty %s", metricName, attr)
 					}
@@ -619,13 +828,17 @@ func TestKSM_ContainerBucket_HasHostAttributes(t *testing.T) {
 }
 
 func TestKSM_ContainerBucket_HasCloudAZ(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmContainerBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			hasAZ := false
 			for _, r := range results {
+				r := r
 				if az, ok := r.Labels.Resource["cloud.availability_zone"]; ok && az != "" {
 					hasAZ = true
 					break
@@ -637,13 +850,17 @@ func TestKSM_ContainerBucket_HasCloudAZ(t *testing.T) {
 }
 
 func TestKSM_ContainerBucket_HasNodeLabels(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmContainerBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			hasNodeLabel := false
 			for _, r := range results {
+				r := r
 				for key := range r.Labels.Resource {
 					if strings.HasPrefix(key, "k8s.node.label.") {
 						hasNodeLabel = true
@@ -660,12 +877,16 @@ func TestKSM_ContainerBucket_HasNodeLabels(t *testing.T) {
 }
 
 func TestKSM_ContainerBucket_HasRawContainerLabel(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmContainerBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				val, has := r.Labels.Datapoint["container"]
 				require.True(t, has, "%s missing raw 'container' label at datapoint scope", metricName)
 				require.True(t, val != "", "%s has empty raw 'container' label", metricName)
@@ -675,13 +896,17 @@ func TestKSM_ContainerBucket_HasRawContainerLabel(t *testing.T) {
 }
 
 func TestKSM_ContainerBucket_HasNodeName(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmContainerBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			hasNodeName := false
 			for _, r := range results {
+				r := r
 				if val, ok := r.Labels.Resource["k8s.node.name"]; ok && val != "" {
 					hasNodeName = true
 					break
@@ -693,13 +918,17 @@ func TestKSM_ContainerBucket_HasNodeName(t *testing.T) {
 }
 
 func TestKSM_ContainerBucket_HasPodLabels(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmContainerBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			hasPodLabel := false
 			for _, r := range results {
+				r := r
 				for key := range r.Labels.Resource {
 					if strings.HasPrefix(key, "k8s.pod.label.") {
 						hasPodLabel = true
@@ -716,13 +945,17 @@ func TestKSM_ContainerBucket_HasPodLabels(t *testing.T) {
 }
 
 func TestKSM_ContainerBucket_HasWorkloadIdentity(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmContainerBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			workloadCount := 0
 			for _, r := range results {
+				r := r
 				if wn, ok := r.Labels.Resource["k8s.workload.name"]; ok && wn != "" {
 					workloadCount++
 					wt := r.Labels.Resource["k8s.workload.type"]
@@ -735,18 +968,23 @@ func TestKSM_ContainerBucket_HasWorkloadIdentity(t *testing.T) {
 }
 
 func TestKSM_ContainerBucket_HasSpecificWorkloadTypeAttr(t *testing.T) {
+	t.Parallel()
 	workloadAttrs := []string{
 		"k8s.deployment.name", "k8s.statefulset.name", "k8s.daemonset.name",
 		"k8s.replicaset.name", "k8s.job.name", "k8s.cronjob.name",
 	}
 	for _, metricName := range ksmContainerBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			hasSpecific := false
 			for _, r := range results {
+				r := r
 				for _, attr := range workloadAttrs {
+					attr := attr
 					if val, ok := r.Labels.Resource[attr]; ok && val != "" {
 						hasSpecific = true
 						break
@@ -762,8 +1000,11 @@ func TestKSM_ContainerBucket_HasSpecificWorkloadTypeAttr(t *testing.T) {
 }
 
 func TestKSM_ContainerBucket_NginxDeploymentName(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmContainerBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			promql := fmt.Sprintf(`%s{"@resource.k8s.cluster.name"="%s","@resource.k8s.pod.name"=~"nginx-test.*"}`,
 				metricName, cfg.ClusterName)
@@ -771,14 +1012,11 @@ func TestKSM_ContainerBucket_NginxDeploymentName(t *testing.T) {
 			require.NoError(t, err, "querying %s for nginx-test", metricName)
 			require.True(t, len(results) > 0, "No %s results from nginx-test pods", metricName)
 			for _, r := range results {
-				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.deployment.name"],
-					"%s nginx-test container k8s.deployment.name", metricName)
-				require.Equal(t, "nginx", r.Labels.Resource["k8s.container.name"],
-					"%s nginx-test container k8s.container.name", metricName)
-				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.workload.name"],
-					"%s nginx-test container k8s.workload.name", metricName)
-				require.Equal(t, "Deployment", r.Labels.Resource["k8s.workload.type"],
-					"%s nginx-test container k8s.workload.type", metricName)
+				r := r
+				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.deployment.name"], "%s nginx-test container k8s.deployment.name", metricName)
+				require.Equal(t, "nginx", r.Labels.Resource["k8s.container.name"], "%s nginx-test container k8s.container.name", metricName)
+				require.Equal(t, "nginx-test", r.Labels.Resource["k8s.workload.name"], "%s nginx-test container k8s.workload.name", metricName)
+				require.Equal(t, "Deployment", r.Labels.Resource["k8s.workload.type"], "%s nginx-test container k8s.workload.type", metricName)
 			}
 		})
 	}
@@ -791,12 +1029,16 @@ func TestKSM_ContainerBucket_NginxDeploymentName(t *testing.T) {
 // --- Deployment ---
 
 func TestKSM_WorkloadBucket_Deployment_HasDeploymentName(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmWorkloadBucket.Deployment {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				val, ok := r.Labels.Resource["k8s.deployment.name"]
 				require.True(t, ok, "%s missing k8s.deployment.name", metricName)
 				require.True(t, val != "", "%s has empty k8s.deployment.name", metricName)
@@ -806,12 +1048,16 @@ func TestKSM_WorkloadBucket_Deployment_HasDeploymentName(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_Deployment_HasNamespace(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmWorkloadBucket.Deployment {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				val, ok := r.Labels.Resource["k8s.namespace.name"]
 				require.True(t, ok, "%s missing k8s.namespace.name", metricName)
 				require.True(t, val != "", "%s has empty k8s.namespace.name", metricName)
@@ -821,12 +1067,16 @@ func TestKSM_WorkloadBucket_Deployment_HasNamespace(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_Deployment_HasWorkloadIdentity(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmWorkloadBucket.Deployment {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				wn := r.Labels.Resource["k8s.workload.name"]
 				wt := r.Labels.Resource["k8s.workload.type"]
 				require.True(t, wn != "", "%s missing k8s.workload.name", metricName)
@@ -837,11 +1087,15 @@ func TestKSM_WorkloadBucket_Deployment_HasWorkloadIdentity(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_Deployment_NoNodeName(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmWorkloadBucket.Deployment {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				_, has := r.Labels.Resource["k8s.node.name"]
 				require.True(t, !has, "%s should NOT have k8s.node.name", metricName)
 			}
@@ -850,13 +1104,18 @@ func TestKSM_WorkloadBucket_Deployment_NoNodeName(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_Deployment_NoHostAttributes(t *testing.T) {
+	t.Parallel()
 	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
 	for _, metricName := range ksmWorkloadBucket.Deployment {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				for _, attr := range hostAttrs {
+					attr := attr
 					_, has := r.Labels.Resource[attr]
 					require.True(t, !has, "%s should NOT have %s", metricName, attr)
 				}
@@ -866,13 +1125,18 @@ func TestKSM_WorkloadBucket_Deployment_NoHostAttributes(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_Deployment_NoCrossContamination(t *testing.T) {
+	t.Parallel()
 	wrongAttrs := []string{"k8s.statefulset.name", "k8s.daemonset.name", "k8s.job.name", "k8s.cronjob.name"}
 	for _, metricName := range ksmWorkloadBucket.Deployment {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				for _, attr := range wrongAttrs {
+					attr := attr
 					_, has := r.Labels.Resource[attr]
 					require.True(t, !has, "%s should NOT have %s", metricName, attr)
 				}
@@ -882,12 +1146,16 @@ func TestKSM_WorkloadBucket_Deployment_NoCrossContamination(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_Deployment_HasRawDeploymentLabel(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmWorkloadBucket.Deployment {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				val, has := r.Labels.Datapoint["deployment"]
 				require.True(t, has, "%s missing raw 'deployment' label at datapoint scope", metricName)
 				require.True(t, val != "", "%s has empty raw 'deployment' label", metricName)
@@ -897,11 +1165,15 @@ func TestKSM_WorkloadBucket_Deployment_HasRawDeploymentLabel(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_Deployment_NoNodeLabels(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmWorkloadBucket.Deployment {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				for key := range r.Labels.Resource {
 					if strings.HasPrefix(key, "k8s.node.label.") {
 						t.Fatalf("%s should NOT have node labels, found %s", metricName, key)
@@ -915,12 +1187,16 @@ func TestKSM_WorkloadBucket_Deployment_NoNodeLabels(t *testing.T) {
 // --- DaemonSet ---
 
 func TestKSM_WorkloadBucket_DaemonSet_HasDaemonSetName(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				val, ok := r.Labels.Resource["k8s.daemonset.name"]
 				require.True(t, ok, "%s missing k8s.daemonset.name", metricName)
 				require.True(t, val != "", "%s has empty k8s.daemonset.name", metricName)
@@ -930,12 +1206,16 @@ func TestKSM_WorkloadBucket_DaemonSet_HasDaemonSetName(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_DaemonSet_HasNamespace(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				val, ok := r.Labels.Resource["k8s.namespace.name"]
 				require.True(t, ok, "%s missing k8s.namespace.name", metricName)
 				require.True(t, val != "", "%s has empty k8s.namespace.name", metricName)
@@ -945,12 +1225,16 @@ func TestKSM_WorkloadBucket_DaemonSet_HasNamespace(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_DaemonSet_HasWorkloadIdentity(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				wn := r.Labels.Resource["k8s.workload.name"]
 				wt := r.Labels.Resource["k8s.workload.type"]
 				require.True(t, wn != "", "%s missing k8s.workload.name", metricName)
@@ -961,11 +1245,15 @@ func TestKSM_WorkloadBucket_DaemonSet_HasWorkloadIdentity(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_DaemonSet_NoNodeName(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				_, has := r.Labels.Resource["k8s.node.name"]
 				require.True(t, !has, "%s should NOT have k8s.node.name", metricName)
 			}
@@ -974,13 +1262,18 @@ func TestKSM_WorkloadBucket_DaemonSet_NoNodeName(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_DaemonSet_NoCrossContamination(t *testing.T) {
+	t.Parallel()
 	wrongAttrs := []string{"k8s.deployment.name", "k8s.statefulset.name", "k8s.job.name", "k8s.cronjob.name"}
 	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				for _, attr := range wrongAttrs {
+					attr := attr
 					_, has := r.Labels.Resource[attr]
 					require.True(t, !has, "%s should NOT have %s", metricName, attr)
 				}
@@ -990,13 +1283,18 @@ func TestKSM_WorkloadBucket_DaemonSet_NoCrossContamination(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_DaemonSet_NoHostAttributes(t *testing.T) {
+	t.Parallel()
 	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
 	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				for _, attr := range hostAttrs {
+					attr := attr
 					_, has := r.Labels.Resource[attr]
 					require.True(t, !has, "%s should NOT have %s (workloads span multiple nodes)", metricName, attr)
 				}
@@ -1006,12 +1304,16 @@ func TestKSM_WorkloadBucket_DaemonSet_NoHostAttributes(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_DaemonSet_HasRawDaemonSetLabel(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				val, has := r.Labels.Datapoint["daemonset"]
 				require.True(t, has, "%s missing raw 'daemonset' label at datapoint scope", metricName)
 				require.True(t, val != "", "%s has empty raw 'daemonset' label", metricName)
@@ -1021,11 +1323,15 @@ func TestKSM_WorkloadBucket_DaemonSet_HasRawDaemonSetLabel(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_DaemonSet_NoNodeLabels(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmWorkloadBucket.DaemonSet {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				for key := range r.Labels.Resource {
 					if strings.HasPrefix(key, "k8s.node.label.") {
 						t.Fatalf("%s should NOT have node labels, found %s", metricName, key)
@@ -1036,17 +1342,144 @@ func TestKSM_WorkloadBucket_DaemonSet_NoNodeLabels(t *testing.T) {
 	}
 }
 
+// --- StatefulSet workload tests ---
+
+func TestKSM_WorkloadBucket_StatefulSet_HasName(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.StatefulSet {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			found := false
+			for _, r := range results {
+				r := r
+				if r.Labels.Datapoint["statefulset"] == "ksm-test-statefulset" {
+					found = true
+				}
+			}
+			require.True(t, found, "%s should have ksm-test-statefulset", metricName)
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_StatefulSet_HasNamespace(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.StatefulSet {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				r := r
+				val, ok := r.Labels.Resource["k8s.namespace.name"]
+				require.True(t, ok && val != "", "%s missing k8s.namespace.name", metricName)
+			}
+		})
+	}
+}
+
+// --- Job workload tests ---
+
+func TestKSM_WorkloadBucket_Job_HasName(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.Job {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			found := false
+			for _, r := range results {
+				r := r
+				if r.Labels.Datapoint["job_name"] == "ksm-test-job" {
+					found = true
+				}
+			}
+			require.True(t, found, "%s should have ksm-test-job", metricName)
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Job_HasNamespace(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.Job {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				r := r
+				val, ok := r.Labels.Resource["k8s.namespace.name"]
+				require.True(t, ok && val != "", "%s missing k8s.namespace.name", metricName)
+			}
+		})
+	}
+}
+
+// --- CronJob workload tests ---
+
+func TestKSM_WorkloadBucket_CronJob_HasName(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.CronJob {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			found := false
+			for _, r := range results {
+				r := r
+				if r.Labels.Datapoint["cronjob"] == "ksm-test-cronjob" {
+					found = true
+				}
+			}
+			require.True(t, found, "%s should have ksm-test-cronjob", metricName)
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_CronJob_HasNamespace(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.CronJob {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				r := r
+				val, ok := r.Labels.Resource["k8s.namespace.name"]
+				require.True(t, ok && val != "", "%s missing k8s.namespace.name", metricName)
+			}
+		})
+	}
+}
+
 // =============================================================================
 // BUCKET 5: CLUSTER-SCOPED METRICS
 // =============================================================================
 
 func TestKSM_ClusterBucket_HasNamespace(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmClusterBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				val, ok := r.Labels.Resource["k8s.namespace.name"]
 				require.True(t, ok, "%s missing k8s.namespace.name", metricName)
 				require.True(t, val != "", "%s has empty k8s.namespace.name", metricName)
@@ -1056,11 +1489,15 @@ func TestKSM_ClusterBucket_HasNamespace(t *testing.T) {
 }
 
 func TestKSM_ClusterBucket_NoNodeName(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmClusterBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				_, has := r.Labels.Resource["k8s.node.name"]
 				require.True(t, !has, "%s should NOT have k8s.node.name", metricName)
 			}
@@ -1069,13 +1506,18 @@ func TestKSM_ClusterBucket_NoNodeName(t *testing.T) {
 }
 
 func TestKSM_ClusterBucket_NoHostAttributes(t *testing.T) {
+	t.Parallel()
 	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
 	for _, metricName := range ksmClusterBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				for _, attr := range hostAttrs {
+					attr := attr
 					_, has := r.Labels.Resource[attr]
 					require.True(t, !has, "%s should NOT have %s", metricName, attr)
 				}
@@ -1085,11 +1527,15 @@ func TestKSM_ClusterBucket_NoHostAttributes(t *testing.T) {
 }
 
 func TestKSM_ClusterBucket_NoWorkloadIdentity(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmClusterBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				_, has := r.Labels.Resource["k8s.workload.name"]
 				require.True(t, !has, "%s should NOT have k8s.workload.name", metricName)
 			}
@@ -1098,11 +1544,15 @@ func TestKSM_ClusterBucket_NoWorkloadIdentity(t *testing.T) {
 }
 
 func TestKSM_ClusterBucket_NoNodeLabels(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmClusterBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				for key := range r.Labels.Resource {
 					if strings.HasPrefix(key, "k8s.node.label.") {
 						t.Fatalf("%s should NOT have node labels, found %s", metricName, key)
@@ -1118,6 +1568,7 @@ func TestKSM_ClusterBucket_NoNodeLabels(t *testing.T) {
 // =============================================================================
 
 func TestKSM_LeaseExistence(t *testing.T) {
+	t.Parallel()
 	gt := getGroundTruth(t)
 
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -1136,6 +1587,7 @@ func TestKSM_LeaseExistence(t *testing.T) {
 
 	leaseByNode := make(map[string]bool)
 	for _, lease := range leases.Items {
+		lease := lease
 		if strings.HasPrefix(lease.Name, "cwagent-node-metadata-") {
 			nodeName := strings.TrimPrefix(lease.Name, "cwagent-node-metadata-")
 			leaseByNode[nodeName] = true
@@ -1148,6 +1600,7 @@ func TestKSM_LeaseExistence(t *testing.T) {
 				"cwagent.amazonaws.com/host.image.id",
 				"cwagent.amazonaws.com/cloud.availability_zone",
 			} {
+				key := key
 				val, ok := annotations[key]
 				require.True(t, ok, "Lease %s missing %s", lease.Name, key)
 				require.True(t, val != "", "Lease %s has empty %s", lease.Name, key)
@@ -1168,16 +1621,21 @@ func TestKSM_LeaseExistence(t *testing.T) {
 // =============================================================================
 
 func TestKSM_AllBuckets_ExpectedLabels(t *testing.T) {
+	t.Parallel()
 	for _, md := range allKSMMetricDefs {
+		md := md
 		if len(md.ExpectedLabels) == 0 {
 			continue
 		}
 		for _, label := range md.ExpectedLabels {
+			label := label
 			t.Run(md.Name+"/"+label, func(t *testing.T) {
+				t.Parallel()
 				results, err := queryCache.Get(context.Background(), md.Name)
 				require.NoError(t, err, "querying %s", md.Name)
 				require.NotEmpty(t, results, "%s not found", md.Name)
 				for _, r := range results {
+					r := r
 					_, ok := r.Labels.Datapoint[label]
 					require.True(t, ok, "%s missing expected label '%s'", md.Name, label)
 				}
@@ -1187,15 +1645,19 @@ func TestKSM_AllBuckets_ExpectedLabels(t *testing.T) {
 }
 
 func TestKSM_AllBuckets_UnitValidation(t *testing.T) {
+	t.Parallel()
 	for _, md := range allKSMMetricDefs {
+		md := md
 		if md.Unit == "" {
 			continue
 		}
 		t.Run(md.Name, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), md.Name)
 			require.NoError(t, err, "querying %s", md.Name)
 			require.NotEmpty(t, results, "%s not found", md.Name)
 			for _, r := range results {
+				r := r
 				unit, ok := r.Labels.Datapoint["__unit__"]
 				require.True(t, ok, "%s missing __unit__", md.Name)
 				require.Equal(t, md.Unit, unit, "%s unit", md.Name)
@@ -1205,12 +1667,16 @@ func TestKSM_AllBuckets_UnitValidation(t *testing.T) {
 }
 
 func TestKSM_WorkloadBucket_HasRawNamespaceLabel(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmWorkloadMetrics() {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				val, has := r.Labels.Datapoint["namespace"]
 				require.True(t, has, "%s missing raw 'namespace' label at datapoint scope", metricName)
 				require.True(t, val != "", "%s has empty raw 'namespace' label", metricName)
@@ -1220,12 +1686,16 @@ func TestKSM_WorkloadBucket_HasRawNamespaceLabel(t *testing.T) {
 }
 
 func TestKSM_ClusterBucket_HasRawNamespaceLabel(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range ksmClusterBucket {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			require.NotEmpty(t, results, "%s not found", metricName)
 			for _, r := range results {
+				r := r
 				val, has := r.Labels.Datapoint["namespace"]
 				require.True(t, has, "%s missing raw 'namespace' label at datapoint scope", metricName)
 				require.True(t, val != "", "%s has empty raw 'namespace' label", metricName)
@@ -1235,13 +1705,428 @@ func TestKSM_ClusterBucket_HasRawNamespaceLabel(t *testing.T) {
 }
 
 func TestKSM_AllBuckets_NoPodTemplateHash(t *testing.T) {
+	t.Parallel()
 	for _, metricName := range allKSMBucketMetrics() {
+		metricName := metricName
 		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
 			results, err := queryCache.Get(context.Background(), metricName)
 			require.NoError(t, err, "querying %s", metricName)
 			for _, r := range results {
+				r := r
 				_, has := r.Labels.Resource["k8s.pod.label.pod-template-hash"]
 				require.True(t, !has, "%s should not have k8s.pod.label.pod-template-hash (removed by awsattributelimit)", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_CronJob_HasCronJobName(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.CronJob {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				r := r
+				val, ok := r.Labels.Resource["k8s.cronjob.name"]
+				require.True(t, ok, "%s missing k8s.cronjob.name", metricName)
+				require.True(t, val != "", "%s has empty k8s.cronjob.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_CronJob_HasRawCronJobLabel(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.CronJob {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				r := r
+				val, has := r.Labels.Datapoint["cronjob"]
+				require.True(t, has, "%s missing raw 'cronjob' label at datapoint scope", metricName)
+				require.True(t, val != "", "%s has empty raw 'cronjob' label", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_CronJob_HasWorkloadIdentity(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.CronJob {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				r := r
+				wn := r.Labels.Resource["k8s.workload.name"]
+				wt := r.Labels.Resource["k8s.workload.type"]
+				require.True(t, wn != "", "%s missing k8s.workload.name", metricName)
+				require.Equal(t, "CronJob", wt, "%s k8s.workload.type", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_CronJob_NoCrossContamination(t *testing.T) {
+	t.Parallel()
+	wrongAttrs := []string{"k8s.deployment.name", "k8s.statefulset.name", "k8s.daemonset.name", "k8s.job.name"}
+	for _, metricName := range ksmWorkloadBucket.CronJob {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				r := r
+				for _, attr := range wrongAttrs {
+					attr := attr
+					_, has := r.Labels.Resource[attr]
+					require.True(t, !has, "%s should NOT have %s", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_CronJob_NoHostAttributes(t *testing.T) {
+	t.Parallel()
+	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
+	for _, metricName := range ksmWorkloadBucket.CronJob {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				r := r
+				for _, attr := range hostAttrs {
+					attr := attr
+					_, has := r.Labels.Resource[attr]
+					require.True(t, !has, "%s should NOT have %s", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_CronJob_NoNodeLabels(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.CronJob {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				r := r
+				for key := range r.Labels.Resource {
+					if strings.HasPrefix(key, "k8s.node.label.") {
+						t.Fatalf("%s should NOT have node labels, found %s", metricName, key)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_CronJob_NoNodeName(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.CronJob {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				r := r
+				_, has := r.Labels.Resource["k8s.node.name"]
+				require.True(t, !has, "%s should NOT have k8s.node.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Job_HasJobName(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.Job {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				r := r
+				val, ok := r.Labels.Resource["k8s.job.name"]
+				require.True(t, ok, "%s missing k8s.job.name", metricName)
+				require.True(t, val != "", "%s has empty k8s.job.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Job_HasRawJobNameLabel(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.Job {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				r := r
+				val, has := r.Labels.Datapoint["job_name"]
+				require.True(t, has, "%s missing raw 'job_name' label at datapoint scope", metricName)
+				require.True(t, val != "", "%s has empty raw 'job_name' label", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Job_HasWorkloadIdentity(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.Job {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				r := r
+				wn := r.Labels.Resource["k8s.workload.name"]
+				wt := r.Labels.Resource["k8s.workload.type"]
+				require.True(t, wn != "", "%s missing k8s.workload.name", metricName)
+				require.Equal(t, "Job", wt, "%s k8s.workload.type", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Job_NoCrossContamination(t *testing.T) {
+	t.Parallel()
+	wrongAttrs := []string{"k8s.deployment.name", "k8s.statefulset.name", "k8s.daemonset.name", "k8s.cronjob.name"}
+	for _, metricName := range ksmWorkloadBucket.Job {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				r := r
+				for _, attr := range wrongAttrs {
+					attr := attr
+					_, has := r.Labels.Resource[attr]
+					require.True(t, !has, "%s should NOT have %s", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Job_NoHostAttributes(t *testing.T) {
+	t.Parallel()
+	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
+	for _, metricName := range ksmWorkloadBucket.Job {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				r := r
+				for _, attr := range hostAttrs {
+					attr := attr
+					_, has := r.Labels.Resource[attr]
+					require.True(t, !has, "%s should NOT have %s", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Job_NoNodeLabels(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.Job {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				r := r
+				for key := range r.Labels.Resource {
+					if strings.HasPrefix(key, "k8s.node.label.") {
+						t.Fatalf("%s should NOT have node labels, found %s", metricName, key)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_Job_NoNodeName(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.Job {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				r := r
+				_, has := r.Labels.Resource["k8s.node.name"]
+				require.True(t, !has, "%s should NOT have k8s.node.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_StatefulSet_HasRawStatefulSetLabel(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.StatefulSet {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				r := r
+				val, has := r.Labels.Datapoint["statefulset"]
+				require.True(t, has, "%s missing raw 'statefulset' label at datapoint scope", metricName)
+				require.True(t, val != "", "%s has empty raw 'statefulset' label", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_StatefulSet_HasStatefulSetName(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.StatefulSet {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				r := r
+				val, ok := r.Labels.Resource["k8s.statefulset.name"]
+				require.True(t, ok, "%s missing k8s.statefulset.name", metricName)
+				require.True(t, val != "", "%s has empty k8s.statefulset.name", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_StatefulSet_HasWorkloadIdentity(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.StatefulSet {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			require.NotEmpty(t, results, "%s not found", metricName)
+			for _, r := range results {
+				r := r
+				wn := r.Labels.Resource["k8s.workload.name"]
+				wt := r.Labels.Resource["k8s.workload.type"]
+				require.True(t, wn != "", "%s missing k8s.workload.name", metricName)
+				require.Equal(t, "StatefulSet", wt, "%s k8s.workload.type", metricName)
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_StatefulSet_NoCrossContamination(t *testing.T) {
+	t.Parallel()
+	wrongAttrs := []string{"k8s.deployment.name", "k8s.daemonset.name", "k8s.job.name", "k8s.cronjob.name"}
+	for _, metricName := range ksmWorkloadBucket.StatefulSet {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				r := r
+				for _, attr := range wrongAttrs {
+					attr := attr
+					_, has := r.Labels.Resource[attr]
+					require.True(t, !has, "%s should NOT have %s", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_StatefulSet_NoHostAttributes(t *testing.T) {
+	t.Parallel()
+	hostAttrs := []string{"host.id", "host.name", "host.type", "host.image.id"}
+	for _, metricName := range ksmWorkloadBucket.StatefulSet {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				r := r
+				for _, attr := range hostAttrs {
+					attr := attr
+					_, has := r.Labels.Resource[attr]
+					require.True(t, !has, "%s should NOT have %s", metricName, attr)
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_StatefulSet_NoNodeLabels(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.StatefulSet {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				r := r
+				for key := range r.Labels.Resource {
+					if strings.HasPrefix(key, "k8s.node.label.") {
+						t.Fatalf("%s should NOT have node labels, found %s", metricName, key)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestKSM_WorkloadBucket_StatefulSet_NoNodeName(t *testing.T) {
+	t.Parallel()
+	for _, metricName := range ksmWorkloadBucket.StatefulSet {
+		metricName := metricName
+		t.Run(metricName, func(t *testing.T) {
+			t.Parallel()
+			results, err := queryCache.Get(context.Background(), metricName)
+			require.NoError(t, err, "querying %s", metricName)
+			for _, r := range results {
+				r := r
+				_, has := r.Labels.Resource["k8s.node.name"]
+				require.True(t, !has, "%s should NOT have k8s.node.name", metricName)
 			}
 		})
 	}

--- a/test/otel/standard/metrics_test.go
+++ b/test/otel/standard/metrics_test.go
@@ -81,6 +81,10 @@ var ksmClusterScopedMetrics = []otelmetrics.MetricDefinition{
 	{Name: "kube_deployment_status_replicas_ready", MetricType: "gauge", Scope: otelmetrics.ScopeCluster},
 	{Name: "kube_deployment_status_replicas", MetricType: "gauge", Scope: otelmetrics.ScopeCluster},
 	{Name: "kube_daemonset_status_desired_number_scheduled", MetricType: "gauge", Scope: otelmetrics.ScopeCluster},
+	{Name: "kube_statefulset_replicas", MetricType: "gauge", Scope: otelmetrics.ScopeCluster},
+	{Name: "kube_statefulset_status_replicas_ready", MetricType: "gauge", Scope: otelmetrics.ScopeCluster},
+	{Name: "kube_job_status_active", MetricType: "gauge", Scope: otelmetrics.ScopeCluster},
+	{Name: "kube_cronjob_status_active", MetricType: "gauge", Scope: otelmetrics.ScopeCluster},
 	{Name: "kube_namespace_status_phase", MetricType: "gauge", Scope: otelmetrics.ScopeCluster, ExpectedLabels: []string{"phase"}},
 }
 
@@ -116,6 +120,7 @@ func metricNames(defs []otelmetrics.MetricDefinition) []string {
 func metricNamesByScope(defs []otelmetrics.MetricDefinition, scope otelmetrics.MetricScope) []string {
 	var names []string
 	for _, d := range defs {
+		d := d
 		if d.Scope == scope {
 			names = append(names, d.Name)
 		}
@@ -133,6 +138,7 @@ func nodeMetricNames() []string {
 func podMetricNames() []string {
 	var names []string
 	for _, m := range allMetrics {
+		m := m
 		if m.Scope == otelmetrics.ScopePod || m.Scope == otelmetrics.ScopeContainer {
 			names = append(names, m.Name)
 		}
@@ -171,6 +177,7 @@ func prometheusScrapedNames() []string {
 func podScopedCadvisorNames() []string {
 	var names []string
 	for _, m := range cadvisorMetrics {
+		m := m
 		if m.Scope == otelmetrics.ScopePod || m.Scope == otelmetrics.ScopeContainer {
 			names = append(names, m.Name)
 		}

--- a/test/otel/standard/resolution_test.go
+++ b/test/otel/standard/resolution_test.go
@@ -34,6 +34,7 @@ var resolutionTestMetrics = []struct {
 // TestMetricResolution validates that metrics are scraped at ~30s intervals by
 // querying a 5-minute range and checking sample counts.
 func TestMetricResolution(t *testing.T) {
+	t.Parallel()
 	end := time.Now()
 	start := end.Add(-5 * time.Minute)
 	step := expectedResolution
@@ -42,7 +43,9 @@ func TestMetricResolution(t *testing.T) {
 	minSamples := expectedSamples / 2
 
 	for _, tm := range resolutionTestMetrics {
+		tm := tm
 		t.Run(tm.source+"/"+tm.name, func(t *testing.T) {
+			t.Parallel()
 			escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(cfg.ClusterName)
 			promql := fmt.Sprintf(`%s{"@resource.k8s.cluster.name"="%s","@resource.host.type"="%s"}`,
 				tm.name, escaped, tm.hostType)


### PR DESCRIPTION
Deploy test workloads (StatefulSet, Job, CronJob, standalone ReplicaSet) to the standard cluster and add 10 new KSM tests validating workload identity, owner chain resolution, and workload-scoped metrics.

- terraform: 5 new K8s resources (StatefulSet + headless Service, CronJob, Job with 24h TTL, standalone ReplicaSet)
- ksm_test.go: 4 pod-bucket tests (workload name per type) + 6 workload- bucket tests (name + namespace per type)
- metrics_test.go: 4 new metric definitions (kube_statefulset_*, kube_job_*, kube_cronjob_*)

155 tests total (was 145).

Workflow Run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/25113978033/job/73595720889