### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       - name: Verify Terraform version
         run: terraform --version
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: ~1.23.0
       - name: Lint Terraform

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,12 +16,12 @@ jobs:
   codeql-analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
         with:
           languages: go
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1


### PR DESCRIPTION
## Description of changes

Pin all third-party GitHub Actions to full commit SHAs with version comments for traceability.

- 5 third-party actions pinned across 2 workflow files
- Version comments (e.g. `# v3.6.0`) retained alongside each SHA

| Action | Version | SHA |
|---|---|---|
| `actions/checkout` | v3.6.0 | `f43a0e5ff2bd294095638e18286ca9a3d1956744` |
| `actions/setup-go` | v3.5.0 | `6edd4406fa81c3da01a34fa6f6343087c207a568` |
| `github/codeql-action/init` | v2.28.1 | `b8d3b6e8af63cde30bdc382c0bc28114f4346c88` |
| `github/codeql-action/analyze` | v2.28.1 | `b8d3b6e8af63cde30bdc382c0bc28114f4346c88` |
| `hashicorp/setup-terraform` | v3.1.2 | `b9cd54a3c349d3f38e8881555d616ced269862dd` |

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A
