### PR TITLE
Feature/efa ec2 integration test

### DIFF
--- a/generator/resources/ec2_efa_test_matrix.json
+++ b/generator/resources/ec2_efa_test_matrix.json
@@ -4,7 +4,7 @@
     "username": "ec2-user",
     "instanceType": "c5n.9xlarge",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
-    "ami": "cloudwatch-agent-integration-test-al2023*",
+    "ami": "cloudwatch-agent-integration-test-x86-al2023*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",

--- a/generator/resources/ec2_efa_test_matrix.json
+++ b/generator/resources/ec2_efa_test_matrix.json
@@ -1,0 +1,13 @@
+[
+  {
+    "os": "al2023",
+    "username": "ec2-user",
+    "instanceType": "c5n.9xlarge",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-al2023*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  }
+]

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -77,6 +77,9 @@ var testTypeToTestConfig = map[string][]testConfig{
 	"ec2_gpu": {
 		{testDir: "./test/nvidia_gpu"},
 	},
+	"ec2_efa": {
+		{testDir: "./test/efa_ec2", terraformDir: "terraform/ec2/efa"},
+	},
 	"ec2_linux_wd": {
 		{testDir: "./test/workload_discovery"},
 	},

--- a/terraform/ec2/efa/main.tf
+++ b/terraform/ec2/efa/main.tf
@@ -146,15 +146,6 @@ resource "aws_instance" "cwagent" {
     sed -i 's/^#*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
     sed -i 's/^#*KbdInteractiveAuthentication.*/KbdInteractiveAuthentication no/' /etc/ssh/sshd_config
     systemctl restart sshd
-
-    # Install EFA driver (no interactive tests - reboot handles module reload)
-    cd /tmp
-    curl -O https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz
-    tar -xf aws-efa-installer-latest.tar.gz
-    cd aws-efa-installer
-    ./efa_installer.sh -y -n
-    # Reboot to load EFA kernel module
-    reboot
   EOT
 
   root_block_device {
@@ -183,12 +174,50 @@ resource "null_resource" "integration_test_setup" {
     host        = aws_eip.efa.public_ip
   }
 
+  # Install EFA driver and trigger reboot
   provisioner "remote-exec" {
     inline = [
       "echo sha ${var.cwa_github_sha}",
       "sudo cloud-init status --wait",
+      "# Install EFA driver",
+      "cd /tmp",
+      "curl -O https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz",
+      "tar -xf aws-efa-installer-latest.tar.gz",
+      "cd aws-efa-installer",
+      "sudo ./efa_installer.sh -y -n",
+      "echo 'EFA driver installed, rebooting...'",
+      "sudo shutdown -r now &",
+    ]
+  }
 
-      "# Verify EFA is available after user_data reboot",
+  depends_on = [
+    aws_instance.cwagent,
+  ]
+}
+
+# Wait for instance to reboot
+resource "null_resource" "integration_test_reboot_wait" {
+  provisioner "local-exec" {
+    command = "echo 'Waiting 60s for instance reboot...' && sleep 60"
+  }
+
+  depends_on = [
+    null_resource.integration_test_setup,
+  ]
+}
+
+# Post-reboot: verify EFA, clone repo, install agent
+resource "null_resource" "integration_test_post_reboot" {
+  connection {
+    type        = "ssh"
+    user        = var.user
+    private_key = local.private_key_content
+    host        = aws_eip.efa.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "# Verify EFA is available after reboot",
       "fi_info -p efa 2>/dev/null || { echo 'FATAL: EFA provider not available'; exit 1; }",
       "ls /sys/class/infiniband/ || { echo 'FATAL: No EFA device found at /sys/class/infiniband/'; exit 1; }",
 
@@ -205,7 +234,7 @@ resource "null_resource" "integration_test_setup" {
   }
 
   depends_on = [
-    aws_instance.cwagent,
+    null_resource.integration_test_reboot_wait,
   ]
 }
 
@@ -235,6 +264,6 @@ resource "null_resource" "integration_test_run" {
   }
 
   depends_on = [
-    null_resource.integration_test_setup,
+    null_resource.integration_test_post_reboot,
   ]
 }

--- a/terraform/ec2/efa/main.tf
+++ b/terraform/ec2/efa/main.tf
@@ -1,0 +1,236 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "common" {
+  source = "../../common"
+}
+
+module "basic_components" {
+  source = "../../basic_components"
+  region = var.region
+}
+
+#####################################################################
+# SSH Key
+#####################################################################
+
+resource "tls_private_key" "ssh_key" {
+  count     = var.ssh_key_name == "" ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "aws_key_pair" "aws_ssh_key" {
+  count      = var.ssh_key_name == "" ? 1 : 0
+  key_name   = "ec2-key-pair-${module.common.testing_id}"
+  public_key = tls_private_key.ssh_key[0].public_key_openssh
+}
+
+locals {
+  ssh_key_name        = var.ssh_key_name != "" ? var.ssh_key_name : aws_key_pair.aws_ssh_key[0].key_name
+  private_key_content = var.ssh_key_name != "" ? var.ssh_key_value : tls_private_key.ssh_key[0].private_key_pem
+  binary_uri          = "${var.s3_bucket}/integration-test/binary/${var.cwa_github_sha}/linux/${var.arc}/${var.binary_name}"
+}
+
+#####################################################################
+# AMI Lookup
+#####################################################################
+
+data "aws_ami" "latest" {
+  most_recent = true
+  owners      = ["self", "amazon"]
+
+  filter {
+    name   = "name"
+    values = [var.ami]
+  }
+}
+
+#####################################################################
+# EFA Security Group
+#####################################################################
+
+resource "aws_security_group" "efa" {
+  name_prefix = "efa-integ-test-${module.common.testing_id}-"
+  vpc_id      = module.basic_components.vpc_id
+
+  # EFA requires all traffic within the security group
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    self      = true
+  }
+
+  # SSH access
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # All outbound
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "efa-integ-test-${module.common.testing_id}"
+  }
+}
+
+#####################################################################
+# EFA Placement Group
+#####################################################################
+
+resource "aws_placement_group" "efa" {
+  name     = "efa-integ-test-${module.common.testing_id}"
+  strategy = "cluster"
+}
+
+#####################################################################
+# EFA Network Interface
+#####################################################################
+
+resource "aws_network_interface" "efa" {
+  subnet_id       = module.basic_components.public_subnet_ids[0]
+  security_groups = [aws_security_group.efa.id]
+  interface_type  = "efa"
+
+  tags = {
+    Name = "efa-integ-test-${module.common.testing_id}"
+  }
+}
+
+#####################################################################
+# Elastic IP for SSH access (network_interface block does not support
+# associate_public_ip_address)
+#####################################################################
+
+resource "aws_eip" "efa" {
+  domain            = "vpc"
+  network_interface = aws_network_interface.efa.id
+
+  tags = {
+    Name = "efa-integ-test-${module.common.testing_id}"
+  }
+
+  depends_on = [aws_instance.cwagent]
+}
+
+#####################################################################
+# EC2 Instance with EFA
+#####################################################################
+
+resource "aws_instance" "cwagent" {
+  ami                                  = data.aws_ami.latest.id
+  instance_type                        = var.ec2_instance_type
+  key_name                             = local.ssh_key_name
+  iam_instance_profile                 = module.basic_components.instance_profile
+  placement_group                      = aws_placement_group.efa.name
+  instance_initiated_shutdown_behavior = "terminate"
+
+  network_interface {
+    device_index         = 0
+    network_interface_id = aws_network_interface.efa.id
+  }
+
+  user_data = <<-EOT
+    #!/bin/bash
+    sudo sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+    sudo sed -i 's/^#*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
+    sudo sed -i 's/^#*KbdInteractiveAuthentication.*/KbdInteractiveAuthentication no/' /etc/ssh/sshd_config
+    sudo systemctl restart sshd
+  EOT
+
+  root_block_device {
+    volume_size = 200
+  }
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  tags = {
+    Name = "cwagent-integ-test-efa-${var.test_name}-${module.common.testing_id}"
+  }
+}
+
+#####################################################################
+# EFA Driver Installation + Test Setup
+#####################################################################
+
+resource "null_resource" "integration_test_setup" {
+  connection {
+    type        = "ssh"
+    user        = var.user
+    private_key = local.private_key_content
+    host        = aws_eip.efa.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo sha ${var.cwa_github_sha}",
+      "sudo cloud-init status --wait",
+
+      "# Install EFA driver",
+      "cd /tmp",
+      "curl -O https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz",
+      "tar -xf aws-efa-installer-latest.tar.gz",
+      "cd aws-efa-installer",
+      "sudo ./efa_installer.sh -y",
+      "echo 'EFA driver installation complete'",
+      "fi_info -p efa 2>/dev/null || { echo 'FATAL: EFA provider not available'; exit 1; }",
+      "ls /sys/class/infiniband/ || { echo 'FATAL: No EFA device found at /sys/class/infiniband/'; exit 1; }",
+
+      "# Clone test repo and install agent",
+      "cd ~",
+      "echo clone ${var.github_test_repo} branch ${var.github_test_repo_branch} and install agent",
+      "git clone --branch ${var.github_test_repo_branch} ${var.github_test_repo} -q",
+      "cd amazon-cloudwatch-agent-test",
+      "git rev-parse --short HEAD",
+      "aws s3 cp --no-progress s3://${local.binary_uri} .",
+      "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
+      var.install_agent,
+    ]
+  }
+
+  depends_on = [
+    aws_instance.cwagent,
+  ]
+}
+
+#####################################################################
+# Run Integration Test
+#####################################################################
+
+resource "null_resource" "integration_test_run" {
+  connection {
+    type        = "ssh"
+    user        = var.user
+    private_key = local.private_key_content
+    host        = aws_eip.efa.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "export LOCAL_STACK_HOST_NAME=${var.local_stack_host_name}",
+      "export AWS_REGION=${var.region}",
+      "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
+      "cd ~/amazon-cloudwatch-agent-test",
+      "echo Running sanity test...",
+      "go test ./test/sanity -p 1 -v",
+      "echo Running EFA integration test...",
+      "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -excludedTests='${var.excluded_tests}' -cwaCommitSha=${var.cwa_github_sha} -instanceId=${aws_instance.cwagent.id} -v",
+    ]
+  }
+
+  depends_on = [
+    null_resource.integration_test_setup,
+  ]
+}

--- a/terraform/ec2/efa/main.tf
+++ b/terraform/ec2/efa/main.tf
@@ -132,7 +132,7 @@ resource "aws_instance" "cwagent" {
   key_name                             = local.ssh_key_name
   iam_instance_profile                 = module.basic_components.instance_profile
   placement_group                      = aws_placement_group.efa.name
-  instance_initiated_shutdown_behavior = "terminate"
+  instance_initiated_shutdown_behavior = "stop"
 
   network_interface {
     device_index         = 0
@@ -141,10 +141,20 @@ resource "aws_instance" "cwagent" {
 
   user_data = <<-EOT
     #!/bin/bash
-    sudo sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
-    sudo sed -i 's/^#*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
-    sudo sed -i 's/^#*KbdInteractiveAuthentication.*/KbdInteractiveAuthentication no/' /etc/ssh/sshd_config
-    sudo systemctl restart sshd
+    # Disable password auth for SSH
+    sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+    sed -i 's/^#*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
+    sed -i 's/^#*KbdInteractiveAuthentication.*/KbdInteractiveAuthentication no/' /etc/ssh/sshd_config
+    systemctl restart sshd
+
+    # Install EFA driver (no interactive tests - reboot handles module reload)
+    cd /tmp
+    curl -O https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz
+    tar -xf aws-efa-installer-latest.tar.gz
+    cd aws-efa-installer
+    ./efa_installer.sh -y -n
+    # Reboot to load EFA kernel module
+    reboot
   EOT
 
   root_block_device {
@@ -178,13 +188,7 @@ resource "null_resource" "integration_test_setup" {
       "echo sha ${var.cwa_github_sha}",
       "sudo cloud-init status --wait",
 
-      "# Install EFA driver",
-      "cd /tmp",
-      "curl -O https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz",
-      "tar -xf aws-efa-installer-latest.tar.gz",
-      "cd aws-efa-installer",
-      "sudo ./efa_installer.sh -y",
-      "echo 'EFA driver installation complete'",
+      "# Verify EFA is available after user_data reboot",
       "fi_info -p efa 2>/dev/null || { echo 'FATAL: EFA provider not available'; exit 1; }",
       "ls /sys/class/infiniband/ || { echo 'FATAL: No EFA device found at /sys/class/infiniband/'; exit 1; }",
 

--- a/terraform/ec2/efa/providers.tf
+++ b/terraform/ec2/efa/providers.tf
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+provider "aws" {
+  region = var.region
+}

--- a/terraform/ec2/efa/variables.tf
+++ b/terraform/ec2/efa/variables.tf
@@ -1,0 +1,136 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "ec2_instance_type" {
+  type    = string
+  default = "t3a.medium"
+}
+
+variable "ssh_key_name" {
+  type    = string
+  default = ""
+}
+
+variable "ami" {
+  type    = string
+  default = "cloudwatch-agent-integration-test-ubuntu*"
+}
+
+variable "ssh_key_value" {
+  type    = string
+  default = ""
+}
+
+variable "user" {
+  type    = string
+  default = ""
+}
+
+variable "install_agent" {
+  description = "go run ./install/install_agent.go deb or go run ./install/install_agent.go rpm"
+  type        = string
+  default     = "go run ./install/install_agent.go rpm"
+}
+
+variable "ca_cert_path" {
+  type    = string
+  default = ""
+}
+
+variable "arc" {
+  type    = string
+  default = "amd64"
+
+  validation {
+    condition     = contains(["amd64", "arm64"], var.arc)
+    error_message = "Valid values for arc are (amd64, arm64)."
+  }
+}
+
+variable "binary_name" {
+  type    = string
+  default = ""
+}
+
+variable "local_stack_host_name" {
+  type    = string
+  default = "localhost.localstack.cloud"
+}
+
+variable "is_selinux_test" {
+  type    = bool
+  default = false
+}
+
+variable "s3_bucket" {
+  type    = string
+  default = ""
+}
+
+variable "test_name" {
+  type    = string
+  default = ""
+}
+
+variable "test_dir" {
+  type    = string
+  default = ""
+}
+
+variable "selinux_branch" {
+  type    = string
+  default = "main"
+}
+
+variable "cwa_github_sha" {
+  type    = string
+  default = ""
+}
+
+variable "github_test_repo" {
+  type    = string
+  default = "https://github.com/aws/amazon-cloudwatch-agent-test.git"
+}
+
+variable "github_test_repo_branch" {
+  type    = string
+  default = "main"
+}
+
+variable "is_canary" {
+  type    = bool
+  default = false
+}
+
+variable "plugin_tests" {
+  type    = string
+  default = ""
+}
+
+
+variable "excluded_tests" {
+  type    = string
+  default = ""
+}
+
+variable "pre_test_setup" {
+  type    = string
+  default = "echo no pre-test setup"
+}
+
+variable "agent_start" {
+  description = "default command should be for ec2 with linux"
+  type        = string
+  default     = "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c "
+}
+
+variable "is_onprem" {
+  description = "Whether to run in on-premises mode instead of EC2 mode"
+  type        = bool
+  default     = false
+}

--- a/test/efa_ec2/efa_ec2_test.go
+++ b/test/efa_ec2/efa_ec2_test.go
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package efa_ec2
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+)
+
+func init() {
+	environment.RegisterEnvironmentMetaDataFlags()
+}
+
+func TestEfaEC2Metrics(t *testing.T) {
+	err := Validate()
+	if err != nil {
+		t.Fatalf("efa ec2 validation failed: %s", err)
+	}
+}

--- a/test/efa_ec2/efa_ec2_unix.go
+++ b/test/efa_ec2/efa_ec2_unix.go
@@ -6,7 +6,6 @@
 package efa_ec2
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -42,7 +41,9 @@ func Validate() error {
 
 	dimensionFilter := awsservice.BuildDimensionFilterList(numberofLinuxAppendDimensions)
 	for _, metricName := range expectedEfaEC2LinuxMetrics {
-		awsservice.ValidateMetric(metricName, metricLinuxNamespace, dimensionFilter)
+		if err := awsservice.ValidateMetric(metricName, metricLinuxNamespace, dimensionFilter); err != nil {
+			return err
+		}
 	}
 
 	// Validate that EFA metrics use short dimension names (device, port, eniId)
@@ -52,11 +53,11 @@ func Validate() error {
 	}
 
 	if err := filesystem.CheckFileRights(agentLinuxLogPath); err != nil {
-		return errors.New(fmt.Sprintf("CloudWatchAgent does not have privellege to write and read CWA's log: %v", err))
+		return fmt.Errorf("CloudWatchAgent does not have privilege to write and read CWA's log: %v", err)
 	}
 
 	if err := filesystem.CheckFileOwnerRights(agentLinuxLogPath, agentLinuxPermission); err != nil {
-		return errors.New(fmt.Sprintf("CloudWatchAgent does not have right to CWA's log: %v", err))
+		return fmt.Errorf("CloudWatchAgent does not have right to CWA's log: %v", err)
 	}
 
 	return nil

--- a/test/efa_ec2/efa_ec2_unix.go
+++ b/test/efa_ec2/efa_ec2_unix.go
@@ -10,6 +10,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
 	"github.com/aws/amazon-cloudwatch-agent-test/filesystem"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
@@ -26,7 +29,8 @@ const (
 )
 
 var (
-	expectedEfaEC2LinuxMetrics = []string{"efa_tx_bytes", "efa_rx_bytes", "efa_tx_pkts", "efa_rx_pkts", "efa_rx_dropped", "efa_rdma_read_bytes", "efa_rdma_write_bytes", "efa_send_bytes", "efa_recv_bytes"}
+	expectedEfaEC2LinuxMetrics    = []string{"efa_tx_bytes", "efa_rx_bytes", "efa_tx_pkts", "efa_rx_pkts", "efa_rx_dropped", "efa_rdma_read_bytes", "efa_rdma_write_bytes", "efa_send_bytes", "efa_recv_bytes"}
+	expectedEfaDimensionNames     = []string{"device", "port", "eniId"}
 )
 
 func Validate() error {
@@ -41,6 +45,12 @@ func Validate() error {
 		awsservice.ValidateMetric(metricName, metricLinuxNamespace, dimensionFilter)
 	}
 
+	// Validate that EFA metrics use short dimension names (device, port, eniId)
+	// instead of OTel-style dotted names (aws.efa.device, aws.efa.port, aws.efa.eni.id)
+	if err := validateEfaDimensionNames(); err != nil {
+		return err
+	}
+
 	if err := filesystem.CheckFileRights(agentLinuxLogPath); err != nil {
 		return errors.New(fmt.Sprintf("CloudWatchAgent does not have privellege to write and read CWA's log: %v", err))
 	}
@@ -49,5 +59,20 @@ func Validate() error {
 		return errors.New(fmt.Sprintf("CloudWatchAgent does not have right to CWA's log: %v", err))
 	}
 
+	return nil
+}
+
+// validateEfaDimensionNames verifies that EFA metrics are published with short
+// dimension names (device, port, eniId) rather than OTel-style dotted names.
+func validateEfaDimensionNames() error {
+	dimFilter := make([]types.DimensionFilter, len(expectedEfaDimensionNames))
+	for i, name := range expectedEfaDimensionNames {
+		dimFilter[i] = types.DimensionFilter{Name: aws.String(name)}
+	}
+
+	// Check at least one EFA metric exists with the expected short dimension names
+	if err := awsservice.ValidateMetric(expectedEfaEC2LinuxMetrics[0], metricLinuxNamespace, dimFilter); err != nil {
+		return fmt.Errorf("EFA metrics missing expected short dimension names %v: %w", expectedEfaDimensionNames, err)
+	}
 	return nil
 }

--- a/test/efa_ec2/efa_ec2_unix.go
+++ b/test/efa_ec2/efa_ec2_unix.go
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package efa_ec2
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/filesystem"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
+)
+
+const (
+	configLinuxJSON               = "resources/config_linux.json"
+	metricLinuxNamespace          = "EfaEC2LinuxTest"
+	configLinuxOutputPath         = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
+	agentLinuxLogPath             = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+	agentLinuxRuntime             = 2 * time.Minute
+	agentLinuxPermission          = "root"
+	numberofLinuxAppendDimensions = 1
+)
+
+var (
+	expectedEfaEC2LinuxMetrics = []string{"efa_tx_bytes", "efa_rx_bytes", "efa_tx_pkts", "efa_rx_pkts", "efa_rx_dropped", "efa_rdma_read_bytes", "efa_rdma_write_bytes", "efa_send_bytes", "efa_recv_bytes"}
+)
+
+func Validate() error {
+	common.CopyFile(configLinuxJSON, configLinuxOutputPath)
+	common.StartAgent(configLinuxOutputPath, true, false)
+
+	time.Sleep(agentLinuxRuntime)
+	common.StopAgent()
+
+	dimensionFilter := awsservice.BuildDimensionFilterList(numberofLinuxAppendDimensions)
+	for _, metricName := range expectedEfaEC2LinuxMetrics {
+		awsservice.ValidateMetric(metricName, metricLinuxNamespace, dimensionFilter)
+	}
+
+	if err := filesystem.CheckFileRights(agentLinuxLogPath); err != nil {
+		return errors.New(fmt.Sprintf("CloudWatchAgent does not have privellege to write and read CWA's log: %v", err))
+	}
+
+	if err := filesystem.CheckFileOwnerRights(agentLinuxLogPath, agentLinuxPermission); err != nil {
+		return errors.New(fmt.Sprintf("CloudWatchAgent does not have right to CWA's log: %v", err))
+	}
+
+	return nil
+}

--- a/test/efa_ec2/resources/config_linux.json
+++ b/test/efa_ec2/resources/config_linux.json
@@ -1,0 +1,29 @@
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "root",
+    "debug": true
+  },
+  "metrics": {
+    "namespace": "EfaEC2LinuxTest",
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}"
+    },
+    "metrics_collected": {
+      "efa": {
+        "measurement": [
+          "efa_tx_bytes",
+          "efa_rx_bytes",
+          "efa_tx_pkts",
+          "efa_rx_pkts",
+          "efa_rx_dropped",
+          "efa_rdma_read_bytes",
+          "efa_rdma_write_bytes",
+          "efa_send_bytes",
+          "efa_recv_bytes"
+        ],
+        "metrics_collection_interval": 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds EFA EC2 integration test with Terraform module and test matrix entry.

## Changes

- **EFA EC2 integration test** (`test/efa_ec2/`) — validates EFA metrics are published to CloudWatch with correct short dimension names (`device`, `port`, `eniId`) and `InstanceId` from append_dimensions
- **Terraform module** — provisions c5n.9xlarge instance with EFA-enabled ENI in a placement group
- **Test matrix entry** (`generator/resources/ec2_efa_test_matrix.json`) — defines AMI and instance config for CI
- **Dimension name validation** — verifies the transform processor correctly renames OTel-style attributes (`aws.efa.device`, `aws.efa.port`, `aws.efa.eni.id`) to CW-friendly short names

## Related PRs

- CWAgent EFA receiver: https://github.com/aws/amazon-cloudwatch-agent/pull/2093 (merged)
- CWAgent dimension rename: https://github.com/aws/amazon-cloudwatch-agent/pull/2110

## Testing

- Test Run - https://github.com/aws/amazon-cloudwatch-agent/actions/runs/26540322870/job/78180256327