### PR TITLE
ci: declare permissions on build-check and codeql-analysis

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   compile:
     strategy:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,11 @@ concurrency:
   group: codeql-${{ github.ref_name }}
   cancel-in-progress: true
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write   # github/codeql-action/upload posts SARIF results
+
 jobs:
   codeql-analyze:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two workflows currently inherit the repo default token scope:

- `build-check.yml` — PR-time compile matrix (ubuntu/windows). `contents: read` covers checkout.
- `codeql-analysis.yml` — runs `github/codeql-action`, which posts SARIF results back via the GitHub API. Standard CodeQL scopes: `actions: read`, `contents: read`, `security-events: write`.