### PR TITLE
Pin EKS tests to k8s 1.32 + AL2, keep otel tests on 1.35 + AL2023

### DIFF
--- a/generator/resources/eks_addon_test_matrix.json
+++ b/generator/resources/eks_addon_test_matrix.json
@@ -1,6 +1,6 @@
 [
   {
-    "k8sVersion": "1.31",
+    "k8sVersion": "1.32",
     "ami": "AL2_x86_64_GPU",
     "terraform_dir": "terraform/eks/addon/gpu",
     "test_dir": "./test/gpu",

--- a/generator/resources/eks_daemon_test_matrix.json
+++ b/generator/resources/eks_daemon_test_matrix.json
@@ -1,12 +1,12 @@
 [
   {
-    "k8sVersion": "1.35",
+    "k8sVersion": "1.32",
     "ami": "AL2_x86_64",
     "instanceType":"t3.medium",
     "arc": "amd64"
   },
   {
-    "k8sVersion": "1.35",
+    "k8sVersion": "1.32",
     "ami": "AL2_ARM_64",
     "instanceType":"m6g.large",
     "arc": "arm64"

--- a/generator/resources/eks_deployment_test_matrix.json
+++ b/generator/resources/eks_deployment_test_matrix.json
@@ -1,5 +1,5 @@
 [
   {
-    "k8sVersion": "1.31"
+    "k8sVersion": "1.32"
   }
 ]

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -50,6 +50,7 @@ type testConfig struct {
 	terraformDir  string
 	instanceType  string
 	ami           string
+	k8sVersion    string
 	runMockServer bool
 	selinuxBranch string
 	// define target matrix field as set(s)
@@ -427,16 +428,22 @@ var testTypeToTestConfig = map[string][]testConfig{
 			testDir:      "./test/otel/standard",
 			terraformDir: "terraform/eks/daemon/otel",
 			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
+			ami:          "AL2023_x86_64_STANDARD",
+			k8sVersion:   "1.35",
 		},
 		{
 			testDir:      "./test/otel/attr_limit",
 			terraformDir: "terraform/eks/daemon/otel-attr-limit",
 			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
+			ami:          "AL2023_x86_64_STANDARD",
+			k8sVersion:   "1.35",
 		},
 		{
 			testDir:      "./test/otel/ebs_csi",
 			terraformDir: "terraform/eks/daemon/otel-ebs-csi",
 			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
+			ami:          "AL2023_x86_64_STANDARD",
+			k8sVersion:   "1.35",
 		},
 		{
 			testDir:      "./test/otel/efa",
@@ -444,6 +451,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
 			instanceType: "c5n.9xlarge",
 			ami:          "AL2023_x86_64_STANDARD",
+			k8sVersion:   "1.35",
 		},
 		{
 			testDir:      "./test/otel/gpu",
@@ -451,6 +459,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
 			instanceType: "g4dn.xlarge",
 			ami:          "AL2023_x86_64_NVIDIA",
+			k8sVersion:   "1.35",
 		},
 		{
 			testDir:      "./test/otel/lis_csi",
@@ -458,6 +467,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
 			instanceType: "i7i.xlarge",
 			ami:          "AL2023_x86_64_STANDARD",
+			k8sVersion:   "1.35",
 		},
 		{
 			testDir:      "./test/otel/multi_efa",
@@ -465,6 +475,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
 			instanceType: "c6in.32xlarge",
 			ami:          "AL2023_x86_64_STANDARD",
+			k8sVersion:   "1.35",
 		},
 		{
 			testDir:      "./test/otel/neuron",
@@ -472,6 +483,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
 			instanceType: "inf2.xlarge",
 			ami:          "AL2023_x86_64_NEURON",
+			k8sVersion:   "1.35",
 		},
 	},
 	"eks_deployment": {
@@ -663,6 +675,9 @@ func genMatrix(testType string, testConfigs []testConfig, ami []string, override
 			}
 			if testConfig.ami != "" {
 				row.Ami = testConfig.ami
+			}
+			if testConfig.k8sVersion != "" {
+				row.K8sVersion = testConfig.k8sVersion
 			}
 			// Apply architecture-specific instance type if configured
 			if testConfig.instanceTypeByArch != nil {

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -423,6 +423,8 @@ var testTypeToTestConfig = map[string][]testConfig{
 			terraformDir: "terraform/eks/daemon/liscsi",
 			targets:      map[string]map[string]struct{}{"arc": {"amd64": {}}},
 			instanceType: "i7i.xlarge",
+			ami:          "AL2023_x86_64_STANDARD",
+			k8sVersion:   "1.35",
 		},
 		{
 			testDir:      "./test/otel/standard",

--- a/terraform/eks/addon/gpu/variables.tf
+++ b/terraform/eks/addon/gpu/variables.tf
@@ -18,7 +18,7 @@ variable "addon_name" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.34"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/awsneuron/variables.tf
+++ b/terraform/eks/daemon/awsneuron/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.28"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/credentials/pod_identity/variables.tf
+++ b/terraform/eks/daemon/credentials/pod_identity/variables.tf
@@ -13,7 +13,7 @@ variable "test_dir" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.30"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/ebs/variables.tf
+++ b/terraform/eks/daemon/ebs/variables.tf
@@ -28,7 +28,7 @@ variable "helm_chart_branch" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.31"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/efa/variables.tf
+++ b/terraform/eks/daemon/efa/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.33"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/emf/variables.tf
+++ b/terraform/eks/daemon/emf/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.27"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/entity/variables.tf
+++ b/terraform/eks/daemon/entity/variables.tf
@@ -13,7 +13,7 @@ variable "test_dir" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.30"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/gpu/variables.tf
+++ b/terraform/eks/daemon/gpu/variables.tf
@@ -23,7 +23,7 @@ variable "cwagent_image_tag" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.34"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/liscsi/variables.tf
+++ b/terraform/eks/daemon/liscsi/variables.tf
@@ -28,7 +28,7 @@ variable "helm_chart_branch" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.35"
+  default = "1.32"
 }
 
 variable "ami_type" {

--- a/terraform/eks/daemon/liscsi/variables.tf
+++ b/terraform/eks/daemon/liscsi/variables.tf
@@ -28,7 +28,7 @@ variable "helm_chart_branch" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.32"
+  default = "1.35"
 }
 
 variable "ami_type" {

--- a/terraform/eks/e2e/variables.tf
+++ b/terraform/eks/e2e/variables.tf
@@ -8,7 +8,7 @@ variable "region" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.31"
+  default = "1.32"
 }
 
 variable "cluster_name" {


### PR DESCRIPTION
# Description of the issue
EKS Integ tests currently use diff K8s versions across the tests and are not uniform. Additionally, not all the existing tests are setup to be compatible with AL2023 (i.e. >=EKS 1.33).

# Description of changes
Container Insights tests (metric_value_benchmark, fluent, statsd, emf, gpu, efa, neuron, entity, etc.) are pinned to k8s 1.32 with AL2 AMIs to avoid cgroup v2 incompatibilities on AL2023.

OTel Container Insights tests (otel/standard, otel/gpu, otel/efa, otel/neuron, etc.) remain on k8s 1.35 with AL2023.

Changes:
- eks_daemon_test_matrix.json: 1.35 -> 1.32, AL2 AMIs
- eks_deployment_test_matrix.json: 1.31 -> 1.32
- eks_addon_test_matrix.json: 1.31 -> 1.32, AL2_x86_64_GPU
- generator: add k8sVersion field to testConfig for per-test overrides
- generator: otel tests override to k8s 1.35 + AL2023 AMIs
- terraform variables.tf: align all defaults to 1.32 (otel dirs keep 1.35)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/25892044219
