### PR TITLE
fix(otel-attr-limit): rename pod sentinel to ensure tier 8 dropping

### DIFF
--- a/terraform/eks/daemon/otel-attr-limit/main.tf
+++ b/terraform/eks/daemon/otel-attr-limit/main.tf
@@ -22,13 +22,18 @@ locals {
   tier6_sentinels = { "ci-test.example.com/sentinel-customer-a" = "v", "ci-test.example.com/sentinel-customer-b" = "v" }
 
   # Padding labels to inflate attribute count.
+  pad_20  = { for i in range(1, 21) : "ci-test.example.com/pad-${format("%03d", i)}" => "v" }
   pad_108 = { for i in range(1, 109) : "ci-test.example.com/pad-${format("%03d", i)}" => "v" }
   pad_120 = { for i in range(1, 121) : "ci-test.example.com/pad-${format("%03d", i)}" => "v" }
 
   common_sentinels = merge(local.tier1_sentinels, local.tier2_sentinels, local.tier3_sentinels, local.tier6_sentinels)
 
-  # Pod padding labels for the high nginx deployment (120 labels as YAML lines).
-  high_pod_padding_yaml = join("\n", [for i in range(1, 121) : "        ci-test.example.com/pod-pad-${format("%03d", i)}: v"])
+  # Pod padding labels for the high nginx deployment (135 labels as YAML lines).
+  # 135 padding + 3 explicit (app, app.kubernetes.io/part-of, aaa-sentinel-pod) = 138 pod labels.
+  # After all tier 1-6 node labels are dropped, the processor enters tier 7/8.
+  # The sentinel is named "aaa-sentinel-pod" to sort alphabetically BEFORE the
+  # pod-pad-* labels, ensuring it is dropped first when the processor prunes tier 8.
+  high_pod_padding_yaml = join("\n", [for i in range(1, 136) : "        ci-test.example.com/pod-pad-${format("%03d", i)}: v"])
 
   low_labels = merge(local.common_sentinels, local.pad_108, {
     "ci-test.example.com/node-color"      = "white"
@@ -40,7 +45,7 @@ locals {
     "ci-test.example.com/attr-limit-node" = "node-mid"
   })
 
-  high_labels = merge(local.common_sentinels, local.pad_120, {
+  high_labels = merge(local.common_sentinels, local.pad_20, {
     "ci-test.example.com/node-color"      = "white"
     "ci-test.example.com/attr-limit-node" = "node-high"
   })
@@ -354,7 +359,7 @@ resource "null_resource" "nginx_high" {
             labels:
               app: attr-limit-nginx-high
               app.kubernetes.io/part-of: attr-limit-test
-              ci-test.example.com/sentinel-pod-customer: v
+              ci-test.example.com/aaa-sentinel-pod: v
       ${local.high_pod_padding_yaml}
           spec:
             nodeSelector:

--- a/test/otel/attr_limit/attribute_limit_test.go
+++ b/test/otel/attr_limit/attribute_limit_test.go
@@ -255,7 +255,7 @@ var tier7KnownPodSentinelKeys = []string{
 }
 
 var tier8CustomerPodSentinelKeys = []string{
-	"k8s.pod.label.ci-test.example.com/sentinel-pod-customer",
+	"k8s.pod.label.ci-test.example.com/aaa-sentinel-pod",
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`TestPhase2TierDroppingHigh` fails because the tier 8 pod sentinel `ci-test.example.com/sentinel-pod-customer` sorts alphabetically **after** all `ci-test.example.com/pod-pad-*` labels. The processor drops tier 8 labels in alphabetical order and stops once under 150, so the sentinel survives while padding labels are dropped first.

## Fix

- Rename pod sentinel to `ci-test.example.com/aaa-sentinel-pod` so it sorts before `pod-pad-*` and is the first tier 8 label dropped
- Increase pod padding from 120 to 135 for additional margin
- Reduce high node padding from 120 to 20 (fewer wasted labels that always get dropped anyway)

## Testing

1. **CDK cluster** (metricsv2-testing, us-east-1, account 322962300869):
   - Patched the nginx-high deployment with renamed sentinel
   - Ran full test suite — all 7 tests pass

2. **Terraform-provisioned cluster** (cwagent-eks-integ-c43edf9f9584a0ac, us-west-2, account 322962300869):
   - Ran `terraform apply` with the fixed `main.tf` — bare EKS cluster, no NFD, matching CI conditions
   - The validator resource (which runs `go test` after 3-min propagation wait) completed successfully
   - All 7 tests passed during the apply

This confirms the fix works in both environments (CDK with NFD labels and bare Terraform without).