### PR TITLE
fix(otel): explicitly enable otelContainerInsights in all EKS daemon otel tests

### DIFF
--- a/terraform/eks/daemon/otel-attr-limit/main.tf
+++ b/terraform/eks/daemon/otel-attr-limit/main.tf
@@ -222,6 +222,7 @@ resource "helm_release" "aws_observability" {
   set = [
     { name = "clusterName", value = aws_eks_cluster.this.name },
     { name = "region", value = var.region },
+    { name = "otelContainerInsights.enabled", value = "true" },
   ]
 
   depends_on = [

--- a/terraform/eks/daemon/otel-ebs-csi/main.tf
+++ b/terraform/eks/daemon/otel-ebs-csi/main.tf
@@ -267,7 +267,8 @@ resource "helm_release" "aws_observability" {
 
   set = [
     { name = "clusterName", value = aws_eks_cluster.this.name },
-    { name = "region", value = var.region }
+    { name = "region", value = var.region },
+    { name = "otelContainerInsights.enabled", value = "true" },
   ]
 
   depends_on = [

--- a/terraform/eks/daemon/otel-efa/main.tf
+++ b/terraform/eks/daemon/otel-efa/main.tf
@@ -264,6 +264,7 @@ resource "helm_release" "aws_observability" {
   set = [
     { name = "clusterName", value = aws_eks_cluster.this.name },
     { name = "region", value = var.region },
+    { name = "otelContainerInsights.enabled", value = "true" },
   ]
 
   depends_on = [

--- a/terraform/eks/daemon/otel-gpu/main.tf
+++ b/terraform/eks/daemon/otel-gpu/main.tf
@@ -335,7 +335,8 @@ resource "helm_release" "aws_observability" {
 
   set = [
     { name = "clusterName", value = aws_eks_cluster.this.name },
-    { name = "region", value = var.region }
+    { name = "region", value = var.region },
+    { name = "otelContainerInsights.enabled", value = "true" },
   ]
 
   depends_on = [

--- a/terraform/eks/daemon/otel-lis-csi/main.tf
+++ b/terraform/eks/daemon/otel-lis-csi/main.tf
@@ -162,7 +162,8 @@ resource "helm_release" "aws_observability" {
 
   set = [
     { name = "clusterName", value = aws_eks_cluster.this.name },
-    { name = "region", value = var.region }
+    { name = "region", value = var.region },
+    { name = "otelContainerInsights.enabled", value = "true" },
   ]
 
   depends_on = [

--- a/terraform/eks/daemon/otel-multi-efa/main.tf
+++ b/terraform/eks/daemon/otel-multi-efa/main.tf
@@ -101,7 +101,8 @@ resource "helm_release" "aws_observability" {
 
   set = [
     { name = "clusterName", value = module.eks.cluster_name },
-    { name = "region", value = var.region }
+    { name = "region", value = var.region },
+    { name = "otelContainerInsights.enabled", value = "true" },
   ]
 
   depends_on = [

--- a/terraform/eks/daemon/otel-neuron/main.tf
+++ b/terraform/eks/daemon/otel-neuron/main.tf
@@ -446,6 +446,7 @@ resource "helm_release" "aws_observability" {
   set = [
     { name = "clusterName", value = aws_eks_cluster.this.name },
     { name = "region", value = var.region },
+    { name = "otelContainerInsights.enabled", value = "true" },
   ]
 
   depends_on = [

--- a/terraform/eks/daemon/otel/main.tf
+++ b/terraform/eks/daemon/otel/main.tf
@@ -138,7 +138,8 @@ resource "helm_release" "aws_observability" {
 
   set = [
     { name = "clusterName", value = aws_eks_cluster.this.name },
-    { name = "region", value = var.region }
+    { name = "region", value = var.region },
+    { name = "otelContainerInsights.enabled", value = "true" },
   ]
 
   depends_on = [


### PR DESCRIPTION
## Summary
- helm-charts PR [#310](https://github.com/aws-observability/helm-charts/pull/310) changed the default for `otelContainerInsights.enabled` from `true` to `false` in `values.yaml`
- All 8 EKS daemon otel integration tests relied on the old default, causing zero metrics to be collected after the helm chart change landed on `release-6.2.0` (May 28)
- This fix explicitly sets `otelContainerInsights.enabled=true` in the helm `set` block for all otel test terraform configs

## Root Cause
The tests clone the latest `release-6.2.0` branch of `aws-observability/helm-charts` at runtime. When PR #310 merged, it flipped `otelContainerInsights.enabled` from `true` (old default) to `false` (new default). Since the test terraform only sets `clusterName` and `region`, it inherits the new default, and the OTEL pipeline never starts.

## Affected Tests
All 8 EKS daemon otel tests that failed in [integration run #26599909586](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/26599909586):
- `otel_standard_test`
- `otel_attr_limit_test`
- `otel_ebs_csi_test`
- `otel_efa_test`
- `otel_multi_efa_test`
- `otel_gpu_test`
- `otel_neuron_test`
- `otel_lis_csi_test`

## Test plan
- [ ] Re-run integration tests on main to confirm all 8 otel tests pass
- [ ] Verify no other tests are affected