### PR TITLE
fix: mitigate OS command injection in local-exec provisioners

### DIFF
--- a/terraform/ecs_ec2/daemon/main.tf
+++ b/terraform/ecs_ec2/daemon/main.tf
@@ -242,15 +242,21 @@ resource "null_resource" "validator" {
     command = <<-EOT
       echo "Validating metrics/logs"
       cd ../../..
-      go test ${var.test_dir} \
+      go test "$TF_TEST_DIR" \
       -timeout 1h \
       -computeType=ECS \
       -ecsLaunchType=EC2 \
       -ecsDeploymentStrategy=DAEMON \
-      -cwagentConfigSsmParamName=${local.cwagent_config_ssm_param_name} \
-      -clusterArn=${aws_ecs_cluster.cluster.arn} \
-      -cwagentECSServiceName=${aws_ecs_service.cwagent_service.name} -v
+      -cwagentConfigSsmParamName="$TF_SSM_PARAM" \
+      -clusterArn="$TF_CLUSTER_ARN" \
+      -cwagentECSServiceName="$TF_SERVICE_NAME" -v
     EOT
+    environment = {
+      TF_TEST_DIR     = var.test_dir
+      TF_SSM_PARAM    = local.cwagent_config_ssm_param_name
+      TF_CLUSTER_ARN  = aws_ecs_cluster.cluster.arn
+      TF_SERVICE_NAME = aws_ecs_service.cwagent_service.name
+    }
   }
   depends_on = [aws_ecs_service.cwagent_service, aws_ecs_service.extra_apps_service, null_resource.disable_metadata]
 }
@@ -261,11 +267,15 @@ resource "null_resource" "disable_metadata" {
     command = <<-EOT
       echo Sleep for 30 seconds to allow instance to be attached to the cluster
       sleep 30
-      echo Setting metadata option for ECS EC2 instance to ${var.metadataEnabled}
-      INSTANCEID=`aws ec2 describe-instances --filters Name=tag:ClusterName,Values=${aws_ecs_cluster.cluster.name} --query "Reservations[*].Instances[*].InstanceId" --output text`
-      echo Instance ID for ECS instance is $INSTANCEID
-      aws ec2 modify-instance-metadata-options --instance-id $INSTANCEID --http-endpoint ${var.metadataEnabled}
+      echo "Setting metadata option for ECS EC2 instance to $TF_METADATA_ENABLED"
+      INSTANCEID=$(aws ec2 describe-instances --filters "Name=tag:ClusterName,Values=$TF_CLUSTER_NAME" --query "Reservations[*].Instances[*].InstanceId" --output text)
+      echo "Instance ID for ECS instance is $INSTANCEID"
+      aws ec2 modify-instance-metadata-options --instance-id "$INSTANCEID" --http-endpoint "$TF_METADATA_ENABLED"
     EOT
+    environment = {
+      TF_CLUSTER_NAME     = aws_ecs_cluster.cluster.name
+      TF_METADATA_ENABLED = var.metadataEnabled
+    }
   }
   depends_on = [aws_ecs_service.cwagent_service, aws_ecs_service.extra_apps_service, aws_autoscaling_group.cluster]
 }

--- a/terraform/ecs_ec2/daemon/variables.tf
+++ b/terraform/ecs_ec2/daemon/variables.tf
@@ -1,6 +1,10 @@
 variable "region" {
   type    = string
   default = "us-west-2"
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.region))
+    error_message = "Region must contain only lowercase letters, digits, and hyphens."
+  }
 }
 
 variable "ami" {
@@ -16,6 +20,10 @@ variable "ec2_instance_type" {
 variable "test_dir" {
   type    = string
   default = "./test/metric_value_benchmark"
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_./-]+$", var.test_dir))
+    error_message = "test_dir must contain only alphanumeric characters, dots, underscores, hyphens, and forward slashes."
+  }
 }
 
 variable "cwagent_image_repo" {
@@ -31,4 +39,8 @@ variable "cwagent_image_tag" {
 variable "metadataEnabled" {
   type    = string
   default = "enabled"
+  validation {
+    condition     = contains(["enabled", "disabled"], var.metadataEnabled)
+    error_message = "metadataEnabled must be either 'enabled' or 'disabled'."
+  }
 }

--- a/terraform/ecs_fargate/linux/main.tf
+++ b/terraform/ecs_fargate/linux/main.tf
@@ -147,16 +147,22 @@ resource "null_resource" "validator" {
     command = <<-EOT
       echo "Validating metrics/logs"
       cd ../../..
-      go test ${var.test_dir} \
+      go test "$TF_TEST_DIR" \
       -timeout 1h \
       -computeType=ECS \
       -ecsLaunchType=FARGATE \
       -ecsDeploymentStrategy=DAEMON \
-      -clusterArn=${aws_ecs_cluster.cluster.arn} \
-      -cwagentECSServiceName=${aws_ecs_service.cwagent_service.name} \
-      -cwagentConfigSsmParamName=${aws_ssm_parameter.cwagent_config.name} \
+      -clusterArn="$TF_CLUSTER_ARN" \
+      -cwagentECSServiceName="$TF_SERVICE_NAME" \
+      -cwagentConfigSsmParamName="$TF_SSM_PARAM" \
       -v
     EOT
+    environment = {
+      TF_TEST_DIR     = var.test_dir
+      TF_CLUSTER_ARN  = aws_ecs_cluster.cluster.arn
+      TF_SERVICE_NAME = aws_ecs_service.cwagent_service.name
+      TF_SSM_PARAM    = aws_ssm_parameter.cwagent_config.name
+    }
   }
   depends_on = [aws_ecs_service.cwagent_service, aws_ecs_service.extra_apps_service]
 }

--- a/terraform/ecs_fargate/linux/variables.tf
+++ b/terraform/ecs_fargate/linux/variables.tf
@@ -4,11 +4,19 @@
 variable "region" {
   type    = string
   default = "us-west-2"
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.region))
+    error_message = "Region must contain only lowercase letters, digits, and hyphens."
+  }
 }
 
 variable "test_dir" {
   type    = string
   default = "./test/ecs/service_discovery"
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_./-]+$", var.test_dir))
+    error_message = "test_dir must contain only alphanumeric characters, dots, underscores, hyphens, and forward slashes."
+  }
 }
 
 variable "cwagent_image_repo" {

--- a/terraform/eks/addon/gpu/main.tf
+++ b/terraform/eks/addon/gpu/main.tf
@@ -17,7 +17,6 @@ data "aws_eks_cluster_auth" "this" {
 
 locals {
   role_arn = format("%s%s", module.basic_components.role_arn, var.beta ? "-eks-beta" : "")
-  aws_eks  = format("%s%s", "aws eks --region ${var.region}", var.beta ? " --endpoint ${var.beta_endpoint}" : "")
 }
 
 resource "aws_eks_cluster" "this" {
@@ -110,10 +109,20 @@ resource "null_resource" "kubectl" {
   ]
   provisioner "local-exec" {
     command = <<-EOT
-      ${local.aws_eks} update-kubeconfig --name ${aws_eks_cluster.this.name}
-      ${local.aws_eks} list-clusters --output text
-      ${local.aws_eks} describe-cluster --name ${aws_eks_cluster.this.name} --output text
+      AWS_EKS_CMD="aws eks --region $TF_REGION"
+      if [ "$TF_BETA" = "true" ]; then
+        AWS_EKS_CMD="$AWS_EKS_CMD --endpoint $TF_BETA_ENDPOINT"
+      fi
+      $AWS_EKS_CMD update-kubeconfig --name "$TF_CLUSTER_NAME"
+      $AWS_EKS_CMD list-clusters --output text
+      $AWS_EKS_CMD describe-cluster --name "$TF_CLUSTER_NAME" --output text
     EOT
+    environment = {
+      TF_REGION        = var.region
+      TF_CLUSTER_NAME  = aws_eks_cluster.this.name
+      TF_BETA          = tostring(var.beta)
+      TF_BETA_ENDPOINT = var.beta_endpoint
+    }
   }
 }
 
@@ -308,17 +317,21 @@ resource "null_resource" "patch_agent_image" {
     command = <<-EOT
       echo "Waiting for CloudWatch Agent DaemonSet to be ready before patching..."
       kubectl rollout status daemonset/cloudwatch-agent -n amazon-cloudwatch --timeout=300s
-      
-      echo "Patching CloudWatch Agent image to ${var.cwagent_image_repo}:${var.cwagent_image_tag}..."
+
+      echo "Patching CloudWatch Agent image to $TF_IMAGE_REPO:$TF_IMAGE_TAG..."
       kubectl patch amazoncloudwatchagents -n amazon-cloudwatch cloudwatch-agent \
         --type='json' \
-        -p='[{"op": "replace", "path": "/spec/image", "value": "${var.cwagent_image_repo}:${var.cwagent_image_tag}"}]'
-      
+        -p="[{\"op\": \"replace\", \"path\": \"/spec/image\", \"value\": \"$TF_IMAGE_REPO:$TF_IMAGE_TAG\"}]"
+
       echo "Waiting for CloudWatch Agent DaemonSet rollout after patching..."
       kubectl rollout status daemonset/cloudwatch-agent -n amazon-cloudwatch --timeout=300s
-      
+
       echo "CloudWatch Agent image patched and rolled out successfully"
     EOT
+    environment = {
+      TF_IMAGE_REPO = var.cwagent_image_repo
+      TF_IMAGE_TAG  = var.cwagent_image_tag
+    }
   }
 
   # Re-run if image changes
@@ -346,11 +359,15 @@ resource "null_resource" "validator" {
       i=0
       while [ $i -lt 10 ]; do
         i=$((i+1))
-        go test ${var.test_dir} -eksClusterName=${aws_eks_cluster.this.name} -computeType=EKS -v -eksDeploymentStrategy=DAEMON -eksGpuType=nvidia && exit 0
+        go test "$TF_TEST_DIR" -eksClusterName="$TF_CLUSTER_NAME" -computeType=EKS -v -eksDeploymentStrategy=DAEMON -eksGpuType=nvidia && exit 0
         sleep 60
       done
       exit 1
     EOT
+    environment = {
+      TF_TEST_DIR     = var.test_dir
+      TF_CLUSTER_NAME = aws_eks_cluster.this.name
+    }
   }
 }
 

--- a/terraform/eks/addon/gpu/variables.tf
+++ b/terraform/eks/addon/gpu/variables.tf
@@ -4,11 +4,19 @@
 variable "region" {
   type    = string
   default = "us-west-2"
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.region))
+    error_message = "Region must contain only lowercase letters, digits, and hyphens."
+  }
 }
 
 variable "test_dir" {
   type    = string
   default = "./test/gpu"
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_./-]+$", var.test_dir))
+    error_message = "test_dir must contain only alphanumeric characters, dots, underscores, hyphens, and forward slashes."
+  }
 }
 
 variable "addon_name" {
@@ -39,16 +47,28 @@ variable "beta" {
 variable "beta_endpoint" {
   type    = string
   default = "https://api.beta.us-west-2.wesley.amazonaws.com"
+  validation {
+    condition     = can(regex("^https://[a-zA-Z0-9._-]+\\.amazonaws\\.com(/[a-zA-Z0-9._/-]*)?$", var.beta_endpoint))
+    error_message = "beta_endpoint must be a valid HTTPS amazonaws.com URL."
+  }
 }
 
 variable "cwagent_image_repo" {
   type        = string
   description = "CloudWatch Agent image repository"
   default     = "public.ecr.aws/cloudwatch-agent/cloudwatch-agent"
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9._/:@-]+$", var.cwagent_image_repo))
+    error_message = "cwagent_image_repo must contain only valid container registry characters."
+  }
 }
 
 variable "cwagent_image_tag" {
   type        = string
   description = "CloudWatch Agent image tag"
   default     = "latest"
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9._-]+$", var.cwagent_image_tag))
+    error_message = "cwagent_image_tag must contain only alphanumeric characters, dots, underscores, and hyphens."
+  }
 }


### PR DESCRIPTION
## Summary

- Add `validation` blocks to user-controllable Terraform variables (`region`, `test_dir`, `beta_endpoint`, `cwagent_image_repo`, `cwagent_image_tag`, `metadataEnabled`) to reject shell metacharacters via strict regex allowlists
- Replace direct `${var.xxx}` interpolation inside `local-exec` provisioner command strings with `environment` maps, so values are passed as real environment variables rather than shell-interpreted strings

This is the same vulnerability class and fix pattern applied in [awslabs/security-hardened-amis-for-eks v20260518](https://github.com/awslabs/security-hardened-amis-for-eks/releases/tag/v20260518).

## Affected Files

| File | Change |
|------|--------|
| `terraform/eks/addon/gpu/variables.tf` | Validation on `region`, `test_dir`, `beta_endpoint`, `cwagent_image_repo`, `cwagent_image_tag` |
| `terraform/eks/addon/gpu/main.tf` | Environment maps on `kubectl`, `patch_agent_image`, `validator` provisioners |
| `terraform/ecs_ec2/daemon/variables.tf` | Validation on `region`, `test_dir`, `metadataEnabled` |
| `terraform/ecs_ec2/daemon/main.tf` | Environment maps on `validator`, `disable_metadata` provisioners |
| `terraform/ecs_fargate/linux/variables.tf` | Validation on `region`, `test_dir` |
| `terraform/ecs_fargate/linux/main.tf` | Environment map on `validator` provisioner |

## Fix Pattern

**Defense-in-depth** with two layers:

1. **Input validation** — `validation {}` blocks ensure variables can only contain characters valid for their purpose (e.g., AWS region names: `^[a-z][a-z0-9-]*$`). Shell metacharacters (`;`, `&&`, `|`, `` ` ``, `$()`) are rejected at plan time.

2. **Environment maps** — Even if validation were bypassed, the `environment = {}` block in provisioners passes values as OS-level environment variables, not as part of the shell command string. The shell script then references them via `"$TF_VAR"` with proper quoting.

## Test Plan

- [ ] `terraform validate` passes on all three modules
- [ ] `terraform plan` succeeds with default variable values
- [ ] `terraform plan` rejects variables with shell metacharacters (e.g., `-var='region=us-west-2; touch /tmp/pwned'`)
- [ ] Existing CI integration tests pass without modification