### PR TITLE
fix(windows): Repair Windows feature integration test pipeline

### DIFF
--- a/generator/resources/ec2_windows_test_matrix.json
+++ b/generator/resources/ec2_windows_test_matrix.json
@@ -1,43 +1,43 @@
 [
   {
     "os": "win-11",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3a.large",
     "ami": "cloudwatch-agent-integration-test-win-11*",
     "useSSM": false
   },
   {
     "os": "win-2016",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3a.large",
     "ami": "cloudwatch-agent-integration-test-win-2016*",
     "useSSM": false
   },
   {
     "os": "win-2019",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3a.large",
     "ami": "cloudwatch-agent-integration-test-win-2019*",
     "useSSM": false
   },
   {
     "os": "win-2022",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3a.large",
     "ami": "cloudwatch-agent-integration-test-win-2022*",
     "useSSM": false
   },
   {
     "os": "win-2022",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3a.large",
     "ami": "cloudwatch-agent-integration-test-win-2022*",
     "useSSM": true
   },
   {
     "os": "win-2025",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3a.large",
     "ami": "cloudwatch-agent-integration-test-win-2025*",
     "useSSM": false
   },
   {
     "os": "win-2025",
-    "instanceType":"t3a.medium",
+    "instanceType":"t3a.large",
     "ami": "cloudwatch-agent-integration-test-win-2025*",
     "useSSM": true
   }

--- a/terraform/ec2/win/main.tf
+++ b/terraform/ec2/win/main.tf
@@ -137,7 +137,7 @@ resource "null_resource" "integration_test_setup_agent" {
       "aws s3 cp s3://${var.s3_bucket}/integration-test/packaging/${var.cwa_github_sha}/amazon-cloudwatch-agent.msi .",
       "powershell.exe -Command \"Write-Output 'Checking for running msiexec processes...'; while (Get-Process msiexec -ErrorAction SilentlyContinue) { Write-Output 'msiexec running; sleeping 10s...'; Start-Sleep -Seconds 10 }; Write-Output 'No msiexec found; starting installer'; Start-Process -FilePath msiexec -ArgumentList '/i amazon-cloudwatch-agent.msi /norestart /qb-' -Wait\"",
       "if %errorlevel% neq 0 (echo MSI install failed with code %errorlevel% & exit 1)",
-      "powershell.exe -Command \"$retries = 0; $maxRetries = 30; $found = $false; while ($retries -lt $maxRetries -and -not $found) { if (Test-Path 'C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1') { $found = $true; Write-Output 'amazon-cloudwatch-agent-ctl.ps1 found in expected location'; } else { $scriptPath = Get-ChildItem -Path 'C:\\Program Files' -Filter amazon-cloudwatch-agent-ctl.ps1 -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName; if ($scriptPath) { $found = $true; Write-Output 'amazon-cloudwatch-agent-ctl.ps1 found at: ' + $scriptPath; } } if (-not $found) { Start-Sleep -Seconds 10; $retries++ } } if (-not $found) { Write-Output 'amazon-cloudwatch-agent-ctl.ps1 not found after installation and retries'; exit 1 }\""
+      "powershell.exe -Command \"$path = 'C:\\Program Files\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1'; for ($i = 0; $i -lt 30; $i++) { if (Test-Path $path) { Write-Output 'amazon-cloudwatch-agent-ctl.ps1 found in expected location'; exit 0 } Start-Sleep -Seconds 5 } Write-Output 'amazon-cloudwatch-agent-ctl.ps1 not found at expected path after 150s'; exit 1\""
     ]
   }
 }
@@ -241,6 +241,7 @@ resource "null_resource" "integration_test_run_validator" {
     user     = "Administrator"
     password = rsadecrypt(aws_instance.cwagent.password_data, local.private_key_content)
     host     = aws_instance.cwagent.public_dns
+    timeout  = "10m"
   }
 
   provisioner "file" {
@@ -266,7 +267,7 @@ resource "null_resource" "integration_test_run_validator" {
       "set AWS_REGION=${var.region}",
       "git clone --branch ${var.github_test_repo_branch} ${var.github_test_repo}",
       "cd amazon-cloudwatch-agent-test",
-      "go test ./test/sanity -p 1 -v",
+      "powershell.exe -ExecutionPolicy Bypass -File test\\sanity\\resources\\verifyWindowsCtlScript.ps1",
       "cd ..",
 
       # Retry logic for amazon-cloudwatch-agent-ctl.ps1 with timeout

--- a/test/feature/windows/parameters.yml
+++ b/test/feature/windows/parameters.yml
@@ -202,8 +202,8 @@ metric_validation:
   - metric_name: "Fault"
     metric_sample_count: 12
     metric_dimension:
-      - name: "HostedIn.Environment"
-        value: "Generic"
+      - name: "Environment"
+        value: "ec2:default"
       - name: "Operation"
         value: "operation"
       - name: "Service"
@@ -211,8 +211,8 @@ metric_validation:
   - metric_name: "Latency"
     metric_sample_count: 12
     metric_dimension:
-      - name: "HostedIn.Environment"
-        value: "Generic"
+      - name: "Environment"
+        value: "ec2:default"
       - name: "Operation"
         value: "operation"
       - name: "Service"
@@ -220,8 +220,8 @@ metric_validation:
   - metric_name: "Error"
     metric_sample_count: 12
     metric_dimension:
-      - name: "HostedIn.Environment"
-        value: "Generic"
+      - name: "Environment"
+        value: "ec2:default"
       - name: "Operation"
         value: "operation"
       - name: "Service"

--- a/test/sanity/sanity_windows.go
+++ b/test/sanity/sanity_windows.go
@@ -6,15 +6,17 @@
 
 package sanity
 
-import (
-	"testing"
+import "testing"
 
-	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
-)
-
+// NOTE: The Windows sanity check is intentionally disabled.
+//
+// Running this via `go test ./test/sanity -p 1 -v` on Windows runners
+// requires compiling the entire util/common import graph, which transitively
+// pulls in aws-sdk-go-v2/service/ec2 (1700+ files) causing it to timing out the job.
+//
+// It has been replaced by invoking the PowerShell script directly from
+// terraform/ec2/win/main.tf:
+//	powershell.exe -ExecutionPolicy Bypass -File test\sanity\resources\verifyWindowsCtlScript.ps1
 func SanityCheck(t *testing.T) {
-	_, err := common.RunShellScript("resources/verifyWindowsCtlScript.ps1")
-	if err != nil {
-		t.Fatalf("Running sanity check failed")
-	}
+	t.Skip("Windows sanity check runs via verifyWindowsCtlScript.ps1 directly from terraform; see note above")
 }

--- a/util/common/logs.go
+++ b/util/common/logs.go
@@ -72,8 +72,10 @@ func StartLogWrite(configFilePath string, duration time.Duration, sendingInterva
 	}
 
 	for _, logPath := range logPaths {
+		log.Printf("StartLogWrite: dispatching writer goroutine for log file %q", logPath)
 		go func(logPath string) {
 			if err := writeToLogs(logPath, duration, sendingInterval, logLinesPerMinute); err != nil {
+				log.Printf("StartLogWrite: writeToLogs for %q returned error: %v", logPath, err)
 				multiErr = multierr.Append(multiErr, err)
 			}
 		}(logPath)
@@ -85,12 +87,20 @@ func StartLogWrite(configFilePath string, duration time.Duration, sendingInterva
 // writeToLogs opens a file at the specified file path and writes the specified number of lines per second (tps)
 // for the specified duration
 func writeToLogs(filePath string, duration, sendingInterval time.Duration, logLinesPerMinute int) error {
+	log.Printf("writeToLogs: creating %q (duration=%s, sendingInterval=%s, linesPerMinute=%d)", filePath, duration, sendingInterval, logLinesPerMinute)
 	f, err := os.Create(filePath)
 	if err != nil {
+		log.Printf("writeToLogs: os.Create(%q) failed: %v", filePath, err)
 		return err
 	}
-	defer f.Close()
-	defer os.Remove(filePath)
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			log.Printf("writeToLogs: f.Close(%q) failed: %v", filePath, cerr)
+		}
+		if rerr := os.Remove(filePath); rerr != nil {
+			log.Printf("writeToLogs: os.Remove(%q) failed: %v", filePath, rerr)
+		}
+	}()
 
 	ticker := time.NewTicker(sendingInterval)
 	defer ticker.Stop()

--- a/util/common/metrics.go
+++ b/util/common/metrics.go
@@ -84,7 +84,7 @@ func StartSendingMetrics(receiver string, duration, sendingInterval time.Duratio
 }
 
 func SendAppSignalsTraceMetrics(duration time.Duration) error {
-	baseDir := getBaseDir()
+	baseDir := getAppSignalsResourceDir("traces")
 
 	for i := 0; i < int(duration/(5*time.Second)); i++ {
 		startTime := time.Now().UnixNano()
@@ -182,11 +182,11 @@ func SendPrometheusMetrics(config PrometheusConfig, agentCollectionDuration time
 	return nil
 }
 
-func getBaseDir() string {
+func getAppSignalsResourceDir(subdir string) string {
 	if runtime.GOOS == "windows" {
-		return "C:\\Users\\Administrator\\amazon-cloudwatch-agent-test\\test\\app_signals\\resources\\traces"
+		return filepath.Join("C:\\", "Users", "Administrator", "amazon-cloudwatch-agent-test", "test", "app_signals", "resources", subdir)
 	}
-	return "/Users/ec2-user/amazon-cloudwatch-agent-test/test/app_signals/resources/traces"
+	return filepath.Join("/", "Users", "ec2-user", "amazon-cloudwatch-agent-test", "test", "app_signals", "resources", subdir)
 }
 
 func generateTraceID() [16]byte {
@@ -344,13 +344,7 @@ func SendAppSignalMetrics(duration time.Duration) error {
 	}
 	fmt.Println("Current Directory:", dir)
 
-	// Determine the base directory for the files based on the OS
-	var baseDir string
-	if runtime.GOOS == "windows" {
-		baseDir = filepath.Join("C:", "Users", "Administrator", "amazon-cloudwatch-agent-test", "test", "app_signals", "resources", "metrics")
-	} else { // assuming macOS or Unix-like system
-		baseDir = filepath.Join("/", "Users", "ec2-user", "amazon-cloudwatch-agent-test", "test", "app_signals", "resources", "metrics")
-	}
+	baseDir := getAppSignalsResourceDir("metrics")
 
 	fmt.Println("Base directory:", baseDir)
 

--- a/validator/validators/basic/basic_validator.go
+++ b/validator/validators/basic/basic_validator.go
@@ -23,7 +23,7 @@ import (
 )
 
 const metricErrorBound = 0.1
-const AppSignalNamespace = "AppSignals"
+const AppSignalNamespace = "ApplicationSignals"
 
 type BasicValidator struct {
 	vConfig models.ValidateConfig
@@ -106,7 +106,7 @@ func (s *BasicValidator) CheckData(startTime, endTime time.Time) error {
 		} else {
 			err := s.ValidateMetric(metric.MetricName, metricNamespace, metricDimensions, metric.MetricValue, metric.MetricSampleCount, startTime, endTime)
 			if err != nil {
-				return err
+				multiErr = multierr.Append(multiErr, err)
 			}
 		}
 
@@ -154,9 +154,8 @@ func (s *BasicValidator) ValidateAppSignalMetrics(metric models.MetricValidation
 		if err != nil {
 			return err
 		}
-		if !AppSignalMetrics.IsAllValuesGreaterThanOrEqualToExpectedValue(metric.MetricName, values, 0) {
-			fmt.Printf("Error values are not the epected values%v", err)
-			return err
+		if err := AppSignalMetrics.IsAllValuesGreaterThanOrEqualToExpectedValueWithError(metric.MetricName, values, 0); err != nil {
+			return fmt.Errorf("App Signals metric %s validation failed: %w", metric.MetricName, err)
 		}
 	}
 


### PR DESCRIPTION
The Windows feature_windows_test (win-2016 / win-2022 / win-11 variants) had been failing due to a stack of compounding bugs across the test harness, validator, and Terraform infrastructure. This lands the full set of verified fixes.

App Signals load generation
* SendAppSignals{Trace,}Metrics built the resource base directory via filepath.Join("C:", ...), which on Windows produces a volume-relative path ("C:Users\...") rather than an absolute one, so the workload's server_consumer.json / client_producer.json could never load. Consolidate path resolution in getAppSignalsResourceDir(subdir) using an absolute "C:\\" root.

App Signals validation (was a structural no-op)
* AppSignalNamespace was "AppSignals"; the agent emits to "ApplicationSignals".
* Fault/Latency/Error assertions in parameters.yml used the stale HostedIn.Environment=Generic dimension; the agent emits Environment=ec2:default.
* ValidateAppSignalMetrics called the boolean variant of IsAllValuesGreaterThanOrEqualToExpectedValue and then returned an err that was guaranteed nil, swallowing every failure. Switch to the *WithError variant and wrap the error with context.

Validator robustness
* CheckData early-returned on the first non-App-Signals metric failure, skipping all remaining metric and log validations (so one flaky metric masked the entire log suite). Switch to multierr.Append.

Log file generation
* writeToLogs registered cleanup defers in the wrong LIFO order, running os.Remove before f.Close. On Windows this left the file in delete-pending state and the agent's tail tracker lost the file. Use a single deferred function with explicit Close-then-Remove ordering. Per-cycle removal is required because the agent tracks tailed files by path+byte-offset and silently skips subsequent cycles after an in-place truncation. Added log lines around the writer lifecycle for observability.

Windows test infrastructure (terraform/ec2/win/main.tf)
* Replace the post-msiexec Get-ChildItem -Recurse fallback with a Test-Path polling loop; the -Recurse walk over C:\Program Files was hanging WinRM for 5+ minutes.
* Replace the on-host `go test ./test/sanity -p 1 -v` with a direct invocation of verifyWindowsCtlScript.ps1. On Windows the sanity test forces a compile of the full util/common import graph (transitively aws-sdk-go-v2/service/ec2, 1700+ files), taking 7-50+ minutes and frequently hanging WinRM. The PowerShell script does the same sanity work in seconds with no Go compile. The Windows SanityCheck Go entry point is left commented-out (with a no-op stub so the package still compiles) as a reference for re-enabling it in the future.
* Set the validator-run WinRM connection timeout to 10m. The longest command in the block is now validator.exe (~9 min for 3 retries), so 10m gives a sane safety margin without giving hung commands excess rope.

Instance capacity
* Bump Windows EC2 integration test instances from t3a.medium (4 GB) to t3a.large (8 GB) across all rows. The JMX workload plus the SDK compile exceeded the 4 GB commit-charge limit and produced VirtualAlloc errno=1455 OOMs.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* https://github.com/aws/amazon-cloudwatch-agent/actions/runs/27989411762
