### PR TITLE
fix(mac): Repair mac feature integration test pipeline

### DIFF
--- a/terraform/ec2/assume_role/main.tf
+++ b/terraform/ec2/assume_role/main.tf
@@ -247,7 +247,7 @@ resource "null_resource" "integration_test_run" {
         "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
         "echo run integration test",
         "cd ~/amazon-cloudwatch-agent-test",
-        "echo run sanity test && go test ./test/sanity -p 1 -v",
+        "echo run sanity test && go test ./test/sanity -p 1 -v || exit 1",
         "echo base assume role arn is ${aws_iam_role.roles["no_context_keys"].arn}",
         "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -assumeRoleArn=${aws_iam_role.roles["no_context_keys"].arn} -instanceArn=${aws_instance.cwagent.arn} -accountId=${data.aws_caller_identity.account_id.account_id} -v"
       ],

--- a/terraform/ec2/creds/main.tf
+++ b/terraform/ec2/creds/main.tf
@@ -204,7 +204,7 @@ resource "null_resource" "integration_test_run" {
         "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
         "echo run integration test",
         "cd ~/amazon-cloudwatch-agent-test",
-        "echo run sanity test && go test ./test/sanity -p 1 -v",
+        "echo run sanity test && go test ./test/sanity -p 1 -v || exit 1",
         "echo assume role arn is ${aws_iam_role.assume_role.arn}",
         "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -assumeRoleArn=${aws_iam_role.assume_role.arn} -instanceId=${aws_instance.cwagent.id} -v"
       ],

--- a/terraform/ec2/efa/main.tf
+++ b/terraform/ec2/efa/main.tf
@@ -257,7 +257,7 @@ resource "null_resource" "integration_test_run" {
       "export PATH=$PATH:/snap/bin:/usr/local/go/bin",
       "cd ~/amazon-cloudwatch-agent-test",
       "echo Running sanity test...",
-      "go test ./test/sanity -p 1 -v",
+      "go test ./test/sanity -p 1 -v || exit 1",
       "echo Running EFA integration test...",
       "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -excludedTests='${var.excluded_tests}' -cwaCommitSha=${var.cwa_github_sha} -instanceId=${aws_instance.cwagent.id} -v",
     ]

--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -254,7 +254,7 @@ resource "null_resource" "integration_test_run" {
         "echo 'Pre-test setup: Replacing {instance_id} and $${aws:InstanceId} placeholders in test resource configs'; find . -path '${var.test_dir}/resources/*.json' -exec sed -i 's/{instance_id}/${module.linux_common.cwagent_id}/g' {} \\; -exec sed -i 's/$${aws:InstanceId}/${module.linux_common.cwagent_id}/g' {} \\; && echo 'Updated all config files in resources directories'"
         ] : [
         "echo Running sanity test...",
-        "go test ./test/sanity -p 1 -v",
+        "go test ./test/sanity -p 1 -v || exit 1",
       ],
 
       [

--- a/terraform/ec2/mac/main.tf
+++ b/terraform/ec2/mac/main.tf
@@ -133,12 +133,12 @@ resource "null_resource" "integration_test" {
       "echo Execute integration tests",
       "export AWS_REGION=${var.region}",
       "sudo chmod +x ./validator",
-      "./validator --validator-config=${module.validator.instance_validator_config} --preparation-mode=true",
-      "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:${module.validator.instance_agent_config}",
-      "./validator --validator-config=${module.validator.instance_validator_config} --preparation-mode=false",
-      "cd ~/amazon-cloudwatch-agent-test",
-      "echo run sanity test && sudo /usr/local/go/bin/go test ./test/sanity -p 1 -v",
-      "sudo /usr/local/go/bin/go test ./test/run_as_user -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -cwaCommitSha=${var.cwa_github_sha} -instanceId=${aws_instance.cwagent.id} -v",
+      "./validator --validator-config=${module.validator.instance_validator_config} --preparation-mode=true || exit 1",
+      "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:${module.validator.instance_agent_config} || exit 1",
+      "./validator --validator-config=${module.validator.instance_validator_config} --preparation-mode=false || exit 1",
+      "cd ~/amazon-cloudwatch-agent-test || exit 1",
+      "echo run sanity test && sudo /usr/local/go/bin/go test ./test/sanity -p 1 -v || exit 1",
+      "sudo /usr/local/go/bin/go test ./test/run_as_user -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -cwaCommitSha=${var.cwa_github_sha} -instanceId=${aws_instance.cwagent.id} -v || exit 1",
     ]
   }
 

--- a/terraform/ec2/userdata/main.tf
+++ b/terraform/ec2/userdata/main.tf
@@ -97,7 +97,7 @@ resource "null_resource" "integration_test" {
         "timeout 120 bash -c 'until [ -f /home/ec2-user/amazon-cloudwatch-agent-test/test/sanity/resources/verifyUnixCtlScript.sh ]; do echo \"Waiting for verifyUnixCtlScript.sh...\"; sleep 2; done'",
         "cd ~/amazon-cloudwatch-agent-test",
         "sudo chmod 777 ~/amazon-cloudwatch-agent-test/test/sanity/resources/verifyUnixCtlScript.sh",
-        "echo run sanity test && go test ./test/sanity -p 1 -v",
+        "echo run sanity test && go test ./test/sanity -p 1 -v || exit 1",
         "go test ${var.test_dir} -p 1 -timeout 1h -computeType=EC2 -bucket=${var.s3_bucket} -plugins='${var.plugin_tests}' -cwaCommitSha=${var.cwa_github_sha} -caCertPath=${var.ca_cert_path} -v"
       ],
     )

--- a/test/feature/mac/parameters.yml
+++ b/test/feature/mac/parameters.yml
@@ -131,8 +131,8 @@ metric_validation:
   - metric_name: "Fault"
     metric_sample_count: 60
     metric_dimension:
-      - name: "HostedIn.Environment"
-        value: "Generic"
+      - name: "Environment"
+        value: "ec2:default"
       - name: "Operation"
         value: "operation"
       - name: "Service"
@@ -140,8 +140,8 @@ metric_validation:
   - metric_name: "Latency"
     metric_sample_count: 60
     metric_dimension:
-      - name: "HostedIn.Environment"
-        value: "Generic"
+      - name: "Environment"
+        value: "ec2:default"
       - name: "Operation"
         value: "operation"
       - name: "Service"
@@ -149,8 +149,8 @@ metric_validation:
   - metric_name: "Error"
     metric_sample_count: 60
     metric_dimension:
-      - name: "HostedIn.Environment"
-        value: "Generic"
+      - name: "Environment"
+        value: "ec2:default"
       - name: "Operation"
         value: "operation"
       - name: "Service"

--- a/test/sanity/resources/verifyUnixCtlScript.sh
+++ b/test/sanity/resources/verifyUnixCtlScript.sh
@@ -22,7 +22,7 @@ assertStatus() {
           ;;
      esac
 
-     result=$(/usr/bin/amazon-cloudwatch-agent-ctl -a status | grep "${grepKey}" | awk -F: '{print $2}' | sed 's/ "//; s/",//')
+     result=$(/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | grep "${grepKey}" | awk -F: '{print $2}' | sed 's/ "//; s/",//')
 
      if [ "${result}" = "${expectedVal}" ]; then
           echo "In step ${step}, ${keyToCheck} is expected"
@@ -34,52 +34,52 @@ assertStatus() {
 
 # init
 step=0
-/usr/bin/amazon-cloudwatch-agent-ctl -a remove-config -c all
-/usr/bin/amazon-cloudwatch-agent-ctl -a stop
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a remove-config -c all
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a stop
 
 step=1
-/usr/bin/amazon-cloudwatch-agent-ctl -a status
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status
 assertStatus "cwa_running_status" "stopped"
 assertStatus "cwa_config_status" "not configured"
 
 step=2
-/usr/bin/amazon-cloudwatch-agent-ctl -a start
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a start
 assertStatus "cwa_running_status" "running"
 assertStatus "cwa_config_status" "configured"
 
 step=3
-/usr/bin/amazon-cloudwatch-agent-ctl -a remove-config -c default -s
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a remove-config -c default -s
 assertStatus "cwa_running_status" "running"
 assertStatus "cwa_config_status" "configured"
 
 step=4
-/usr/bin/amazon-cloudwatch-agent-ctl -a prep-restart
-/usr/bin/amazon-cloudwatch-agent-ctl -a stop
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a prep-restart
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a stop
 assertStatus "cwa_running_status" "stopped"
 assertStatus "cwa_config_status" "configured"
 
 step=5
-/usr/bin/amazon-cloudwatch-agent-ctl -a cond-restart
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a cond-restart
 assertStatus "cwa_running_status" "running"
 assertStatus "cwa_config_status" "configured"
 
 step=6
-/usr/bin/amazon-cloudwatch-agent-ctl -a append-config -c default -s
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -c default -s
 assertStatus "cwa_running_status" "running"
 assertStatus "cwa_config_status" "configured"
 
 step=7
-/usr/bin/amazon-cloudwatch-agent-ctl -a remove-config -c all
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a remove-config -c all
 assertStatus "cwa_running_status" "running"
 assertStatus "cwa_config_status" "not configured"
 
 step=8
-/usr/bin/amazon-cloudwatch-agent-ctl -a fetch-config -s
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -s
 assertStatus "cwa_running_status" "running"
 assertStatus "cwa_config_status" "configured"
 
 step=9
-/usr/bin/amazon-cloudwatch-agent-ctl -a remove-config -c all
-/usr/bin/amazon-cloudwatch-agent-ctl -a stop
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a remove-config -c all
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a stop
 assertStatus "cwa_running_status" "stopped"
 assertStatus "cwa_config_status" "not configured"


### PR DESCRIPTION
The mac feature_mac_test (and its Monterey/Ventura/Sonoma Amd64/Arm64 variants) was reporting green despite multiple silently-broken assertions. This commit lands the verified set of fixes.

### Test harness exit-code propagation (terraform/ec2)
* Terraform remote-exec runs inline lists through the remote shell without 'set -e', so only the last command's exit code determines provisioner success. On mac the validator binary, fetch-config call, and the unix sanity test all ran mid-script and their non-zero exits were silently swallowed; only the final 'go test ./test/run_as_user' gated the result. Guard each critical command with '|| exit 1' so failures actually fail the job. Verified locally via terraform apply reproduction (mid-script 'false' was ignored unless guarded).
* Apply the same guard to the other unix terraform configs that share the pattern (linux, efa, creds, assume_role, userdata) -- on those the sanity test runs mid-script before the integration test (last command), so a real sanity regression would have gone undetected.

### App Signals dimensions (test/feature/mac/parameters.yml)
* Mac feature parameters.yml asserted Fault/Latency/Error metrics with HostedIn.Environment=Generic. The agent emits these to the ApplicationSignals namespace with Environment=ec2:default (verified against CloudWatch). The dimension mismatch caused the validator's Fetch to return zero datapoints, which previously slipped past two layers of swallowed errors (namespace+validator+harness). Update to the correct Environment=ec2:default dimension, matching the analogous fix landed for Windows in #713.

### Unix sanity script ctl binary path (test/sanity/resources)
* verifyUnixCtlScript.sh invoked /usr/bin/amazon-cloudwatch-agent-ctl via absolute path. That symlink is created by the Linux rpm spec (amazon-cloudwatch-agent.spec line 32: ln -f -s /opt/aws/.../ctl /usr/bin/ctl) but is not created by the mac pkg installer (pkgutil shows only /opt/aws/amazon-cloudwatch-agent/bin/ctl). Every ctl invocation in the script therefore failed with exit 127 on mac. Switch to /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -- the canonical install location on both OSes (Linux's /usr/bin entry is itself a symlink to this path). Verified end-to-end on a live mac instance via SSM: all 9 sanity steps pass with the fix.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* https://github.com/aws/amazon-cloudwatch-agent/actions/runs/28072414127