### PR TITLE
fix: read mac pkg tar.gz from CWD so arm64/amd64 stay distinct

### DIFF
--- a/pkg/tools/create_pkg.sh
+++ b/pkg/tools/create_pkg.sh
@@ -6,7 +6,7 @@ AGENT_VERSION=$(</tmp/CWAGENT_VERSION)
 #create a .pkg file
 rm -rf /tmp/AmazonCWAgentPackage
 mkdir /tmp/AmazonCWAgentPackage
-gunzip -c /tmp/amazon-cloudwatch-agent.tar.gz | tar -C /tmp/AmazonCWAgentPackage -xvf -
+gunzip -c ./amazon-cloudwatch-agent.tar.gz | tar -C /tmp/AmazonCWAgentPackage -xvf -
 COMMON_CONFIG_PATH=/tmp/AmazonCWAgentPackage/opt/aws/amazon-cloudwatch-agent/etc/common-config.toml
 SAMPLE_SUFFIX=SAMPLE_DO_NOT_MODIFY
 mv ${COMMON_CONFIG_PATH} ${COMMON_CONFIG_PATH}.${SAMPLE_SUFFIX}


### PR DESCRIPTION
# Description of the issue
The MakeMacPkg job in the agent repo's test-build-packages.yml workflow invokes pkg/tools/create_pkg.sh twice per build:

  cd /tmp/        && ./create_pkg.sh ... amd64
  cd /tmp/arm64/  && ./create_pkg.sh ... arm64

Each working directory is pre-staged with its own arch-specific amazon-cloudwatch-agent.tar.gz produced by the agent Makefile's package-darwin target. The script was supposed to pick up the local tar.gz per invocation.

However, the script hardcoded an absolute path:

  gunzip -c /tmp/amazon-cloudwatch-agent.tar.gz | tar ...

The second invocation (arm64) therefore re-read the amd64 tar.gz left at /tmp/, producing an arm64-labeled .pkg that actually contained x86_64 binaries. On Apple Silicon mac2.metal hosts in CI, this caused the installed CWA agent to run under Rosetta 2 translation, generating enough CPU wake-ups to trip macOS Monterey's symptomsd 150-wakes/sec resource limit. The kernel sent SIGTRAP, launchd respawned the agent, and the UDP :8125 statsd socket cycled closed/open — silently dropping test packets sent during the dead window and flaking feature_mac_test's statsd_gauge_1 / statsd_counter_1 assertions on Monterey arm64 runs.

# Description of changes
Changing the path to relative ./amazon-cloudwatch-agent.tar.gz makes each invocation read its own arch tar.gz from CWD. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Verified by extracting the resulting S3 pkgs:

- Before fix: arm64 pkg and amd64 pkg had byte-identical x86_64 binaries (every SHA-256 matched).
- After fix: arm64 pkg contains 'Mach-O 64-bit executable arm64' binaries; all SHAs differ from the amd64 pkg; previously-flaky Monterey arm64 feature_mac_test passes on first attempt with validator retries disabled.

Test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/28217578554
