### PR TITLE
Standardize EFA test cluster names to cwagent-eks-integ- prefix

### DIFF
--- a/terraform/eks/daemon/efa/main.tf
+++ b/terraform/eks/daemon/efa/main.tf
@@ -14,7 +14,7 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.0"
 
-  name               = "integ-${module.common.testing_id}"
+  name               = "cwagent-eks-integ-${module.common.testing_id}"
   kubernetes_version = var.k8s_version
 
   vpc_id     = aws_vpc.efa_test_vpc.id

--- a/terraform/eks/daemon/otel-multi-efa/main.tf
+++ b/terraform/eks/daemon/otel-multi-efa/main.tf
@@ -15,7 +15,7 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.0"
 
-  name               = "cwagent-mefa-${module.common.testing_id}"
+  name               = "cwagent-eks-integ-${module.common.testing_id}"
   kubernetes_version = var.k8s_version
 
   vpc_id     = aws_vpc.efa_test_vpc.id


### PR DESCRIPTION
# Description of changes
The efa and otel-multi-efa EKS tests used divergent cluster names (integ-* and cwagent-mefa-*) while every other integ/e2e EKS test uses the shared cwagent-eks-integ- prefix. Align both so the cluster-cleaner allowlist covers them without EFA-specific prefixes.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A
