### PR TITLE
Use unique SSM parameter names and fix command-completion helper in ssm_document test

### DIFF
--- a/test/ssm_document/helper.go
+++ b/test/ssm_document/helper.go
@@ -14,6 +14,16 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 )
 
+// cleanupSSMParameter best-effort deletes an SSM parameter, logging any failure. Defer it
+// immediately after each PutStringParameter so a failure in a later step never leaves a
+// uniquely-named parameter orphaned in the account.
+func cleanupSSMParameter(name string) {
+	log.Printf("Cleaning up SSM parameter: %s", name)
+	if err := awsservice.DeleteParameter(name); err != nil {
+		log.Printf("Warning: Failed to delete SSM parameter %s: %v", name, err)
+	}
+}
+
 func RunAndVerifySSMAction(documentName string, instanceIds []string, tc testCase) error {
 	log.Printf("Testing %s action", tc.actionName)
 

--- a/test/ssm_document/ssm_document_unix.go
+++ b/test/ssm_document/ssm_document_unix.go
@@ -40,6 +40,8 @@ func Validate() error {
 	// Generate unique ID to guarantee uniqueness
 	uniqueID := uuid.New().String()[:8]
 	documentName := testManageAgentDocument + uniqueID
+	agentConfig1Name := agentConfigFile1 + "-" + uniqueID
+	agentConfig2Name := agentConfigFile2 + "-" + uniqueID
 	metadata := environment.GetEnvironmentMetaData()
 	instanceIds := []string{metadata.InstanceId}
 
@@ -104,16 +106,17 @@ func Validate() error {
 	}
 
 	// Test configure action
-	log.Printf("Putting SSM parameter: %s", agentConfigFile1)
-	if err := awsservice.PutStringParameter(agentConfigFile1, agentConfig1); err != nil {
+	log.Printf("Putting SSM parameter: %s", agentConfig1Name)
+	if err := awsservice.PutStringParameter(agentConfig1Name, agentConfig1); err != nil {
 		return err
 	}
+	defer cleanupSSMParameter(agentConfig1Name)
 
 	configureTest := testCase{
 		parameters: map[string][]string{
 			paramAction:                        {actionConfigure},
 			paramOptionalConfigurationSource:   {configSourceSSM},
-			paramOptionalConfigurationLocation: {agentConfigFile1},
+			paramOptionalConfigurationLocation: {agentConfig1Name},
 		},
 		actionName:           actionConfigure,
 		expectedAgentStatus:  agentStatusRunning,
@@ -124,26 +127,17 @@ func Validate() error {
 	}
 
 	// Test configure (append) action
-	log.Printf("Putting SSM parameter: %s", agentConfigFile2)
-	if err := awsservice.PutStringParameter(agentConfigFile2, agentConfig2); err != nil {
+	log.Printf("Putting SSM parameter: %s", agentConfig2Name)
+	if err := awsservice.PutStringParameter(agentConfig2Name, agentConfig2); err != nil {
 		return err
 	}
-
-	// Ensure SSM parameters are cleaned up
-	defer func() {
-		for _, paramName := range []string{agentConfigFile1, agentConfigFile2} {
-			log.Printf("Cleaning up SSM parameter: %s", paramName)
-			if deleteErr := awsservice.DeleteParameter(paramName); deleteErr != nil {
-				log.Printf("Warning: Failed to delete SSM parameter %s: %v", paramName, deleteErr)
-			}
-		}
-	}()
+	defer cleanupSSMParameter(agentConfig2Name)
 
 	appendTest := testCase{
 		parameters: map[string][]string{
 			paramAction:                        {actionConfigureAppend},
 			paramOptionalConfigurationSource:   {configSourceSSM},
-			paramOptionalConfigurationLocation: {agentConfigFile2},
+			paramOptionalConfigurationLocation: {agentConfig2Name},
 		},
 		actionName:           actionConfigureAppend,
 		expectedAgentStatus:  agentStatusRunning,

--- a/test/ssm_document/ssm_document_windows.go
+++ b/test/ssm_document/ssm_document_windows.go
@@ -32,6 +32,8 @@ func Validate() error {
 	// Generate unique ID to guarantee uniqueness
 	uniqueID := uuid.New().String()[:8]
 	documentName := testManageAgentDocument + uniqueID
+	agentConfig1Name := agentConfigFile1 + "-" + uniqueID
+	agentConfig2Name := agentConfigFile2 + "-" + uniqueID
 	metadata := environment.GetEnvironmentMetaData()
 	instanceIds := []string{metadata.InstanceId}
 
@@ -89,16 +91,17 @@ func Validate() error {
 	}
 
 	// Test configure action
-	log.Printf("Putting SSM parameter: %s", agentConfigFile1)
-	if err := awsservice.PutStringParameter(agentConfigFile1, agentConfig1); err != nil {
+	log.Printf("Putting SSM parameter: %s", agentConfig1Name)
+	if err := awsservice.PutStringParameter(agentConfig1Name, agentConfig1); err != nil {
 		return err
 	}
+	defer cleanupSSMParameter(agentConfig1Name)
 
 	configureTest := testCase{
 		parameters: map[string][]string{
 			paramAction:                        {actionConfigure},
 			paramOptionalConfigurationSource:   {configSourceSSM},
-			paramOptionalConfigurationLocation: {agentConfigFile1},
+			paramOptionalConfigurationLocation: {agentConfig1Name},
 		},
 		actionName:           actionConfigure,
 		expectedAgentStatus:  agentStatusRunning,
@@ -109,26 +112,17 @@ func Validate() error {
 	}
 
 	// Test configure (append) action
-	log.Printf("Putting SSM parameter: %s", agentConfigFile2)
-	if err := awsservice.PutStringParameter(agentConfigFile2, agentConfig2); err != nil {
+	log.Printf("Putting SSM parameter: %s", agentConfig2Name)
+	if err := awsservice.PutStringParameter(agentConfig2Name, agentConfig2); err != nil {
 		return err
 	}
-
-	// Ensure SSM parameters are cleaned up
-	defer func() {
-		for _, paramName := range []string{agentConfigFile1, agentConfigFile2} {
-			log.Printf("Cleaning up SSM parameter: %s", paramName)
-			if deleteErr := awsservice.DeleteParameter(paramName); deleteErr != nil {
-				log.Printf("Warning: Failed to delete SSM parameter %s: %v", paramName, deleteErr)
-			}
-		}
-	}()
+	defer cleanupSSMParameter(agentConfig2Name)
 
 	appendTest := testCase{
 		parameters: map[string][]string{
 			paramAction:                        {actionConfigureAppend},
 			paramOptionalConfigurationSource:   {configSourceSSM},
-			paramOptionalConfigurationLocation: {agentConfigFile2},
+			paramOptionalConfigurationLocation: {agentConfig2Name},
 		},
 		actionName:           actionConfigureAppend,
 		expectedAgentStatus:  agentStatusRunning,

--- a/util/awsservice/ssm.go
+++ b/util/awsservice/ssm.go
@@ -4,8 +4,8 @@
 package awsservice
 
 import (
-	"errors"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -85,9 +85,18 @@ func DeleteSSMDocument(name string) error {
 	return err
 }
 
-func WaitForCommandCompletion(commandId, instanceId string) (*ssm.ListCommandInvocationsOutput, error) {
-	for i := 0; i < 12; i++ {
-		time.Sleep(5 * time.Second)
+// WaitForCommandCompletion polls an SSM command invocation until it reaches a terminal
+// state. It returns immediately on Success, and returns an error immediately on the terminal
+// failure states (Failed, Cancelled, TimedOut) surfacing StatusDetails. The optional timeout
+// defaults to 2m; only a genuinely hung command waits that long. The deadline is checked
+// between polls, so the effective wait may exceed the timeout by up to one ~5s poll interval.
+func WaitForCommandCompletion(commandId, instanceId string, timeout ...time.Duration) (*ssm.ListCommandInvocationsOutput, error) {
+	wait := 2 * time.Minute
+	if len(timeout) > 0 && timeout[0] > 0 {
+		wait = timeout[0]
+	}
+	deadline := time.Now().Add(wait)
+	for {
 		result, err := SsmClient.ListCommandInvocations(ctx, &ssm.ListCommandInvocationsInput{
 			CommandId:  aws.String(commandId),
 			InstanceId: aws.String(instanceId),
@@ -99,12 +108,25 @@ func WaitForCommandCompletion(commandId, instanceId string) (*ssm.ListCommandInv
 
 		if len(result.CommandInvocations) > 0 {
 			invocation := result.CommandInvocations[0]
-			if invocation.Status == types.CommandInvocationStatusSuccess {
+			switch invocation.Status {
+			case types.CommandInvocationStatusSuccess:
 				return result, nil
+			case types.CommandInvocationStatusFailed,
+				types.CommandInvocationStatusCancelled,
+				types.CommandInvocationStatusTimedOut:
+				details := ""
+				if invocation.StatusDetails != nil {
+					details = ": " + *invocation.StatusDetails
+				}
+				return nil, fmt.Errorf("command %s on instance %s reached terminal status %s%s", commandId, instanceId, invocation.Status, details)
 			}
 		}
+
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("command %s on instance %s did not complete within %s", commandId, instanceId, wait)
+		}
+		time.Sleep(5*time.Second + time.Duration(rand.Int63n(int64(time.Second))))
 	}
-	return nil, errors.New("commands did not complete within 1 minute")
 }
 
 func PutStringParameter(name, value string) error {


### PR DESCRIPTION
# Description of changes
TestSSMDocument is chronically flaky (fails on nearly every "Test Artifacts" run on main). Two test-side races fixed:

1. Shared parameter names. Every job in the matrix wrote the same SSM parameter names (agentConfig1/agentConfig2) in one account+region, so concurrent jobs' cleanup deleted parameters out from under each other -> the agent's fetch-config GetParameter (and the test's own DeleteParameter) hit ParameterNotFound. Suffix both names with the per-run uuid8 already used for the document name, in the unix and windows validators.

2. WaitForCommandCompletion masked real failures. It only returned on Success and otherwise looped a fixed 60s, so a command that reached Failed/Cancelled/TimedOut in ~1s was reported as the misleading "commands did not complete within 1 minute". Return immediately on terminal non-Success states (surfacing StatusDetails), make the timeout configurable (default 2m), and add jitter to polling. The signature stays backward-compatible (variadic timeout).

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* https://github.com/aws/amazon-cloudwatch-agent/actions/runs/29105410910
