### PR TITLE
test(ecs_sd): retry log-event validation to de-flake service discovery scenarios

### DIFF
--- a/test/ecs/service_discovery/ecs_servicediscovery_runner.go
+++ b/test/ecs/service_discovery/ecs_servicediscovery_runner.go
@@ -7,6 +7,7 @@ package service_discovery
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -22,6 +23,10 @@ import (
 
 const (
 	MaxRetryCount = 15
+	// logEventPropagationTimeout bounds phase 2 (waiting for events once the log group
+	// exists) by wall clock rather than a retry count, since each attempt can block ~90s
+	// internally in GetLogsSince on a not-yet-created stream.
+	logEventPropagationTimeout = 5 * time.Minute
 	// Log group format: https://github.com/aws/amazon-cloudwatch-agent/blob/5ef3dba446cb56a4c2306878592b5d14300ae82f/translator/translate/otel/exporter/awsemf/prometheus.go#L38
 	ECSLogGroupNameFormat = "/aws/ecs/containerinsights/%s/prometheus"
 	// Log stream based on job name in extra_apps.tpl:https://github.com/aws/amazon-cloudwatch-agent-test/blob/main/test/ecs/service_discovery/resources/extra_apps.tpl#L41
@@ -148,26 +153,59 @@ func (t ECSServiceDiscoveryTestRunner) ValidateCloudWatchLogs() status.TestResul
 	return testResult
 }
 
+// ValidateLogGroupFormat waits for the scenario's log group, then validates its events. The
+// returned bool reports whether the log group was located -- i.e. whether the caller should
+// run cleanup -- NOT whether validation passed; inspect the error for pass/fail. It returns
+// (false, err) only when the group never appeared.
 func (t ECSServiceDiscoveryTestRunner) ValidateLogGroupFormat(logGroupName string, config ValidationConfig) (bool, error) {
 	start := time.Now()
 
 	log.Printf("Scenario %s: Sleeping to allow metric collection in CloudWatch Logs.", t.scenarioName)
 	time.Sleep(1 * time.Minute)
 
+	// Phase 1: wait for the log group to be created.
 	log.Printf("Scenario %s: Searching for LogGroup: %s\n", t.scenarioName, logGroupName)
-
+	logGroupFound := false
 	for retries := 0; retries < MaxRetryCount; retries++ {
 		if awsservice.IsLogGroupExists(logGroupName) {
-			end := time.Now()
-			return true, t.ValidateLogsContent(logGroupName, config, start, end)
+			logGroupFound = true
+			break
 		}
+		log.Printf("Scenario %s: Retry %d/%d: log group not found. Waiting 20 seconds...\n", t.scenarioName, retries+1, MaxRetryCount)
+		time.Sleep(20 * time.Second)
+	}
+	if !logGroupFound {
+		return false, fmt.Errorf("scenario %s: log group %s not found after %d retries", t.scenarioName, logGroupName, MaxRetryCount)
+	}
 
-		log.Printf("Scenario %s: Retry %d/%d: Log group not found. Waiting 20 seconds...\n", t.scenarioName, retries+1, MaxRetryCount)
+	// Phase 2: group exists; validate content, retrying while the target stream is still
+	// catching up -- empty (ErrNoLogEvents) or not yet created (ResourceNotFoundException).
+	// Any other error (schema/job/cluster mismatch, or a transient AWS error) fails fast by
+	// design. Bounded by a wall-clock deadline, not a retry count, because each attempt can
+	// itself block ~90s inside GetLogsSince (StandardRetries x 30s) on a missing stream.
+	deadline := time.Now().Add(logEventPropagationTimeout)
+	var lastErr error
+	for {
+		end := time.Now()
+		err := t.ValidateLogsContent(logGroupName, config, start, end)
+		if err == nil {
+			return true, nil
+		}
+		if !errors.Is(err, awsservice.ErrNoLogEvents) && !awsservice.IsResourceNotFoundException(err) {
+			// true = log group located (caller should clean up), not "validation passed".
+			return true, err
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			break
+		}
+		log.Printf("Scenario %s: log events not available yet after %s; waiting 20 seconds...\n", t.scenarioName, time.Since(start).Round(time.Second))
 		time.Sleep(20 * time.Second)
 	}
 
-	log.Printf("Scenario %s: ECS ServiceDiscovery Test has exhausted %v retry times", t.scenarioName, MaxRetryCount)
-	return false, fmt.Errorf("scenario %s: test retries exhausted: %d", t.scenarioName, MaxRetryCount)
+	// Group exists but never produced events within the deadline: return true so the caller
+	// still cleans it up and reports the real cause rather than a misleading "not found".
+	return true, fmt.Errorf("scenario %s: no log events within %s: %w", t.scenarioName, logEventPropagationTimeout, lastErr)
 }
 
 func (t ECSServiceDiscoveryTestRunner) ValidateLogsContent(logGroupName string, config ValidationConfig, start time.Time, end time.Time) error {

--- a/util/awsservice/cloudwatchlogs.go
+++ b/util/awsservice/cloudwatchlogs.go
@@ -24,10 +24,6 @@ const (
 	NoLogTypeFound = "NoLogTypeFound"
 )
 
-// catch ResourceNotFoundException when deleting the log group and log stream, as these
-// are not useful exceptions to log errors on during cleanup
-var rnf *types.ResourceNotFoundException
-
 // DeleteLogGroupAndStream cleans up a log group and stream by name. This gracefully handles
 // ResourceNotFoundException errors from calling the APIs
 func DeleteLogGroupAndStream(logGroupName, logStreamName string) {
@@ -41,7 +37,7 @@ func DeleteLogStream(logGroupName, logStreamName string) {
 		LogGroupName:  aws.String(logGroupName),
 		LogStreamName: aws.String(logStreamName),
 	})
-	if err != nil && !errors.As(err, &rnf) {
+	if err != nil && !IsResourceNotFoundException(err) {
 		log.Printf("Error occurred while deleting log stream %s: %v", logStreamName, err)
 	}
 }
@@ -51,7 +47,7 @@ func DeleteLogGroup(logGroupName string) {
 	_, err := CwlClient.DeleteLogGroup(ctx, &cloudwatchlogs.DeleteLogGroupInput{
 		LogGroupName: aws.String(logGroupName),
 	})
-	if err != nil && !errors.As(err, &rnf) {
+	if err != nil && !IsResourceNotFoundException(err) {
 		log.Printf("Error occurred while deleting log group %s: %v", logGroupName, err)
 	}
 }
@@ -108,7 +104,7 @@ func GetLogsSince(logGroup, logStream string, since, until *time.Time) ([]types.
 		attempts += 1
 
 		if err != nil {
-			if errors.As(err, &rnf) && attempts <= StandardRetries {
+			if IsResourceNotFoundException(err) && attempts <= StandardRetries {
 				// The log group/stream hasn't been created yet, so wait and retry
 				time.Sleep(30 * time.Second)
 				continue
@@ -325,10 +321,22 @@ func AssertPerLog(validators ...LogEventValidator) LogEventsValidator {
 	}
 }
 
+// ErrNoLogEvents is returned by AssertLogsNotEmpty when no log events are found in the
+// queried time window. Callers may use errors.Is to retry on propagation delays, but should
+// treat it as a hard failure where events are expected unconditionally.
+var ErrNoLogEvents = errors.New("no log events")
+
+// IsResourceNotFoundException reports whether err is a CloudWatch Logs
+// ResourceNotFoundException -- e.g. the log group or stream does not exist yet.
+func IsResourceNotFoundException(err error) bool {
+	var rnfErr *types.ResourceNotFoundException
+	return errors.As(err, &rnfErr)
+}
+
 func AssertLogsNotEmpty() LogEventsValidator {
 	return func(events []types.OutputLogEvent) error {
 		if len(events) == 0 {
-			return errors.New("no log events")
+			return ErrNoLogEvents
 		}
 		return nil
 	}

--- a/util/awsservice/cloudwatchlogs_test.go
+++ b/util/awsservice/cloudwatchlogs_test.go
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package awsservice_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
+)
+
+// TestAssertLogsNotEmpty locks the sentinel contract the ECS service-discovery retry logic
+// depends on: an empty event list yields an error matchable via errors.Is against
+// ErrNoLogEvents, including when wrapped, and a non-empty list yields nil.
+func TestAssertLogsNotEmpty(t *testing.T) {
+	validator := awsservice.AssertLogsNotEmpty()
+
+	if err := validator(nil); !errors.Is(err, awsservice.ErrNoLogEvents) {
+		t.Fatalf("empty events: expected errors.Is(err, ErrNoLogEvents), got %v", err)
+	}
+	if wrapped := fmt.Errorf("scenario x: %w", validator(nil)); !errors.Is(wrapped, awsservice.ErrNoLogEvents) {
+		t.Fatalf("wrapped empty events: expected errors.Is to match ErrNoLogEvents, got %v", wrapped)
+	}
+	if err := validator([]types.OutputLogEvent{{}}); err != nil {
+		t.Fatalf("non-empty events: expected nil, got %v", err)
+	}
+}
+
+// TestIsResourceNotFoundException covers the other half of the retry contract: RNF detection
+// must match a direct or wrapped *types.ResourceNotFoundException and nothing else.
+func TestIsResourceNotFoundException(t *testing.T) {
+	rnf := &types.ResourceNotFoundException{}
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"direct", rnf, true},
+		{"wrapped", fmt.Errorf("get logs: %w", rnf), true},
+		{"unrelated", errors.New("throttled"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := awsservice.IsResourceNotFoundException(tc.err); got != tc.want {
+				t.Fatalf("IsResourceNotFoundException(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description of the issue
ValidateLogGroupFormat retried only on log-group existence, then validated log events exactly once. Only the first scenario (dockerLabel) survived reliably -- it waits out log-group creation, incidentally giving the pipeline ~100-120s. Scenarios reusing the existing group (or checking a stream new to that scenario) got only the flat 60s wait, below the ~125s pipeline minimum (sd_frequency 1m + scrape_interval 1m + flush + ingestion), so whichever scenario's SD-tick/scrape alignment fell outside the window failed with "no log events" -- a race whose victim rotated run to run.

# Description of changes
* Retry ValidateLogsContent when the stream exists but is still empty, spanning multiple SD cycles; fail fast on genuine validation errors. 
* Add a typed ErrNoLogEvents sentinel to AssertLogsNotEmpty so the retry matches on identity rather than a substring.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Flaky run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/29217023388/job/86721391140
* Clean run: WIP
