### PR TITLE
fix(efa): use full IAM role names to avoid 38-char name_prefix cap

### DIFF
--- a/terraform/eks/daemon/efa/main.tf
+++ b/terraform/eks/daemon/efa/main.tf
@@ -28,9 +28,6 @@ module "eks" {
 
   eks_managed_node_groups = {
     efa_nodes = {
-      # Full role name; "<name>-eks-node-group-" name_prefix would exceed the 38-char cap.
-      iam_role_use_name_prefix = false
-
       # EFA configuration - only at node group level in v21
       enable_efa_support = true
       ami_type           = "AL2023_x86_64_NVIDIA"

--- a/terraform/eks/daemon/efa/main.tf
+++ b/terraform/eks/daemon/efa/main.tf
@@ -17,6 +17,9 @@ module "eks" {
   name               = "cwagent-eks-integ-${module.common.testing_id}"
   kubernetes_version = var.k8s_version
 
+  # Full role name (<=64); the module's "<name>-cluster-" name_prefix would exceed the 38-char cap.
+  iam_role_use_name_prefix = false
+
   vpc_id     = aws_vpc.efa_test_vpc.id
   subnet_ids = aws_subnet.efa_test_public_subnet[*].id
 
@@ -25,6 +28,9 @@ module "eks" {
 
   eks_managed_node_groups = {
     efa_nodes = {
+      # Full role name; "<name>-eks-node-group-" name_prefix would exceed the 38-char cap.
+      iam_role_use_name_prefix = false
+
       # EFA configuration - only at node group level in v21
       enable_efa_support = true
       ami_type           = "AL2023_x86_64_NVIDIA"

--- a/terraform/eks/daemon/otel-multi-efa/main.tf
+++ b/terraform/eks/daemon/otel-multi-efa/main.tf
@@ -29,24 +29,22 @@ module "eks" {
 
   eks_managed_node_groups = {
     standard = {
-      iam_role_use_name_prefix = false
-      ami_type                 = "AL2023_x86_64_STANDARD"
-      instance_types           = ["t3.medium"]
-      min_size                 = 1
-      max_size                 = 1
-      desired_size             = 1
-      subnet_ids               = aws_subnet.efa_test_public_subnet[*].id
+      ami_type       = "AL2023_x86_64_STANDARD"
+      instance_types = ["t3.medium"]
+      min_size       = 1
+      max_size       = 1
+      desired_size   = 1
+      subnet_ids     = aws_subnet.efa_test_public_subnet[*].id
     }
 
     multi_efa = {
-      iam_role_use_name_prefix = false
-      enable_efa_support       = true
-      ami_type                 = var.ami_type
-      instance_types           = [var.instance_type]
-      min_size                 = 1
-      max_size                 = 1
-      desired_size             = 1
-      subnet_ids               = aws_subnet.efa_test_private_subnet[*].id
+      enable_efa_support = true
+      ami_type           = var.ami_type
+      instance_types     = [var.instance_type]
+      min_size           = 1
+      max_size           = 1
+      desired_size       = 1
+      subnet_ids         = aws_subnet.efa_test_private_subnet[*].id
 
       labels = {
         "ci-test.example.com/multi-efa-sm" = "true"

--- a/terraform/eks/daemon/otel-multi-efa/main.tf
+++ b/terraform/eks/daemon/otel-multi-efa/main.tf
@@ -18,6 +18,9 @@ module "eks" {
   name               = "cwagent-eks-integ-${module.common.testing_id}"
   kubernetes_version = var.k8s_version
 
+  # Full role name (<=64); the module's "<name>-cluster-" name_prefix would exceed the 38-char cap.
+  iam_role_use_name_prefix = false
+
   vpc_id     = aws_vpc.efa_test_vpc.id
   subnet_ids = aws_subnet.efa_test_public_subnet[*].id
 
@@ -26,22 +29,24 @@ module "eks" {
 
   eks_managed_node_groups = {
     standard = {
-      ami_type       = "AL2023_x86_64_STANDARD"
-      instance_types = ["t3.medium"]
-      min_size       = 1
-      max_size       = 1
-      desired_size   = 1
-      subnet_ids     = aws_subnet.efa_test_public_subnet[*].id
+      iam_role_use_name_prefix = false
+      ami_type                 = "AL2023_x86_64_STANDARD"
+      instance_types           = ["t3.medium"]
+      min_size                 = 1
+      max_size                 = 1
+      desired_size             = 1
+      subnet_ids               = aws_subnet.efa_test_public_subnet[*].id
     }
 
     multi_efa = {
-      enable_efa_support = true
-      ami_type           = var.ami_type
-      instance_types     = [var.instance_type]
-      min_size           = 1
-      max_size           = 1
-      desired_size       = 1
-      subnet_ids         = aws_subnet.efa_test_private_subnet[*].id
+      iam_role_use_name_prefix = false
+      enable_efa_support       = true
+      ami_type                 = var.ami_type
+      instance_types           = [var.instance_type]
+      min_size                 = 1
+      max_size                 = 1
+      desired_size             = 1
+      subnet_ids               = aws_subnet.efa_test_private_subnet[*].id
 
       labels = {
         "ci-test.example.com/multi-efa-sm" = "true"


### PR DESCRIPTION
# Description of changes
#721 standardized the `efa` and `otel-multi-efa` EKS integration-test cluster names to the shared `cwagent-eks-integ-` prefix so the cluster-cleaner allowlist covers them. Those two tests build their cluster via the `terraform-aws-modules/eks` v21 module, which derives the cluster IAM role from a `"<cluster-name>-cluster-"` IAM role `name_prefix` (38-char cap). The standardized name makes that 43 chars, so `terraform apply` fails before the test runs:

```
Error: expected length of name_prefix to be in the range (1 - 38), got cwagent-eks-integ-<id>-cluster-
```

Only these two tests are affected — every other EKS test uses a raw `aws_eks_cluster` with an explicitly-named IAM role (`name`, 64-char limit), not the module's 38-capped `name_prefix`.

## Fix
Set `iam_role_use_name_prefix = false` on the eks **module (cluster)** in both configs, so the cluster IAM role uses the full role name (`cwagent-eks-integ-<id>-cluster`, IAM 64-char limit) instead of the 38-capped prefix. The cluster name is unchanged, so #721's cluster-cleaner allowlist still matches, and the role stays unique per run because the name embeds `module.common.testing_id`.

The managed **node groups are intentionally left on the module default** (`iam_role_use_name_prefix = true`). In v21 that flag does not propagate from the cluster — each node group sets it independently — and the node-group role name derives from the short node-group map key (`<key>-eks-node-group-`, ≤ 25 chars), which is already well under the 38-char cap and needs no change. Disabling `name_prefix` there would drop the random suffix and resolve to a static, account-global name (the node-group key carries no `testing_id`), risking `EntityAlreadyExists` on concurrent/retried runs — so `name_prefix` is kept to preserve per-run uniqueness.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Passing subset run (efa + otel_multi_efa) against this change: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/29777734101