### PR TITLE
fix(credential_chain): accept both SDK v1 and v2 provider names in CommonConfigTest

### DIFF
--- a/test/credential_chain/common_config_runner.go
+++ b/test/credential_chain/common_config_runner.go
@@ -106,10 +106,13 @@ func (t *CommonConfigTestRunner) SetUpConfig() error {
 func (t *CommonConfigTestRunner) Validate() status.TestGroupResult {
 	t.Cleanup()
 	return util.ValidateCredentialTest(t.GetTestName(), util.ExpectedResults{
-		Namespace:              util.SharedTestNamespace,
-		MetricName:             util.MetricNameCpuUsageActive,
-		CredentialProviderName: util.ProviderNameSharedConfig,
-		AccessKeyID:            t.accessKeyID,
+		Namespace:  util.SharedTestNamespace,
+		MetricName: util.MetricNameCpuUsageActive,
+		// aws-sdk-go v1 agents report SharedCredentialsProvider for common-config shared credentials;
+		// aws-sdk-go-v2 agents report SharedConfigCredentials. Accept both so the same test repo works
+		// against agents on either side of the SDK v2 migration.
+		CredentialProviderNames: []string{util.ProviderNameSharedConfig, util.ProviderNameSharedCredentials},
+		AccessKeyID:             t.accessKeyID,
 	}, metadata)
 }
 

--- a/test/credential_chain/home_env_runner.go
+++ b/test/credential_chain/home_env_runner.go
@@ -127,10 +127,12 @@ func (t *HomeEnvTestRunner) Validate() status.TestGroupResult {
 	// need to clean up the invalid root credentials before validation runs
 	t.Cleanup()
 	return util.ValidateCredentialTest(t.GetTestName(), util.ExpectedResults{
-		Namespace:              util.SharedTestNamespace,
-		MetricName:             util.MetricNameCpuUsageActive,
-		CredentialProviderName: util.ProviderNameSharedConfig,
-		AccessKeyID:            t.accessKeyID,
+		Namespace:  util.SharedTestNamespace,
+		MetricName: util.MetricNameCpuUsageActive,
+		// The SDK default chain resolves the HOME shared credentials file as SharedConfigCredentials
+		// on both aws-sdk-go v1 (session shared config) and aws-sdk-go-v2 (config.LoadDefaultConfig).
+		CredentialProviderNames: []string{util.ProviderNameSharedConfig},
+		AccessKeyID:             t.accessKeyID,
 	}, metadata)
 }
 

--- a/test/credential_chain/util/constants.go
+++ b/test/credential_chain/util/constants.go
@@ -30,6 +30,11 @@ const (
 	UserCWAgentHomeDir = "/home/cwagent"
 	AwsCredentialsPath = ".aws/credentials"
 
+	// ProviderNameSharedCredentials is logged by agents built on aws-sdk-go v1, where shared credentials
+	// resolve via credentials.SharedCredentialsProvider.
+	ProviderNameSharedCredentials = "SharedCredentialsProvider"
+	// ProviderNameSharedConfig is logged by agents built on aws-sdk-go-v2, where shared credentials
+	// resolve via config.LoadSharedConfigProfile, and by the SDK default chain's shared config resolution.
 	ProviderNameSharedConfig = "SharedConfigCredentials"
 )
 

--- a/test/credential_chain/util/validation_util.go
+++ b/test/credential_chain/util/validation_util.go
@@ -11,6 +11,8 @@ import (
 	"log"
 	"os"
 	"regexp"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -35,8 +37,11 @@ type CredentialProviderInfo struct {
 	AccessKeyID  string
 }
 
-// ParseAgentLogsForCredentialProvider extracts credential provider name from logs
-func ParseAgentLogsForCredentialProvider(expectedProvider string) (*CredentialProviderInfo, error) {
+// ParseAgentLogsForCredentialProvider extracts credential provider name from logs. A match is returned as soon as
+// a log line reports one of the expected providers. Multiple expected providers allow the same test to pass against
+// agents built on either aws-sdk-go v1 or aws-sdk-go-v2, which log different provider names for the same credential
+// source (e.g. SharedCredentialsProvider vs SharedConfigCredentials for shared credential files).
+func ParseAgentLogsForCredentialProvider(expectedProviders ...string) (*CredentialProviderInfo, error) {
 	file, err := os.Open(common.AgentLogFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open agent log: %w", err)
@@ -57,7 +62,7 @@ func ParseAgentLogsForCredentialProvider(expectedProvider string) (*CredentialPr
 				AccessKeyID:  matches[1],
 			}
 
-			if lastMatch.ProviderName == expectedProvider {
+			if slices.Contains(expectedProviders, lastMatch.ProviderName) {
 				return lastMatch, nil
 			}
 		}
@@ -68,10 +73,10 @@ func ParseAgentLogsForCredentialProvider(expectedProvider string) (*CredentialPr
 	}
 
 	if lastMatch != nil {
-		return nil, fmt.Errorf("provider mis-match: expected %s, got %s", expectedProvider, lastMatch.ProviderName)
+		return nil, fmt.Errorf("provider mis-match: expected one of %v, got %s", expectedProviders, lastMatch.ProviderName)
 	}
 
-	return nil, fmt.Errorf("no credential provider (%s) not found", expectedProvider)
+	return nil, fmt.Errorf("no credential provider log line found (expected one of %v)", expectedProviders)
 }
 
 // getDimensions returns the dimensions for metric queries
@@ -145,21 +150,16 @@ func ValidateMetric(testName string, namespace string, metricName string, metada
 	return testResult
 }
 
-// ValidateCredentialProvider verifies the expected credential provider was used
-func ValidateCredentialProvider(expectedProvider string, expectedAccessKeyID string) status.TestResult {
+// ValidateCredentialProvider verifies one of the expected credential providers was used
+func ValidateCredentialProvider(expectedProviders []string, expectedAccessKeyID string) status.TestResult {
 	testResult := status.TestResult{
-		Name:   fmt.Sprintf("ValidateCredentialProvider: %s", expectedProvider),
+		Name:   fmt.Sprintf("ValidateCredentialProvider: %s", strings.Join(expectedProviders, "|")),
 		Status: status.FAILED,
 	}
 
-	info, err := ParseAgentLogsForCredentialProvider(expectedProvider)
+	info, err := ParseAgentLogsForCredentialProvider(expectedProviders...)
 	if err != nil {
 		testResult.Reason = fmt.Errorf("failed to parse agent logs: %w", err)
-		return testResult
-	}
-
-	if info.ProviderName != expectedProvider {
-		testResult.Reason = fmt.Errorf("expected provider %s but got %s", expectedProvider, info.ProviderName)
 		return testResult
 	}
 
@@ -179,10 +179,12 @@ func ValidateCredentialProvider(expectedProvider string, expectedAccessKeyID str
 }
 
 type ExpectedResults struct {
-	Namespace              string
-	MetricName             string
-	CredentialProviderName string
-	AccessKeyID            string
+	Namespace  string
+	MetricName string
+	// CredentialProviderNames lists the acceptable credential provider names. Any single match passes,
+	// which keeps the test compatible with both aws-sdk-go v1 and aws-sdk-go-v2 based agents.
+	CredentialProviderNames []string
+	AccessKeyID             string
 }
 
 func ValidateCredentialTest(testName string, expected ExpectedResults, metadata *environment.MetaData) status.TestGroupResult {
@@ -192,7 +194,7 @@ func ValidateCredentialTest(testName string, expected ExpectedResults, metadata 
 			// Validate metric delivery (proves credentials worked)
 			ValidateMetric(testName, expected.Namespace, expected.MetricName, metadata),
 			// Validate credential provider (proves correct credential source was used)
-			ValidateCredentialProvider(expected.CredentialProviderName, expected.AccessKeyID),
+			ValidateCredentialProvider(expected.CredentialProviderNames, expected.AccessKeyID),
 		},
 	}
 }


### PR DESCRIPTION
# Description of the issue
#719 changed CommonConfigTest's expected credential provider name to the aws-sdk-go-v2 value (`SharedConfigCredentials`), anticipating the agent's SDK v2 migration. Agent `main` still resolves common-config shared credentials through the SDK v1 chain, which logs `SharedCredentialsProvider`. Since agent CI pins this repo to `main`, every agent PR's `al2:credential_chain_test` has been failing deterministically since #719 merged:

```
ValidateCredentialProvider: SharedConfigCredentials   Failed
failed to parse agent logs: provider mis-match: expected SharedConfigCredentials, got SharedCredentialsProvider
```

Credentials themselves resolve fine (the metric validation in the same test passes) — only the provider-name log assertion mismatches.

# Description of changes
Make the assertion compatible both ways so the same test repo main passes against agents on either side of the SDK v2 migration:

- Restore `ProviderNameSharedCredentials` (`SharedCredentialsProvider`, v1) alongside `ProviderNameSharedConfig` (`SharedConfigCredentials`, v2).
- `ParseAgentLogsForCredentialProvider` now takes a set of acceptable provider names and passes on any match.
- CommonConfigTest accepts both names. HomeEnvTest is unchanged in behavior — the SDK default chain reports `SharedConfigCredentials` under both v1 and v2.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- `go build`, `go vet`, and `gofmt` clean on `./test/credential_chain/...`
- The parse regex (`[^:\s]+`) already strips the v2 `SharedConfigCredentials: /path` suffix, verified against the failing run's log format
- Sample run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/29793125729