### PR TITLE
Replace DNSCache dependency with nsi

### DIFF
--- a/msi/tools/amazon-cloudwatch-agent.wxs
+++ b/msi/tools/amazon-cloudwatch-agent.wxs
@@ -93,7 +93,7 @@
             >
                 <ServiceDependency Id="Tcpip"/>
                 <ServiceDependency Id="Dhcp"/>
-                <ServiceDependency Id="Dnscache"/>
+                <ServiceDependency Id="nsi"/>
                 <ServiceConfig 
                 FirstFailureActionType="restart" 
                 SecondFailureActionType="restart" 


### PR DESCRIPTION
# Description of the issue
Currently, the CloudWatch Agent service on windows depends on Dnscache service to be up and running to ensure networking drivers and interfaces are available before trying to start the CloudWatch Agent service. This is to ensure that when CWA doesn't attempt network calls to CloudWatch too early, and avoid a crash on startup from failed network calls.

However, Dnscache is not strictly necessary for network connectivity and some users may choose to disable it. If Dnscache service is disabled, CloudWatch Agent will fail to start on a reboot:
```
The AmazonCloudWatchAgent service depends on the Dnscache service which failed to start because of the following error: 
The service cannot be started, either because it is disabled or because it has no enabled devices associated with it.
```

# Description of changes
Replace Dnscache dependency with nsi (Network Store Interface). This is the primary dependency of Dnscache so this change moves the dependency up one link.

```
PS C:\Users\Administrator> sc.exe qc DNSCache
[SC] QueryServiceConfig SUCCESS
SERVICE_NAME: DNSCache
        TYPE               : 20  WIN32_SHARE_PROCESS
        START_TYPE         : 4   DISABLED
        ERROR_CONTROL      : 1   NORMAL
        BINARY_PATH_NAME   : C:\Windows\system32\svchost.exe -k NetworkService -p
        LOAD_ORDER_GROUP   : TDI
        TAG                : 0
        DISPLAY_NAME       : DNS Client
        DEPENDENCIES       : nsi
        SERVICE_START_NAME : NT AUTHORITY\NetworkService

```

This change will allow CloudWatch Agent to startup sooner and not rely on Dnscache service, allowing users to disable Dnscache and maintain CloudWatch Agent functionality.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
I changed the DNSCache dependency to NSI (Network Store Interface).
```
sc.exe config AmazonCloudWatchAgent depend= Tcpip/Dhcp/nsi
```
And then restart the host. This time, the agent came up running.
```
PS C:\Program Files\Amazon> cd .\AmazonCloudWatchAgent\
PS C:\Program Files\Amazon\AmazonCloudWatchAgent> .\amazon-cloudwatch-agent-ctl.ps1 -a status
{
  "status": "running",
  "starttime": "2026-07-17T22:01:03",
  "configstatus": "configured",
  "version": "1.300069.0b1529"
}
```



