### PR TITLE
Add ubuntu 26.04 to integration test matrix

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -33,6 +33,17 @@
     "family": "linux"
   },
   {
+    "os": "ubuntu-26",
+    "username": "ubuntu",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go deb",
+    "ami": "cloudwatch-agent-integration-test-ubuntu-26*",
+    "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.deb",
+    "family": "linux"
+  },
+  {
     "os": "ubuntu-22.04",
     "username": "ubuntu",
     "instanceType": "m6g.medium",


### PR DESCRIPTION
# Description of the issue
Add Ubuntu 26.04 to the integration test matrix for CloudWatch Agent OS onboarding.

# Description of changes
Added ubuntu-26 (amd64) entry to `generator/resources/ec2_linux_test_matrix.json` so integration tests run on Ubuntu 26.04.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran integration tests with OS filter `ubuntu-26` — all ubuntu-26 tests passed.
  
Workflow run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/30527344923