### PR TITLE
test(eks): mark entity daemon test as WIP

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -432,6 +432,7 @@ var testTypeToTestConfig = map[string][]testConfig{
 		{
 			testDir: "./test/entity", terraformDir: "terraform/eks/daemon/entity",
 			targets: map[string]map[string]struct{}{"arc": {"amd64": {}}},
+			wip:     true,
 		},
 		{
 			testDir: "./test/efa", terraformDir: "terraform/eks/daemon/efa",


### PR DESCRIPTION
# Description of the issue
Marks the `eks_daemon:entity_test` as WIP (`wip: true`) in the test generator.

This test currently fails for reasons unrelated to the agent — a required test fixture image it depends on is unavailable, so the app pods can't start and the Terraform apply times out waiting on them. Flagging it WIP so its failures are overruled and don't fail integration runs while the fixture is restored.

Tracked separately for the real fix; the WIP flag will be removed once the dependency is available again.

# Description of changes
- `generator/test_case_generator.go`: add `wip: true` to the `./test/entity` - `eks_daemon` entry (same mechanism already used by `./test/awsneuron`).

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- `go run --tags=generator generator/test_case_generator.go` regenerates the matrix; `eks_daemon:entity_test` now has `wip: true`.
- `gofmt` clean.