### PR TITLE
test(amp): defensive retry-on-empty for AMP query path

### DIFF
--- a/test/amp/amp_test.go
+++ b/test/amp/amp_test.go
@@ -38,6 +38,13 @@ const (
 	// template prometheus query for getting average of 3 min
 	ampQueryTemplate          = "avg_over_time(%s%s[3m])"
 	ampHistogramQueryTemplate = "quantile_over_time(0.5, %s_bucket%s[3m])"
+
+	// queryRetryAttempts is the maximum number of times to issue the AMP
+	// query when it returns an empty result set (metric not yet queryable
+	// because of remote-write propagation delay).
+	queryRetryAttempts = 3
+	// queryRetryDelay is how long to wait between AMP query attempts.
+	queryRetryDelay = 30 * time.Second
 )
 
 type Source int
@@ -243,7 +250,7 @@ func (t *AmpTestRunner) validateMetric(queryTemplate string, metricName string, 
 	query := buildPrometheusQuery(queryTemplate, metricName, dims)
 	log.Printf("querying metrics for %s using the following query\n%s\n", metricName, query)
 
-	responseJSON, err := queryAMPMetrics(metadata.AmpWorkspaceId, query)
+	responseJSON, err := queryAMPMetricsWithRetry(metadata.AmpWorkspaceId, query)
 	if err != nil {
 		log.Printf("failed to fetch metric values from AMP for %s: %s\n", metricName, err)
 		return testResult
@@ -421,6 +428,40 @@ func buildPrometheusQuery(template string, metricName string, dims []types.Dimen
 		dimsStr = dimsStr[:len(dimsStr)-1]
 	}
 	return fmt.Sprintf(template, metricName, "{"+dimsStr+"}")
+}
+
+// queryAMPMetricsWithRetry issues the AMP query up to queryRetryAttempts times,
+// retrying on both request errors and empty result sets. The failure mode it
+// guards against is metric remote-write propagation delay: the datapoint may not
+// be queryable on the first attempt but lands moments later. Each attempt is a
+// fresh instant query evaluated at the AMP server's current time, so the 3m
+// avg_over_time window advances on its own; there is no explicit window to
+// recompute (unlike the CloudWatch GetMetricData harness, which recomputes its
+// StartTime/EndTime, and unlike the entity log-query fix, which deliberately
+// holds its window constant because the events already exist and are only
+// unindexed). When all attempts are exhausted the last response (or error) is
+// returned unchanged, so the caller's existing empty-result check still fails
+// the test genuinely.
+func queryAMPMetricsWithRetry(wsID string, q string) (AMPResponse, error) {
+	var responseJSON AMPResponse
+	var err error
+	for attempt := 1; attempt <= queryRetryAttempts; attempt++ {
+		responseJSON, err = queryAMPMetrics(wsID, q)
+		if err != nil {
+			log.Printf("AMP query attempt %d/%d returned error: %s", attempt, queryRetryAttempts, err)
+		} else if len(responseJSON.Data.Result) == 0 {
+			log.Printf("AMP query attempt %d/%d returned empty result", attempt, queryRetryAttempts)
+		} else {
+			log.Printf("AMP query attempt %d/%d succeeded with %d series", attempt, queryRetryAttempts, len(responseJSON.Data.Result))
+			return responseJSON, nil
+		}
+
+		if attempt < queryRetryAttempts {
+			log.Printf("waiting %s before AMP query retry", queryRetryDelay)
+			time.Sleep(queryRetryDelay)
+		}
+	}
+	return responseJSON, err
 }
 
 func queryAMPMetrics(wsID string, q string) (AMPResponse, error) {


### PR DESCRIPTION
## Scope (updated after root-cause investigation)

This is a **defensive hardening** of the AMP query path. It does **not** fix the current `al2:selinux_amp_test` failures. See "Why this does not fix the current flake" below.

## What this changes

`validateMetric` issued a single PromQL instant query (`avg_over_time(m[3m])`) via `queryAMPMetrics` with no retry, and failed the metric if the result set was empty. This adds `queryAMPMetricsWithRetry` (3 attempts, 30s apart), retrying on both request errors and empty result sets, and switches `validateMetric` to use it.

- Each attempt is a fresh instant query evaluated at the AMP server's current time, so the 3-minute `avg_over_time` lookback advances on its own. There is no explicit start/end window to recompute.
- On exhaustion the last response or error is returned unchanged, so a genuine empty result still fails the test.

This guards against remote-write propagation delay: once a workspace exists and the agent is publishing, a metric can briefly be un-queryable and land moments later.

## Why this does not fix the current flake

Investigation of PR aws/amazon-cloudwatch-agent#2225's failing `al2:selinux_amp_test` jobs (run 30667884230 attempts 1 and 9, run 30764785279 attempt 2, run 30995079411 attempt 1 on the current head) shows every failure is a Terraform provisioning error, upstream of the query path:

```
Error: creating Prometheus Workspace: operation error amp: CreateWorkspace,
https response error StatusCode: 402, ..., ServiceQuotaExceededException:
Limit exceeded. Maximum workspaces per region: 75
  on .terraform/modules/amp/main.tf line 30, in resource "aws_prometheus_workspace" "this"
```

`terraform apply` fails at `aws_prometheus_workspace` creation, so the Go test binary never runs and `queryAMPMetrics` is never reached. No query-path log lines and no 429/403/throttle appear in any failed log. That is an infrastructure service-quota issue (the region is at the 75 AMP-workspace cap), addressed by raising the quota and/or ensuring workspaces are reliably torn down, not by this test-code change.

## Status

Kept open as an independent, low-risk query-path improvement. It is not a fix for the quota-driven flake and should not be treated as one.

## Verification

- `gofmt` clean
- `go test -c -tags=integration ./test/amp/` compiles on go 1.23.12 (matches CI)
- Not exercised in CI
