### PR TITLE
Add debian 13 to integration test matrix

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -66,6 +66,17 @@
     "family": "linux"
   },
   {
+    "os": "debian-13",
+    "username": "admin",
+    "instanceType": "c6g.large",
+    "installAgentCommand": "go run ./install/install_agent.go deb",
+    "ami": "cloudwatch-agent-integration-test-debian-13-arm64*",
+    "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
+    "arc": "arm64",
+    "binaryName": "amazon-cloudwatch-agent.deb",
+    "family": "linux"
+  },
+  {
     "os": "al2",
     "username": "ec2-user",
     "instanceType":"t3a.medium",


### PR DESCRIPTION
# Description of the issue
Add Debian 13 (Trixie) to the integration test matrix for CloudWatch Agent OS onboarding.

# Description of changes
Added debian-13 (arm64) entry to `generator/resources/ec2_linux_test_matrix.json` so integration tests run on Debian 13 (Trixie). Cloned from the existing Debian 12 arm64 config (c6g.large, admin user, deb).

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the integration test with the OS filter debian-13 — all debian-13 tests passed.

Workflow run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/31102683559