### PR TITLE
Add bounded re-validation for eks_daemon metric benchmark flake

### DIFF
--- a/test/metric/revalidate.go
+++ b/test/metric/revalidate.go
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package metric
+
+import "time"
+
+// RevalidateMaxAttempts is the number of times to query CloudWatch before
+// declaring final failure. Chosen to allow up to ~4 minutes of additional
+// propagation time beyond the initial sleep, which is sufficient for the
+// majority of late-arriving (metric, dimension-set) pairs observed in CI.
+const RevalidateMaxAttempts = 5
+
+// RevalidateInterval is the pause between consecutive re-validation attempts.
+// 60 seconds balances giving CloudWatch time to surface late dimension sets
+// against keeping the overall test duration reasonable.
+const RevalidateInterval = 60 * time.Second
+
+// RetryValidation performs bounded, spaced re-validation of a metric query.
+//
+// It calls validate up to maxAttempts times, sleeping interval between
+// consecutive attempts (but NOT after the final attempt). It returns true as
+// soon as validate returns true, or false after all attempts are exhausted.
+//
+// This addresses the root cause of flaky EKS metric_value_benchmark failures:
+// CloudWatch propagates some (metric, dimension-set) pairs after the initial
+// query window, causing all-or-nothing validation to fail even though the
+// agent is correctly publishing. Re-querying with spacing catches late
+// arrivals without masking genuine regressions.
+func RetryValidation(maxAttempts int, interval time.Duration, validate func() bool) bool {
+	for i := 0; i < maxAttempts; i++ {
+		if validate() {
+			return true
+		}
+		// Do not sleep after the final attempt.
+		if i < maxAttempts-1 {
+			time.Sleep(interval)
+		}
+	}
+	return false
+}

--- a/test/metric/revalidate_test.go
+++ b/test/metric/revalidate_test.go
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package metric
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRetryValidation_SuccessOnFirstAttempt(t *testing.T) {
+	calls := 0
+	ok := RetryValidation(5, 0, func() bool {
+		calls++
+		return true
+	})
+	if !ok {
+		t.Fatal("expected true, got false")
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetryValidation_SuccessAfterKFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		failCount  int
+		maxAttempt int
+	}{
+		{"success on 2nd attempt", 1, 5},
+		{"success on 3rd attempt", 2, 5},
+		{"success on last attempt", 4, 5},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			ok := RetryValidation(tc.maxAttempt, 0, func() bool {
+				calls++
+				return calls > tc.failCount
+			})
+			if !ok {
+				t.Fatalf("expected true, got false")
+			}
+			expectedCalls := tc.failCount + 1
+			if calls != expectedCalls {
+				t.Fatalf("expected %d calls, got %d", expectedCalls, calls)
+			}
+		})
+	}
+}
+
+func TestRetryValidation_AllFail(t *testing.T) {
+	const maxAttempts = 5
+	calls := 0
+	ok := RetryValidation(maxAttempts, 0, func() bool {
+		calls++
+		return false
+	})
+	if ok {
+		t.Fatal("expected false, got true")
+	}
+	if calls != maxAttempts {
+		t.Fatalf("expected %d calls, got %d", maxAttempts, calls)
+	}
+}
+
+func TestRetryValidation_DoesNotSleepAfterFinalAttempt(t *testing.T) {
+	// With a non-zero interval and maxAttempts=2, if we always fail we should
+	// only sleep once (between attempt 1 and 2), not after attempt 2.
+	start := time.Now()
+	const interval = 10 * time.Millisecond
+	RetryValidation(2, interval, func() bool { return false })
+	elapsed := time.Since(start)
+	// Should have slept ~10ms (1 interval), not ~20ms (2 intervals).
+	if elapsed >= 2*interval {
+		t.Fatalf("expected ~1 interval sleep, but elapsed %v", elapsed)
+	}
+}

--- a/test/metric_value_benchmark/eks_daemonset_test.go
+++ b/test/metric_value_benchmark/eks_daemonset_test.go
@@ -33,7 +33,27 @@ type EKSDaemonTestRunner struct {
 func (e *EKSDaemonTestRunner) Validate() status.TestGroupResult {
 	var testResults []status.TestResult
 	if e.env.EksDeploymentStrategy != eksdeploymenttype.PODIDENTITY {
-		testResults = append(testResults, metric.ValidateMetrics(e.env, "", eks_resources.GetExpectedDimsToMetrics(e.env))...)
+		// Re-validate metric dimensions with bounded retries to accommodate
+		// CloudWatch per-dimension-set propagation lateness. Some (metric,
+		// dimension-set) pairs arrive after the initial query, causing
+		// all-or-nothing validation to fail despite the agent publishing
+		// correctly.
+		var metricsResults []status.TestResult
+		metric.RetryValidation(metric.RevalidateMaxAttempts, metric.RevalidateInterval, func() bool {
+			metricsResults = metric.ValidateMetrics(e.env, "", eks_resources.GetExpectedDimsToMetrics(e.env))
+			failCount := 0
+			for _, r := range metricsResults {
+				if r.Status == status.FAILED {
+					failCount++
+				}
+			}
+			if failCount > 0 {
+				log.Printf("Re-validation attempt: found %d failure(s)", failCount)
+				return false
+			}
+			return true
+		})
+		testResults = append(testResults, metricsResults...)
 	}
 	metrics := e.GetMeasuredMetrics()
 	for _, name := range metrics {


### PR DESCRIPTION
## Problem
`eks_daemon:metric_value_benchmark_test` is flaky. The suite runs a single all-or-nothing validation once, after a fixed 5-minute sleep, and races CloudWatch per-(metric, dimension-set) propagation. In failing runs the agent is alive and publishing: the large majority of the ~195 expected (metric, dimension-set) pairs across 73 metric names pass, and most "missing" metrics are also found on other dimension sets in the same run. A tail of dimension sets simply lands in CloudWatch after the query, so the all-or-nothing group fails.

## Change
- Add a pure, dependency-free helper `RetryValidation(maxAttempts int, interval time.Duration, validate func() bool) bool` in `test/metric/revalidate.go` (constants `RevalidateMaxAttempts = 5`, `RevalidateInterval = 60s`). It returns as soon as validation succeeds and does not sleep after the final attempt.
- `EKSDaemonTestRunner.Validate()` now wraps the existing `metric.ValidateMetrics` call in `RetryValidation`, re-querying up to 5 times with 60s spacing. Only the final attempt's results feed the `TestGroupResult` (assigned per attempt, not accumulated), so intermediate misses do not leak and genuine regressions still fail after all attempts are exhausted.
- The existing 5-minute initial sleep (`GetAgentRunDuration`) and the all-or-nothing status logic are unchanged. Re-validation is purely additive; worst-case added time is four 60-second waits, only on failing/late runs, well within the go test timeout.
- `metric.ValidateMetrics` is not modified, so other callers are unaffected.

## Testing
- New unit tests in `test/metric/revalidate_test.go`: success on first attempt, success after K failures, all-fail, and no-sleep-after-final. All pass.
- `go vet ./test/metric/ ./test/metric_value_benchmark/` is clean.
- The integration package compiles: `go test -c -tags integration ./test/metric_value_benchmark/`.

## Scope
Targets `eks_daemon`. The same helper can later cover the deployment and Windows suites.
