### PR TITLE
Add SLES 16 (arm64 and x86-64) to integration test matrix

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -284,5 +284,16 @@
     "arc": "arm64",
     "binaryName": "amazon-cloudwatch-agent.rpm",
     "family": "linux"
+  },
+  {
+    "os": "sles-16",
+    "username": "ec2-user",
+    "instanceType": "t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-sles-16 20*",
+    "caCertPath": "/var/lib/ca-certificates/ca-bundle.pem",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
   }
 ]

--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -273,5 +273,16 @@
     "arc": "arm64",
     "binaryName": "amazon-cloudwatch-agent.rpm",
     "family": "linux"
+  },
+  {
+    "os": "sles-16",
+    "username": "ec2-user",
+    "instanceType": "m6g.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-sles-16-arm64 20*",
+    "caCertPath": "/var/lib/ca-certificates/ca-bundle.pem",
+    "arc": "arm64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
   }
 ]


### PR DESCRIPTION
# Description of the issue
Add SLES 16 to the integration test matrix for CloudWatch Agent OS onboarding (arm64 and x86-64).

# Description of changes
Added sles-16 entries (arm64 and amd64) to `generator/resources/ec2_linux_test_matrix.json`. Cloned from the existing SLES 15 configs: arm64 (m6g.medium) and x86-64 (t3a.medium), both ec2-user / rpm / caCertPath /var/lib/ca-certificates/ca-bundle.pem.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the integration test with the OS filter sles-16 — all sles-16 tests passed on both arm64 and x86-64.

Workflow run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/31484708388