### PR TITLE
Fix DBI Ubuntu setup: apt dpkg lock race and unbounded setup hang

### DIFF
--- a/test/otel_collect/database_insights/database_insights_test.go
+++ b/test/otel_collect/database_insights/database_insights_test.go
@@ -6,6 +6,7 @@
 package database_insights
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os/exec"
@@ -22,6 +23,7 @@ import (
 )
 
 const (
+	setupTimeout    = 10 * time.Minute
 	workloadDur     = 5 * time.Minute
 	serverLogsGroup = "/aws/self-managed-database-insights/postgresql/server-logs"
 	rawEventsGroup  = "/aws/self-managed-database-insights/postgresql/raw-events"
@@ -47,8 +49,20 @@ func (t *DbiTestRunner) GetMeasuredMetrics() []string {
 
 func (t *DbiTestRunner) SetupBeforeAgentRun() error {
 	log.Println("=== Running PostgreSQL setup ===")
-	out, err := exec.Command("bash", "resources/database_insights_setup.sh").CombinedOutput()
+	// Bound the setup script so a hang fails fast with its partial output instead
+	// of stalling silently until the job-level 60-minute timeout: CombinedOutput
+	// buffers all output, so nothing is visible in CI until the script exits.
+	ctx, cancel := context.WithTimeout(context.Background(), setupTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", "resources/database_insights_setup.sh")
+	// Ensure Wait returns shortly after the kill even if orphaned sudo children
+	// keep the output pipe open.
+	cmd.WaitDelay = 10 * time.Second
+	out, err := cmd.CombinedOutput()
 	log.Printf("setup.sh output:\n%s", string(out))
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("setup.sh timed out after %v; output above shows the last step reached", setupTimeout)
+	}
 	if err != nil {
 		return fmt.Errorf("setup.sh failed: %w", err)
 	}

--- a/test/otel_collect/database_insights/database_insights_test.go
+++ b/test/otel_collect/database_insights/database_insights_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	setupTimeout    = 10 * time.Minute
+	setupTimeout    = 20 * time.Minute
 	workloadDur     = 5 * time.Minute
 	serverLogsGroup = "/aws/self-managed-database-insights/postgresql/server-logs"
 	rawEventsGroup  = "/aws/self-managed-database-insights/postgresql/raw-events"

--- a/test/otel_collect/database_insights/resources/database_insights_setup.sh
+++ b/test/otel_collect/database_insights/resources/database_insights_setup.sh
@@ -35,8 +35,10 @@ if type -P yum >/dev/null 2>&1; then
     PG_DATA="/var/lib/pgsql/data"
 elif type -P apt-get >/dev/null 2>&1; then
     # Ubuntu, Debian
-    sudo apt-get update -y
-    sudo apt-get install -y postgresql postgresql-contrib
+    # DPkg::Lock::Timeout makes apt wait (up to 300s) for the dpkg lock instead of
+    # exiting 100 immediately when unattended-upgrades holds it on freshly booted instances.
+    sudo apt-get -o DPkg::Lock::Timeout=300 update -y
+    sudo apt-get -o DPkg::Lock::Timeout=300 install -y postgresql postgresql-contrib
     PG_DATA=$(find /etc/postgresql -maxdepth 2 -name "main" -type d | sort -V | tail -1)
     if [[ -z "$PG_DATA" ]]; then
         echo "ERROR: Could not find PostgreSQL config directory"


### PR DESCRIPTION
# Description of the issue

`otel_collect_database_insights_test` on ubuntu-24 fails intermittently in two distinct ways, observed across 4 attempts of the same run ([example run](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/31476853937)):

**1. Fast failure (attempts 2, 3 — [job log](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/31476853937/job/93783719648)):**

```
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 6592 (unattended-upgr)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
... setup.sh failed: exit status 100
--- FAIL: TestDbi (25.86s)
```

On a freshly booted Ubuntu instance, `unattended-upgrades` grabs the dpkg frontend lock right as `setup.sh` runs `apt-get install`. apt exits 100 immediately instead of waiting.

**2. Silent hang (attempts 1, 4 — [job log](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/31476853937/job/93793142117)):**

`=== Running PostgreSQL setup ===` is printed, then nothing for 50+ minutes until the workflow's 60-minute timeout kills the job. The harness runs setup.sh via `exec.Command(...).CombinedOutput()` — no timeout, and all output buffered until the script exits — so a hang produces zero diagnostics.

# Description of changes

- **setup.sh:** run apt with `-o DPkg::Lock::Timeout=300` so it waits (up to 5 min) for the dpkg lock instead of failing instantly. Supported by apt on Ubuntu 24.04.
- **Test harness:** run setup.sh under a 20-minute `context.WithTimeout` with `cmd.WaitDelay`, and on expiry fail immediately, printing the partial output. it converts a silent 60-minute stall into a 20-minute failure that shows exactly which setup step blocked, so the next occurrence is diagnosable from the CI log.

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

All in `ubuntu:24.04` containers (systemd-enabled where the full script runs):

| Test | Runs | Result |
|---|---|---|
| Patched apt commands vs held dpkg frontend lock (fcntl, as unattended-upgrades uses) | 10 | 10/10 exit 0 |
| Full 7-step setup.sh end-to-end; postgres `active`, `pg_stat_statements` created, `cw_monitor` login via pgpass | 1 | pass |
| Full setup.sh with a real `unattended-upgrade` process running concurrently | 3 | 3/3 pass |
| Negative control: unpatched setup.sh under identical lock contention | 1 | exit 100 with the exact CI error |
| Timeout mechanism: hanging child killed at deadline, partial output captured, `DeadlineExceeded` detected | 1 | pass |
| `go vet` + `go test -c` on the package | — | clean |

- Also tested in Github Integration test suite in CWA Main repo - https://github.com/aws/amazon-cloudwatch-agent/actions/runs/31615845373/job/94198021450