### PR TITLE
Fix otel_collect prometheus test fake exporter on Python 3.6 hosts

### DIFF
--- a/test/otel_collect/prometheus/prometheus_test.go
+++ b/test/otel_collect/prometheus/prometheus_test.go
@@ -75,12 +75,17 @@ func (t *PrometheusOtelTestRunner) SetupBeforeAgentRun() error {
 	if err := os.WriteFile("/tmp/metrics", []byte(prometheusMetrics), os.ModePerm); err != nil {
 		return fmt.Errorf("unable to write /tmp/metrics: %w", err)
 	}
-	// Serve from /tmp via cd rather than --directory: the --directory flag needs
-	// Python 3.7+, and EL8 distros can default to Python 3.6 (observed on the
-	// rocky-linux-8 AMI rotated in on 2026-08-11), where the flag makes the
-	// server exit immediately and the scrape target is never up.
+	// Serve from /tmp via an inner shell cd rather than --directory: the
+	// --directory flag needs Python 3.7+, and EL8 distros can default to
+	// Python 3.6 (observed on the rocky-linux-8 AMI rotated in on 2026-08-11),
+	// where the flag makes the server exit immediately and the scrape target
+	// is never up.
+	// The backgrounded command must stay a SIMPLE command: backgrounding an
+	// and-list like `cd /tmp && python3 ... &` forks a subshell that keeps the
+	// stdout pipe open, and RunCommand (exec.Command().Output()) blocks on
+	// pipe EOF until the server exits — hanging setup until the job timeout.
 	commands = []string{
-		"cd /tmp && sudo python3 -m http.server 9100 &> /dev/null &",
+		"sudo bash -c 'cd /tmp && exec python3 -m http.server 9100' &> /dev/null &",
 	}
 	if err := common.RunCommands(commands); err != nil {
 		return err

--- a/test/otel_collect/prometheus/prometheus_test.go
+++ b/test/otel_collect/prometheus/prometheus_test.go
@@ -75,8 +75,12 @@ func (t *PrometheusOtelTestRunner) SetupBeforeAgentRun() error {
 	if err := os.WriteFile("/tmp/metrics", []byte(prometheusMetrics), os.ModePerm); err != nil {
 		return fmt.Errorf("unable to write /tmp/metrics: %w", err)
 	}
+	// Serve from /tmp via cd rather than --directory: the --directory flag needs
+	// Python 3.7+, and EL8 distros can default to Python 3.6 (observed on the
+	// rocky-linux-8 AMI rotated in on 2026-08-11), where the flag makes the
+	// server exit immediately and the scrape target is never up.
 	commands = []string{
-		"sudo python3 -m http.server 9100 --directory /tmp &> /dev/null &",
+		"cd /tmp && sudo python3 -m http.server 9100 &> /dev/null &",
 	}
 	if err := common.RunCommands(commands); err != nil {
 		return err
@@ -84,7 +88,15 @@ func (t *PrometheusOtelTestRunner) SetupBeforeAgentRun() error {
 	t.RegisterCleanup(func() error {
 		return common.RunCommands([]string{"sudo pkill -f 'python3 -m http.server 9100' || true"})
 	})
-	time.Sleep(2 * time.Second)
+	// Fail setup loudly if the fake exporter is not actually serving metrics,
+	// instead of letting the agent scrape a dead port for the whole run and
+	// fail minutes later with an unrelated-looking "metric not found" error.
+	healthCheck := []string{
+		"for i in $(seq 1 15); do curl -sf http://localhost:9100/metrics > /dev/null && exit 0; sleep 1; done; echo 'fake node exporter is not serving /metrics on :9100'; exit 1",
+	}
+	if err := common.RunCommands(healthCheck); err != nil {
+		return fmt.Errorf("fake node exporter failed to start: %w", err)
+	}
 	return nil
 }
 

--- a/test/otel_collect/prometheus/prometheus_test.go
+++ b/test/otel_collect/prometheus/prometheus_test.go
@@ -75,15 +75,9 @@ func (t *PrometheusOtelTestRunner) SetupBeforeAgentRun() error {
 	if err := os.WriteFile("/tmp/metrics", []byte(prometheusMetrics), os.ModePerm); err != nil {
 		return fmt.Errorf("unable to write /tmp/metrics: %w", err)
 	}
-	// Serve from /tmp via an inner shell cd rather than --directory: the
-	// --directory flag needs Python 3.7+, and EL8 distros can default to
-	// Python 3.6 (observed on the rocky-linux-8 AMI rotated in on 2026-08-11),
-	// where the flag makes the server exit immediately and the scrape target
-	// is never up.
-	// The backgrounded command must stay a SIMPLE command: backgrounding an
-	// and-list like `cd /tmp && python3 ... &` forks a subshell that keeps the
-	// stdout pipe open, and RunCommand (exec.Command().Output()) blocks on
-	// pipe EOF until the server exits — hanging setup until the job timeout.
+	// cd in an inner shell: --directory needs Python 3.7+, some AMIs ship 3.6.
+	// Keep the backgrounded command simple: an and-list forks a subshell that
+	// holds the stdout pipe open and blocks RunCommand until the server exits.
 	commands = []string{
 		"sudo bash -c 'cd /tmp && exec python3 -m http.server 9100' &> /dev/null &",
 	}
@@ -93,9 +87,8 @@ func (t *PrometheusOtelTestRunner) SetupBeforeAgentRun() error {
 	t.RegisterCleanup(func() error {
 		return common.RunCommands([]string{"sudo pkill -f 'python3 -m http.server 9100' || true"})
 	})
-	// Fail setup loudly if the fake exporter is not actually serving metrics,
-	// instead of letting the agent scrape a dead port for the whole run and
-	// fail minutes later with an unrelated-looking "metric not found" error.
+	// Fail setup fast if the exporter is not serving, instead of letting the
+	// agent scrape a dead port for the whole run.
 	healthCheck := []string{
 		"for i in $(seq 1 15); do curl -sf http://localhost:9100/metrics > /dev/null && exit 0; sleep 1; done; echo 'fake node exporter is not serving /metrics on :9100'; exit 1",
 	}


### PR DESCRIPTION
# Description of the issue

`rocky-linux-8:otel_collect_prometheus_test` fails on every attempt since 2026-08-11:

```
Messages:   metric node_cpu_seconds_total failed: metric node_cpu_seconds_total not found after 3 retries
--- FAIL: TestPrometheus (243.66s)
```

All 4 validated metrics return `count=0` on all 3 validation attempts ([failing job](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/31476853937/job/93783719788), 11 consecutive failures across runs 31476853937, 31615845373, 31514661020, 31508918570 and 31423720987).

Root cause: the test starts its fake node exporter with

```
sudo python3 -m http.server 9100 --directory /tmp &> /dev/null &
```

The `--directory` flag requires Python 3.7+. On hosts where `python3` resolves to 3.6 (EL8 default), the server exits immediately with `error: unrecognized arguments: --directory`. Because the command is backgrounded with output discarded and never health-checked, the death is invisible: the agent scrapes a dead port for the entire 3-minute run, nothing is ingested, and validation fails minutes later with an unrelated-looking error.

# Description of changes

Two changes to `SetupBeforeAgentRun` in `test/otel_collect/prometheus/prometheus_test.go`:

- Serve from `/tmp` via `sudo bash -c 'cd /tmp && exec python3 -m http.server 9100'` instead of `--directory /tmp`, which works on Python 3.6 and newer. The backgrounded command must stay a simple command: backgrounding an and-list (`cd /tmp && python3 ... &`) forks a subshell that holds the stdout pipe open, and the harness's `exec.Command().Output()` blocks on pipe EOF until the server exits — verified against a dispatch run of an earlier revision of this PR, where setup hung until the 60-minute job timeout.
- Replace the blind 2-second sleep with a health check that polls `http://localhost:9100/metrics` for up to 15 seconds and fails setup loudly if the exporter is not serving — so any future environment change that breaks the exporter fails in seconds with a clear message instead of a misleading validation failure minutes later.

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

- On rockylinux:8 with Python 3.6.8 (matching the failing environment), 15 repeated runs each: the old command results in a dead server 0/15 serving; the new command serves `/metrics` with correct content 15/15.
- Exact failure mechanism reproduced: `python3 -m http.server --directory` on 3.6 prints `error: unrecognized arguments: --directory` and exits.
- Negative control: with the old command, the new health check correctly fails within seconds.
- New command also verified serving correctly on ubuntu:24.04 (Python 3.12).
- `go vet` and `go test -c` on the package: clean, including after rebase onto latest main.
- Also tested in Github Integration test suite in CWA Main repo - https://github.com/aws/amazon-cloudwatch-agent/actions/runs/31692678001/job/94439845001


- Hang-shape regression check via the harness code path (`exec.Command("bash","-c",...).Output()`): simple-command background returns in 2ms; and-list background blocks (reproduced); the shipped inner-`bash -c` shape returns in 2ms and the health check passes in 1s on rockylinux:8 / Python 3.6.8 with correct content.