### PR TITLE
Scope ssm_document to SSM instances; add non-SSM OS variants

### DIFF
--- a/generator/resources/ec2_linux_test_matrix.json
+++ b/generator/resources/ec2_linux_test_matrix.json
@@ -147,10 +147,43 @@
     "username": "rocky",
     "instanceType":"t3a.medium",
     "installAgentCommand": "go run ./install/install_agent.go rpm",
-    "ami": "cloudwatch-agent-integration-test-rocky-linux-8*",
+    "ami": "cloudwatch-agent-integration-test-rocky-linux-8 20*",
     "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
     "arc": "amd64",
     "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
+  {
+    "os": "rocky-linux-8-withoutSSM",
+    "username": "rocky",
+    "instanceType":"t3a.medium",
+    "installAgentCommand": "go run ./install/install_agent.go rpm",
+    "ami": "cloudwatch-agent-integration-test-rocky-linux-8-withoutSSM*",
+    "caCertPath": "/etc/ssl/certs/ca-bundle.crt",
+    "arc": "amd64",
+    "binaryName": "amazon-cloudwatch-agent.rpm",
+    "family": "linux"
+  },
+  {
+    "os": "debian-12-withoutSSM",
+    "username": "admin",
+    "instanceType": "c6g.large",
+    "installAgentCommand": "go run ./install/install_agent.go deb",
+    "ami": "cloudwatch-agent-integration-test-debian-12-withoutSSM-arm64*",
+    "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
+    "arc": "arm64",
+    "binaryName": "amazon-cloudwatch-agent.deb",
+    "family": "linux"
+  },
+  {
+    "os": "debian-13-withoutSSM",
+    "username": "admin",
+    "instanceType": "c6g.large",
+    "installAgentCommand": "go run ./install/install_agent.go deb",
+    "ami": "cloudwatch-agent-integration-test-debian-13-withoutSSM-arm64*",
+    "caCertPath": "/etc/ssl/certs/ca-certificates.crt",
+    "arc": "arm64",
+    "binaryName": "amazon-cloudwatch-agent.deb",
     "family": "linux"
   },
   {

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -212,7 +212,14 @@ var testTypeToTestConfig = map[string][]testConfig{
 			testDir: "./test/dualstack_endpoint",
 			targets: map[string]map[string]struct{}{"os": {"al2": {}}, "arc": {"amd64": {}}},
 		},
-		{testDir: "./test/ssm_document"},
+		{
+			testDir: "./test/ssm_document",
+			excludedOs: map[string]struct{}{
+				"rocky-linux-8-withoutSSM": {},
+				"debian-12-withoutSSM":     {},
+				"debian-13-withoutSSM":     {},
+			},
+		},
 		{
 			testDir: "./test/system_metrics/enabled",
 			targets: map[string]map[string]struct{}{"os": {"al2": {}}, "arc": {"amd64": {}}},


### PR DESCRIPTION
## What
Run the ssm_document integration test only on SSM-enabled instances, and add non-SSM variants of the OSes that previously had no SSM agent.

## Why
ssm_document drives the CloudWatch agent via an SSM document and therefore requires a registered SSM agent. rocky-linux-8, debian-12 and debian-13 image recipes strip the SSM agent at bake time, so the readiness wait times out and the test fails during setup (never reaching the code under test).

## Changes
- Image recipes (out of band, EC2 Image Builder): rocky-linux-8, debian-12, debian-13 now keep the SSM agent (uninstallAfterBuild=false + install component), making SSM the default; new -withoutSSM recipes/AMIs preserve the non-SSM configuration.
- Matrix: add rocky-linux-8-withoutSSM, debian-12-withoutSSM, debian-13-withoutSSM.
- rocky-linux-8 AMI filter tightened so it resolves the SSM image, not the -withoutSSM image.
- ssm_document: excludedOs for the three -withoutSSM variants.