### PR TITLE
fix: run DBI PostgreSQL install non-interactively to prevent setup hang

### DIFF
--- a/test/otel_collect/database_insights/resources/database_insights_setup.sh
+++ b/test/otel_collect/database_insights/resources/database_insights_setup.sh
@@ -37,8 +37,15 @@ elif type -P apt-get >/dev/null 2>&1; then
     # Ubuntu, Debian
     # DPkg::Lock::Timeout makes apt wait (up to 300s) for the dpkg lock instead of
     # exiting 100 immediately when unattended-upgrades holds it on freshly booted instances.
-    sudo apt-get -o DPkg::Lock::Timeout=300 update -y
-    sudo apt-get -o DPkg::Lock::Timeout=300 install -y postgresql postgresql-contrib
+    #
+    # DEBIAN_FRONTEND=noninteractive and NEEDRESTART_MODE=a keep the install from opening
+    # an interactive prompt. When the AMI's running kernel is older than the installed one,
+    # needrestart's post-install trigger otherwise renders a "Pending kernel upgrade" dialog
+    # and waits for input forever, which hangs setup.sh until the harness timeout kills it.
+    sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a \
+        apt-get -o DPkg::Lock::Timeout=300 update -y
+    sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a \
+        apt-get -o DPkg::Lock::Timeout=300 install -y postgresql postgresql-contrib
     PG_DATA=$(find /etc/postgresql -maxdepth 2 -name "main" -type d | sort -V | tail -1)
     if [[ -z "$PG_DATA" ]]; then
         echo "ERROR: Could not find PostgreSQL config directory"


### PR DESCRIPTION
# Description of the issue

`ubuntu-24:otel_collect_database_insights_test` intermittently fails before the
agent under test ever starts. The PostgreSQL setup script stalls and the test
fails only when the harness timeout expires:

```
setup.sh timed out after 20m0s; output above shows the last step reached
--- FAIL: TestDbi (1210.07s)
```

The partial output shows the cause: during
`apt-get install postgresql postgresql-contrib`, needrestart's dpkg post-invoke
trigger draws an interactive "Pending kernel upgrade" dialog, because the booted
kernel (`6.17.0-1019-aws`) is older than the installed one (`7.0.0-1011-aws`).
Over a non-interactive SSH session nothing answers it, so the install blocks
until the harness kills it. Whether a run is affected depends on the AMI's kernel
state, which is why it is intermittent.

# Description of changes

Pass `DEBIAN_FRONTEND=noninteractive` (debconf cannot prompt) and
`NEEDRESTART_MODE=a` (needrestart restarts services instead of asking) to both
`apt-get` calls in `database_insights_setup.sh`.

Set per command inside the `elif type -P apt-get` branch, so RPM-family and SLES
hosts are unaffected — needrestart is Debian-family only.

Complements the existing `-o DPkg::Lock::Timeout=300` on the same commands, which
covers a different failure mode: that makes apt wait for the dpkg lock, but does
not stop a post-install trigger from opening a dialog.

# License

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.

# Tests

Two `Run Integration Tests` dispatches, same agent commit, same filters, an hour
apart — differing only in which test-repo branch is cloned:

| Test repo branch | Result |
|---|---|
| `main` (unpatched) | kernel dialog, timeout at 20m, `FAIL: TestDbi (1210.07s)` — [run](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/33417574106/job/99572944935) |
| this branch | `PostgreSQL setup complete`, `PASS: TestDbi (381.45s)` — [run](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/33412505823/job/99561279584) |

The control reproduced the kernel mismatch, so the trigger was present and the
pass is attributable to this change. Both runs' overall status is `failure`
because the OS/test-dir filters skip most matrix jobs; the relevant signal is
each run's `ubuntu-24:otel_collect_database_insights_test` job conclusion.

`bash -n` passes.
