### PR TITLE
Fix prometheus flaky tests

### DIFF
--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -259,7 +259,7 @@ resource "null_resource" "integration_test_run" {
       # the repair only runs when a mismatch is actually detected.
       [
         "echo Go toolchain: $(go version) GOROOT=$(go env GOROOT) candidates=$(which -a go | tr '\\n' ' ')",
-        "GO_DRIVER=$(go version | awk '{print $3}'); GO_COMPILER=$(go tool compile -V | awk '{print $3}')",
+        "GO_DRIVER=$(go version | awk '{print $3}' | sed 's/-X:.*//'); GO_COMPILER=$(go tool compile -V | awk '{print $3}' | sed 's/-X:.*//')",
         "if [ \"$GO_DRIVER\" != \"$GO_COMPILER\" ]; then",
         "  echo \"Go toolchain mismatch: driver $GO_DRIVER, compiler $GO_COMPILER - attempting repair\"",
         "  (sudo dnf -y distro-sync golang golang-bin golang-src || sudo yum -y distro-sync golang golang-bin golang-src) || echo 'Could not repair the Go toolchain automatically'",

--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -63,6 +63,22 @@ resource "null_resource" "integration_test_setup" {
       [
         "echo sha ${var.cwa_github_sha}",
         "sudo cloud-init status --wait",
+
+        # Pin the Go toolchain for the lifetime of this job, and record how it got
+        # here. Something on these hosts upgrades the golang packages mid-run: in
+        # ITAR runs the toolchain was self-consistent when the tests started and
+        # reported 1.26.7-vs-1.25.12 by the time the compiler ran ~4 minutes later,
+        # preceded each time by a root-issued `shutdown -r +1`. AL2023 AMIs are
+        # normally locked to one repository version, so this is not stock
+        # behaviour. The lock keeps `go` and its compile tool on a single release;
+        # the diagnostics identify the trigger so it can be fixed in the image.
+        # RPM-only, so each command degrades to a warning on deb/zypper hosts.
+        "echo Go packages: $(rpm -q --last golang golang-bin golang-src 2>/dev/null | head -3 | tr '\\n' ' ')",
+        "echo dnf releasever: $(cat /etc/dnf/vars/releasever 2>/dev/null || echo 'not pinned')",
+        "systemctl list-timers --all 2>/dev/null | grep -iE 'dnf|yum|patch|update' || echo 'No package-update timers found'",
+        "sudo dnf --setopt=lock_timeout=60 install -y 'dnf-command(versionlock)' 2>/dev/null || true",
+        "sudo dnf --setopt=lock_timeout=60 versionlock add golang golang-bin golang-src 2>/dev/null || sudo yum versionlock add golang golang-bin golang-src 2>/dev/null || echo 'Could not version-lock Go; toolchain may still change mid-run'",
+
         "echo clone ${var.github_test_repo} branch ${var.github_test_repo_branch} and install agent",
         # check for vendor directory specifically instead of overall test repo to avoid issues with SELinux
         "if [ ! -d amazon-cloudwatch-agent-test/vendor ]; then",

--- a/terraform/ec2/linux/main.tf
+++ b/terraform/ec2/linux/main.tf
@@ -234,6 +234,23 @@ resource "null_resource" "integration_test_run" {
         "cd ~/amazon-cloudwatch-agent-test",
       ],
 
+      # Verify the Go toolchain is self-consistent before building any test.
+      # A partial `golang` package upgrade on the running instance can leave the
+      # `go` driver and $GOROOT's compile binary on different releases, which makes
+      # every package - including the standard library - fail to build with
+      # "compile: version X does not match go tool version Y". The echo runs
+      # unconditionally so the toolchain in use is always visible in the job log;
+      # the repair only runs when a mismatch is actually detected.
+      [
+        "echo Go toolchain: $(go version) GOROOT=$(go env GOROOT) candidates=$(which -a go | tr '\\n' ' ')",
+        "GO_DRIVER=$(go version | awk '{print $3}'); GO_COMPILER=$(go tool compile -V | awk '{print $3}')",
+        "if [ \"$GO_DRIVER\" != \"$GO_COMPILER\" ]; then",
+        "  echo \"Go toolchain mismatch: driver $GO_DRIVER, compiler $GO_COMPILER - attempting repair\"",
+        "  (sudo dnf -y distro-sync golang golang-bin golang-src || sudo yum -y distro-sync golang golang-bin golang-src) || echo 'Could not repair the Go toolchain automatically'",
+        "  echo Go toolchain after repair: $(go version) / $(go tool compile -V)",
+        "fi",
+      ],
+
       # On-premises specific environment variables
       local.is_onprem ? [
         "export RUN_IN_AWS=false",

--- a/terraform/eks/daemon/main.tf
+++ b/terraform/eks/daemon/main.tf
@@ -512,7 +512,11 @@ resource "null_resource" "validator" {
     command = <<-EOT
       echo "Validating EKS metrics/logs"
       cd ../../..
-      go test ${var.test_dir} -eksClusterName=${aws_eks_cluster.this.name} -computeType=EKS -v -eksDeploymentStrategy=DAEMON
+      # Explicit timeout: Go defaults to 10m, which the GPU variant exceeds. It
+      # validates hundreds of (metric, dimension-set) pairs serially, each with
+      # bounded CloudWatch re-validation, so 10m is not enough to distinguish a
+      # slow suite from a hung one.
+      go test ${var.test_dir} -timeout 30m -eksClusterName=${aws_eks_cluster.this.name} -computeType=EKS -v -eksDeploymentStrategy=DAEMON
     EOT
   }
 }

--- a/test/metric_value_benchmark/prometheus_test.go
+++ b/test/metric_value_benchmark/prometheus_test.go
@@ -8,6 +8,8 @@ package metric_value_benchmark
 import (
 	_ "embed"
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
@@ -16,6 +18,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-test/test/metric/dimension"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/status"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/test_runner"
+	"github.com/aws/amazon-cloudwatch-agent-test/util/awsservice"
 	"github.com/aws/amazon-cloudwatch-agent-test/util/common"
 )
 
@@ -27,6 +30,22 @@ var _ test_runner.ITestRunner = (*PrometheusTestRunner)(nil)
 
 //go:embed agent_configs/prometheus.yaml
 var prometheusConfig string
+
+const (
+	// prometheusExporterPort must match the scrape target in agent_configs/prometheus.yaml.
+	prometheusExporterPort = 8101
+	// prometheusLogGroup must match log_group_name in agent_configs/prometheus_config.json.
+	// The agent writes EMF events here and CloudWatch extracts the metrics from them,
+	// so its presence separates "agent never published" from "CloudWatch has not
+	// surfaced the metrics yet" when validation fails.
+	prometheusLogGroup = "prometheus_test"
+	// prometheusRevalidateInterval is deliberately shorter than the shared
+	// metric.RevalidateInterval (60s), which was sized for the EKS Container
+	// Insights suite's ~195 (metric, dimension-set) pairs. This sub-test validates
+	// five metrics from a single EMF event, so five samples 30s apart cover the same
+	// two minutes of propagation lateness at half the worst-case cost.
+	prometheusRevalidateInterval = 30 * time.Second
+)
 
 const prometheusMetrics = `prometheus_test_untyped{include="yes",prom_type="untyped"} 1
 # TYPE prometheus_test_counter counter
@@ -54,13 +73,64 @@ prometheus_test_histogram_bucket{include="yes",le="+Inf",prom_type="histogram"} 
 func (t *PrometheusTestRunner) Validate() status.TestGroupResult {
 	metricsToFetch := t.GetMeasuredMetrics()
 	testResults := make([]status.TestResult, len(metricsToFetch))
-	for i, metricName := range metricsToFetch {
-		testResults[i] = t.validatePrometheusMetric(metricName)
+
+	// Re-validate with bounded retries. CloudWatch does not always surface
+	// EMF-extracted metrics by the time the first query runs, so a single query
+	// fails with "No values found" even when the agent published correctly.
+	ok := metric.RetryValidation(metric.RevalidateMaxAttempts, prometheusRevalidateInterval, func() bool {
+		failed := 0
+		for i, metricName := range metricsToFetch {
+			testResults[i] = t.validatePrometheusMetric(metricName)
+			if testResults[i].Status == status.FAILED {
+				failed++
+				log.Printf("Validation of %s failed: %v", metricName, testResults[i].Reason)
+			}
+		}
+		return failed == 0
+	})
+	if !ok {
+		logPrometheusDiagnostics()
 	}
 
 	return status.TestGroupResult{
 		Name:        t.GetTestName(),
 		TestResults: testResults,
+	}
+}
+
+// logPrometheusDiagnostics records the state that distinguishes the possible
+// causes of a "No values found" failure: whether the agent ever published EMF
+// events, whether the scrape target was still serving, and what the agent logged.
+func logPrometheusDiagnostics() {
+	log.Print("Prometheus validation failed; collecting diagnostics")
+
+	// If the log group is absent, the agent never published and the problem is
+	// upstream of CloudWatch metric extraction.
+	log.Printf("EMF log group %q exists: %t", prometheusLogGroup, awsservice.IsLogGroupExists(prometheusLogGroup))
+
+	diagnostics := []struct {
+		label   string
+		command string
+	}{
+		{"scrape target response", fmt.Sprintf(
+			"curl -s -o /dev/null -w 'HTTP %%{http_code}' http://localhost:%d/metrics || true",
+			prometheusExporterPort)},
+		{"listening sockets", fmt.Sprintf(
+			"sudo ss -lntp 2>/dev/null | grep ':%d' || echo 'nothing listening on %d'",
+			prometheusExporterPort, prometheusExporterPort)},
+		// prometheus_config.json sets "logfile": "", so the agent logs to stderr
+		// rather than common.AgentLogFile. journalctl is the only place to read it.
+		{"agent log (errors)",
+			"sudo journalctl -u amazon-cloudwatch-agent --no-pager 2>/dev/null " +
+				"| grep -iE 'error|prometheus|emf' | tail -50 || true"},
+	}
+	for _, d := range diagnostics {
+		out, err := common.RunCommand(d.command)
+		if err != nil {
+			log.Printf("%s: could not collect (%v)", d.label, err)
+			continue
+		}
+		log.Printf("%s:\n%s", d.label, out)
 	}
 }
 
@@ -72,21 +142,44 @@ func (t *PrometheusTestRunner) GetAgentConfigFileName() string {
 	return "prometheus_config.json"
 }
 
+// GetAgentRunDuration overrides the 30s default. 30s yields only a single
+// datapoint per metric at a 10s stat period, so any propagation lag at all is
+// enough to fail validation. Two minutes yields roughly a dozen, which buys
+// margin against propagation rather than extra scrape coverage (the delta-based
+// counter and summary metrics need only two scrapes to report).
+func (t *PrometheusTestRunner) GetAgentRunDuration() time.Duration {
+	return 2 * time.Minute
+}
+
 func (t *PrometheusTestRunner) SetupBeforeAgentRun() error {
 	err := t.BaseTestRunner.SetupBeforeAgentRun()
 	if err != nil {
 		return err
 	}
-	startPrometheusCommands := []string{
-		fmt.Sprintf("cat <<EOF | sudo tee /tmp/prometheus_config.yaml\n%s\nEOF", prometheusConfig),
-		fmt.Sprintf("cat <<EOF | sudo tee /tmp/metrics\n%s\nEOF", prometheusMetrics),
-		"sudo python3 -m http.server 8101 --directory /tmp &> /dev/null &",
-	}
 
-	err = common.RunCommands(startPrometheusCommands)
-	if err != nil {
+	// Quoted heredoc: the config must be written verbatim, with no parameter or
+	// command substitution.
+	writeConfig := []string{
+		fmt.Sprintf("cat <<'EOF' | sudo tee /tmp/prometheus_config.yaml\n%s\nEOF", prometheusConfig),
+	}
+	if err = common.RunCommands(writeConfig); err != nil {
 		return err
 	}
+
+	// Serve the exposition from an in-process Go server rather than shelling out
+	// to `python3 -m http.server --directory /tmp &> /dev/null &`. The old form
+	// discarded startup errors and always reported success because backgrounding
+	// makes the shell exit 0, so a target that never bound looked identical to a
+	// healthy one until validation failed. net.Listen here fails synchronously,
+	// and the listener is bound before this returns, so no readiness poll is
+	// needed. It also drops the --directory flag, which requires Python 3.7+ and
+	// is unavailable on the EL8 hosts in this matrix.
+	stop, err := common.StartPrometheusFakeServer(prometheusExporterPort, prometheusMetrics)
+	if err != nil {
+		return fmt.Errorf("failed to start prometheus scrape target: %w", err)
+	}
+	t.RegisterCleanup(func() error { stop(); return nil })
+
 	return nil
 }
 
@@ -154,16 +247,24 @@ func (t *PrometheusTestRunner) validatePrometheusMetric(metricName string) statu
 	}
 
 	if len(failed) > 0 {
+		testResult.Reason = fmt.Errorf("could not resolve dimensions for %s", metricName)
 		return testResult
 	}
 
 	fetcher := metric.MetricValueFetcher{}
 	values, err := fetcher.Fetch(namespace, metricName, dims, metric.AVERAGE, metric.HighResolutionStatPeriod)
 	if err != nil {
+		// Record the error rather than discarding it. Without this, a
+		// GetMetricData throttling or credential failure is indistinguishable
+		// from the metric genuinely having no datapoints yet, which makes the
+		// difference between a test-timing problem and an agent problem
+		// impossible to tell apart from the job output.
+		testResult.Reason = fmt.Errorf("fetching %s: %w", metricName, err)
 		return testResult
 	}
 
 	if !metric.IsAllValuesGreaterThanOrEqualToExpectedValue(metricName, values, 0) {
+		testResult.Reason = fmt.Errorf("no acceptable values for %s (got %v)", metricName, values)
 		return testResult
 	}
 

--- a/test/ssm_document/helper.go
+++ b/test/ssm_document/helper.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
@@ -31,7 +33,7 @@ func cleanupSSMParameter(name string) {
 func runAndVerifySSMAction(documentName string, instanceIds []string, tc testCase) error {
 	log.Printf("Testing %s action", tc.actionName)
 
-	out, err := awsservice.RunSSMDocument(documentName, instanceIds, tc.parameters)
+	out, _, err := awsservice.RunSSMDocumentAwaitDelivery(documentName, instanceIds, tc.parameters)
 	if err != nil {
 		return fmt.Errorf("%s action failed: %v", tc.actionName, err)
 	}
@@ -57,12 +59,7 @@ func verifyAgentAction(out *ssm.SendCommandOutput, instanceId, documentName stri
 
 	// Verify agent status
 	statusParams := map[string][]string{"action": {"status"}}
-	statusOut, err := awsservice.RunSSMDocument(documentName, []string{instanceId}, statusParams)
-	if err != nil {
-		return fmt.Errorf("failed to check agent status: %v", err)
-	}
-
-	statusResult, err := awsservice.WaitForCommandCompletion(*statusOut.Command.CommandId, instanceId)
+	statusOut, statusResult, err := awsservice.RunSSMDocumentAwaitDelivery(documentName, []string{instanceId}, statusParams)
 	if err != nil {
 		return fmt.Errorf("failed to get status result: %v", err)
 	}
@@ -71,22 +68,63 @@ func verifyAgentAction(out *ssm.SendCommandOutput, instanceId, documentName stri
 		return fmt.Errorf("no command invocations returned for status check")
 	}
 
-	for _, plugin := range statusResult.CommandInvocations[0].CommandPlugins {
-		if plugin.Status == types.CommandPluginStatusFailed {
-			return fmt.Errorf("command plugin failed: %s", *plugin.Name)
+	// Same populate-after-Success race as the output assertions: an empty plugin Output
+	// yields a zero-value agentStatus and a misleading "Expected: running, Output: "
+	// mismatch. Re-read until a plugin emits parseable JSON.
+	statusCommandId := *statusOut.Command.CommandId
+	for attempt := 0; attempt <= outputPollAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(outputPollInterval)
+			refreshed, refreshErr := awsservice.GetCommandInvocationResult(statusCommandId, instanceId)
+			if refreshErr != nil {
+				log.Printf("Re-reading status command %s failed (attempt %d/%d): %v", statusCommandId, attempt, outputPollAttempts, refreshErr)
+				continue
+			}
+			if len(refreshed.CommandInvocations) == 0 {
+				continue
+			}
+			statusResult = refreshed
 		}
-		if plugin.Status == types.CommandPluginStatusTimedOut {
-			return fmt.Errorf("command plugin timed out: %s", *plugin.Name)
-		}
-		outputAsByte := []byte(*plugin.Output)
-		if json.Valid(outputAsByte) {
-			err := json.Unmarshal([]byte(*plugin.Output), &status)
-			if err != nil {
+
+		parsed := false
+		for _, plugin := range statusResult.CommandInvocations[0].CommandPlugins {
+			if plugin.Status == types.CommandPluginStatusFailed {
+				return fmt.Errorf("command plugin failed: %s", *plugin.Name)
+			}
+			if plugin.Status == types.CommandPluginStatusTimedOut {
+				return fmt.Errorf("command plugin timed out: %s", *plugin.Name)
+			}
+			if plugin.Output == nil || strings.TrimSpace(*plugin.Output) == "" {
+				continue
+			}
+			outputAsByte := []byte(*plugin.Output)
+			if !json.Valid(outputAsByte) {
+				continue
+			}
+			// Unmarshal into a fresh value: json.Unmarshal merges into a non-zero
+			// destination, so reusing `status` would let one plugin (or an earlier
+			// attempt) contribute fields to a struct that never existed as a whole.
+			var candidate agentStatus
+			if err := json.Unmarshal(outputAsByte, &candidate); err != nil {
 				return fmt.Errorf("failed to unmarshal status output: %v", err)
 			}
+			status = candidate
+			parsed = true
+			break
+		}
+		if parsed && status.Status != "" {
+			if attempt > 0 {
+				log.Printf("Agent status for command %s parsed on re-read attempt %d/%d", statusCommandId, attempt, outputPollAttempts)
+			}
+			break
 		}
 	}
 
+	if status.Status == "" {
+		return fmt.Errorf("agent status output for command %s never populated after %d re-reads over %s\nCommand output:\n%s",
+			statusCommandId, outputPollAttempts, time.Duration(outputPollAttempts)*outputPollInterval,
+			awsservice.GetCommandInvocationDetails(statusCommandId, instanceId))
+	}
 	if status.Status != tc.expectedAgentStatus {
 		return fmt.Errorf("agent status verification failed. Expected: %s, Output: %s", tc.expectedAgentStatus, status.Status)
 	}
@@ -102,20 +140,17 @@ func verifyAgentAction(out *ssm.SendCommandOutput, instanceId, documentName stri
 func runAndVerifySSMActionWithOutput(documentName string, instanceIds []string, tc testCase, expectedOutput string) error {
 	log.Printf("Testing %s action", tc.actionName)
 
-	out, err := awsservice.RunSSMDocument(documentName, instanceIds, tc.parameters)
+	out, result, err := awsservice.RunSSMDocumentAwaitDelivery(documentName, instanceIds, tc.parameters)
 	if err != nil {
-		return fmt.Errorf("%s action failed: %v", tc.actionName, err)
-	}
-
-	result, err := awsservice.WaitForCommandCompletion(*out.Command.CommandId, instanceIds[0])
-	if err != nil {
-		commandOutput := awsservice.GetCommandInvocationDetails(*out.Command.CommandId, instanceIds[0])
+		commandOutput := "no command was sent"
+		if out != nil {
+			commandOutput = awsservice.GetCommandInvocationDetails(*out.Command.CommandId, instanceIds[0])
+		}
 		return fmt.Errorf("%s action failed to complete: %v\nCommand output:\n%s", tc.actionName, err, commandOutput)
 	}
 
-	if !commandOutputContains(result, expectedOutput) {
-		commandOutput := awsservice.GetCommandInvocationDetails(*out.Command.CommandId, instanceIds[0])
-		return fmt.Errorf("%s output verification failed: expected output %q not found\nCommand output:\n%s", tc.actionName, expectedOutput, commandOutput)
+	if ok, inspected := commandOutputContainsWithRetry(result, *out.Command.CommandId, instanceIds[0], expectedOutput); !ok {
+		return fmt.Errorf("%s output verification failed: expected output %q not found\nCommand output:\n%s", tc.actionName, expectedOutput, inspected)
 	}
 
 	if err := verifyAgentAction(out, instanceIds[0], documentName, tc); err != nil {
@@ -132,13 +167,12 @@ func runAndVerifySSMActionWithOutput(documentName string, instanceIds []string, 
 func runAndVerifySSMActionFailure(documentName string, instanceIds []string, tc testCase, expectedOutput string) error {
 	log.Printf("Testing %s action (expecting failure)", tc.actionName)
 
-	out, err := awsservice.RunSSMDocument(documentName, instanceIds, tc.parameters)
-	if err != nil {
+	out, _, err := awsservice.RunSSMDocumentAwaitDelivery(documentName, instanceIds, tc.parameters)
+	if out == nil {
 		return fmt.Errorf("%s action failed to send: %v", tc.actionName, err)
 	}
 
 	commandId := *out.Command.CommandId
-	_, err = awsservice.WaitForCommandCompletion(commandId, instanceIds[0])
 	commandOutput := awsservice.GetCommandInvocationDetails(commandId, instanceIds[0])
 	if err == nil {
 		return fmt.Errorf("%s action was expected to fail but succeeded\nCommand output:\n%s", tc.actionName, commandOutput)
@@ -149,8 +183,11 @@ func runAndVerifySSMActionFailure(documentName string, instanceIds []string, tc 
 	if !errors.As(err, &termErr) || termErr.Status != types.CommandInvocationStatusFailed {
 		return fmt.Errorf("%s action reached an unexpected terminal state: %v\nCommand output:\n%s", tc.actionName, err, commandOutput)
 	}
-	if expectedOutput != "" && !strings.Contains(commandOutput, expectedOutput) {
-		return fmt.Errorf("%s failure output verification failed: expected output %q not found\nCommand output:\n%s", tc.actionName, expectedOutput, commandOutput)
+	if expectedOutput != "" {
+		refreshed, ok := commandDetailsContainWithRetry(commandId, instanceIds[0], expectedOutput, commandOutput)
+		if !ok {
+			return fmt.Errorf("%s failure output verification failed: expected output %q not found\nCommand output:\n%s", tc.actionName, expectedOutput, refreshed)
+		}
 	}
 
 	log.Printf("%s action failed as expected", tc.actionName)
@@ -188,6 +225,82 @@ func verifyEnvConfigContent(expected map[string]string) error {
 }
 
 // commandOutputContains reports whether any command plugin's output contains expected.
+// SSM makes a command invocation's terminal Status visible before it populates
+// CommandPlugins[].Output, so an assertion made on the result WaitForCommandCompletion
+// returned can see Status=Success with an empty Output and wrongly conclude the expected
+// text is absent. The helpers below re-read a bounded number of times, but ONLY while the
+// output is still unpopulated: once any plugin has emitted output, a missing expected
+// string is a real failure and is reported immediately. That keeps the retry from masking
+// a genuinely wrong output, and keeps genuine failures fast.
+const (
+	outputPollAttempts = 6
+	outputPollInterval = 5 * time.Second
+)
+
+func outputPollBackoff() time.Duration {
+	return outputPollInterval + time.Duration(rand.Int63n(int64(time.Second)))
+}
+
+// commandOutputPopulated reports whether any plugin has emitted non-empty output yet.
+func commandOutputPopulated(result *ssm.ListCommandInvocationsOutput) bool {
+	if len(result.CommandInvocations) == 0 {
+		return false
+	}
+	for _, plugin := range result.CommandInvocations[0].CommandPlugins {
+		if plugin.Output != nil && strings.TrimSpace(*plugin.Output) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// commandOutputContainsWithRetry checks the already-fetched result first, then re-reads
+// while the output is unpopulated. It returns the rendering of whatever it last inspected
+// so the caller reports the same snapshot the decision was made on.
+func commandOutputContainsWithRetry(result *ssm.ListCommandInvocationsOutput, commandId, instanceId, expected string) (bool, string) {
+	if commandOutputContains(result, expected) {
+		return true, ""
+	}
+	if commandOutputPopulated(result) {
+		return false, awsservice.GetCommandInvocationDetails(commandId, instanceId)
+	}
+	for attempt := 1; attempt <= outputPollAttempts; attempt++ {
+		time.Sleep(outputPollBackoff())
+		refreshed, err := awsservice.GetCommandInvocationResult(commandId, instanceId)
+		if err != nil {
+			log.Printf("Re-reading command %s output failed (attempt %d/%d): %v", commandId, attempt, outputPollAttempts, err)
+			continue
+		}
+		if commandOutputContains(refreshed, expected) {
+			log.Printf("Expected output for command %s appeared on re-read attempt %d/%d", commandId, attempt, outputPollAttempts)
+			return true, ""
+		}
+		if commandOutputPopulated(refreshed) {
+			return false, awsservice.GetCommandInvocationDetails(commandId, instanceId)
+		}
+	}
+	return false, fmt.Sprintf("output never populated after %d re-reads over %s\n%s",
+		outputPollAttempts, time.Duration(outputPollAttempts)*outputPollInterval,
+		awsservice.GetCommandInvocationDetails(commandId, instanceId))
+}
+
+// commandDetailsContainWithRetry is the string-rendered equivalent for failure paths.
+// It returns the most recent rendering so the caller can report what was actually seen.
+func commandDetailsContainWithRetry(commandId, instanceId, expected, details string) (string, bool) {
+	if strings.Contains(details, expected) {
+		return details, true
+	}
+	for attempt := 1; attempt <= outputPollAttempts; attempt++ {
+		time.Sleep(outputPollBackoff())
+		details = awsservice.GetCommandInvocationDetails(commandId, instanceId)
+		if strings.Contains(details, expected) {
+			log.Printf("Expected failure output for command %s appeared on re-read attempt %d/%d", commandId, attempt, outputPollAttempts)
+			return details, true
+		}
+	}
+	return details, false
+}
+
 func commandOutputContains(result *ssm.ListCommandInvocationsOutput, expected string) bool {
 	if len(result.CommandInvocations) == 0 {
 		return false

--- a/util/awsservice/imds.go
+++ b/util/awsservice/imds.go
@@ -5,8 +5,16 @@ package awsservice
 
 import (
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+)
+
+const (
+	// imdsMaxAttempts bounds retries of the instance identity document lookup.
+	imdsMaxAttempts = 5
+	// imdsRetryInterval is the pause between attempts.
+	imdsRetryInterval = 2 * time.Second
 )
 
 var identityDoc *imds.GetInstanceIdentityDocumentOutput
@@ -30,10 +38,20 @@ func GetImdsMetadata() *imds.GetInstanceIdentityDocumentOutput {
 	}
 	var err error
 
+	// Retry before giving up. A single slow IMDS response used to abort the whole
+	// job via log.Fatalf before any assertion ran, because callers reach this from
+	// the middle of a test rather than from setup.
 	// TODO: this only works for EC2 based testing
-	identityDoc, err = ImdsClient.GetInstanceIdentityDocument(ctx, &imds.GetInstanceIdentityDocumentInput{})
-	if err != nil {
-		log.Fatalf("Error occurred while retrieving imds identityDoc: %v", err)
+	for attempt := 1; attempt <= imdsMaxAttempts; attempt++ {
+		identityDoc, err = ImdsClient.GetInstanceIdentityDocument(ctx, &imds.GetInstanceIdentityDocumentInput{})
+		if err == nil {
+			return identityDoc
+		}
+		log.Printf("Attempt %d/%d: could not retrieve imds identityDoc: %v", attempt, imdsMaxAttempts, err)
+		if attempt < imdsMaxAttempts {
+			time.Sleep(imdsRetryInterval)
+		}
 	}
-	return identityDoc
+	log.Fatalf("Error occurred while retrieving imds identityDoc after %d attempts: %v", imdsMaxAttempts, err)
+	return nil
 }

--- a/util/awsservice/ssm.go
+++ b/util/awsservice/ssm.go
@@ -16,6 +16,10 @@ import (
 	"github.com/aws/smithy-go"
 )
 
+// throttleRetryAttempts bounds how many times a single invocation read is retried
+// when throttled.
+const throttleRetryAttempts = 5
+
 // isThrottlingError reports whether err is a rate-limit response rather than a
 // real failure. Throttling is retryable at the call site; the SDK's own retryer
 // gives up after 3 attempts, which is not enough when the full test matrix polls
@@ -42,14 +46,53 @@ func CreateSSMDocument(name string, content string, documentType types.DocumentT
 	return err
 }
 
+// commandDeliveryTimeout bounds how long SSM itself will keep trying to hand a command
+// to the agent. Without it SendCommand defaults to 3600s, so an undeliverable command sits
+// in Pending/Delayed far longer than any test waits and the client-side deadline fires
+// first — reporting "did not complete" and hiding SSM's own verdict. At 90s SSM flips the
+// invocation to TimedOut/DeliveryTimedOut before WaitForCommandCompletion's 2m default,
+// so the failure names the real cause. Healthy commands complete in ~11s.
+const commandDeliveryTimeout int32 = 90
+
 func RunSSMDocument(name string, instanceIds []string, parameters map[string][]string) (*ssm.SendCommandOutput, error) {
 	out, err := SsmClient.SendCommand(ctx, &ssm.SendCommandInput{
-		DocumentName: aws.String(name),
-		InstanceIds:  instanceIds,
-		Parameters:   parameters,
+		DocumentName:   aws.String(name),
+		InstanceIds:    instanceIds,
+		Parameters:     parameters,
+		TimeoutSeconds: aws.Int32(commandDeliveryTimeout),
 	})
 
 	return out, err
+}
+
+// RunSSMDocumentAwaitDelivery sends a document and waits for it to complete, resending once
+// if SSM never managed to deliver the first attempt. A Pending/Delayed invocation means the
+// command never reached the agent ("the system attempted to send the command to the managed
+// node but wasn't successful"), which is a transport failure rather than a test failure and
+// is worth one retry. Only one resend, and only for undelivered commands, so a genuinely
+// failing command still fails on the first attempt.
+func RunSSMDocumentAwaitDelivery(name string, instanceIds []string, parameters map[string][]string) (*ssm.SendCommandOutput, *ssm.ListCommandInvocationsOutput, error) {
+	var lastErr error
+	for attempt := 1; attempt <= 2; attempt++ {
+		out, err := RunSSMDocument(name, instanceIds, parameters)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		result, err := WaitForCommandCompletion(*out.Command.CommandId, instanceIds[0])
+		if err == nil {
+			return out, result, nil
+		}
+		lastErr = err
+
+		var undelivered *CommandUndeliveredError
+		if !errors.As(err, &undelivered) || attempt == 2 {
+			return out, nil, err
+		}
+		log.Printf("Command %s was never delivered to %s (%s); resending once",
+			*out.Command.CommandId, instanceIds[0], undelivered.Details)
+	}
+	return nil, nil, lastErr
 }
 
 // WaitForSSMReady waits for instances to be registered and online with SSM.
@@ -78,12 +121,23 @@ func WaitForSSMReady(instanceIds []string, timeout time.Duration) error {
 				break
 			}
 
-			// Check if the instance is online
+			// Check if the instance is online. Note PingStatus==Online only means the
+			// agent registered; it does not guarantee SSM can deliver a command to it.
 			info := result.InstanceInformationList[0]
 			if info.PingStatus != types.PingStatusOnline {
 				allReady = false
 				break
 			}
+			agentVersion := "unknown"
+			if info.AgentVersion != nil {
+				agentVersion = *info.AgentVersion
+			}
+			lastPing := "unknown"
+			if info.LastPingDateTime != nil {
+				lastPing = info.LastPingDateTime.Format(time.RFC3339)
+			}
+			log.Printf("SSM agent on %s: version %s, platform %s, last ping %s",
+				instanceId, agentVersion, info.PlatformType, lastPing)
 		}
 
 		if allReady {
@@ -118,6 +172,32 @@ func (e *CommandTerminalError) Error() string {
 	return fmt.Sprintf("command %s on instance %s reached terminal status %s%s", e.CommandId, e.InstanceId, e.Status, e.Details)
 }
 
+// isDeliveryFailure reports whether a StatusDetails value describes SSM failing to hand the
+// command to the agent, rather than the command running and failing.
+func isDeliveryFailure(details string) bool {
+	switch details {
+	case "DeliveryTimedOut", "Undeliverable", "Terminated":
+		return true
+	}
+	return false
+}
+
+// CommandUndeliveredError is returned when the deadline expires while the invocation is
+// still Pending or Delayed, i.e. SSM never handed the command to the agent. This is a
+// transport failure, distinct from a command that ran and failed, so callers can retry it.
+type CommandUndeliveredError struct {
+	CommandId  string
+	InstanceId string
+	Status     types.CommandInvocationStatus
+	Details    string
+	Waited     time.Duration
+}
+
+func (e *CommandUndeliveredError) Error() string {
+	return fmt.Sprintf("command %s was never delivered to instance %s within %s (status %s, details %q) - SSM could not hand the command to the agent",
+		e.CommandId, e.InstanceId, e.Waited, e.Status, e.Details)
+}
+
 // WaitForCommandCompletion polls an SSM command invocation until it reaches a terminal
 // state. It returns immediately on Success, and returns an error immediately on the terminal
 // failure states (Failed, Cancelled, TimedOut) surfacing StatusDetails. The optional timeout
@@ -129,6 +209,8 @@ func WaitForCommandCompletion(commandId, instanceId string, timeout ...time.Dura
 		wait = timeout[0]
 	}
 	deadline := time.Now().Add(wait)
+	var lastStatus, loggedStatus types.CommandInvocationStatus
+	var lastDetails, loggedDetails string
 	for {
 		result, err := SsmClient.ListCommandInvocations(ctx, &ssm.ListCommandInvocationsInput{
 			CommandId:  aws.String(commandId),
@@ -146,7 +228,7 @@ func WaitForCommandCompletion(commandId, instanceId string, timeout ...time.Dura
 				if time.Now().After(deadline) {
 					return nil, fmt.Errorf("command %s on instance %s: still throttled at deadline %s: %w", commandId, instanceId, wait, err)
 				}
-				time.Sleep(5*time.Second + time.Duration(rand.Int63n(int64(time.Second))))
+				time.Sleep(pollBackoff())
 				continue
 			}
 			return nil, err
@@ -154,12 +236,27 @@ func WaitForCommandCompletion(commandId, instanceId string, timeout ...time.Dura
 
 		if len(result.CommandInvocations) > 0 {
 			invocation := result.CommandInvocations[0]
+			lastStatus = invocation.Status
+			lastDetails = ""
+			if invocation.StatusDetails != nil {
+				lastDetails = *invocation.StatusDetails
+			}
+			if lastStatus != loggedStatus || lastDetails != loggedDetails {
+				log.Printf("Command %s on instance %s: status %s (%s)", commandId, instanceId, lastStatus, lastDetails)
+				loggedStatus, loggedDetails = lastStatus, lastDetails
+			}
 			switch invocation.Status {
 			case types.CommandInvocationStatusSuccess:
 				return result, nil
 			case types.CommandInvocationStatusFailed,
 				types.CommandInvocationStatusCancelled,
 				types.CommandInvocationStatusTimedOut:
+				if invocation.Status == types.CommandInvocationStatusTimedOut && isDeliveryFailure(lastDetails) {
+					return nil, &CommandUndeliveredError{
+						CommandId: commandId, InstanceId: instanceId,
+						Status: invocation.Status, Details: lastDetails, Waited: time.Since(deadline.Add(-wait)),
+					}
+				}
 				details := ""
 				if invocation.StatusDetails != nil {
 					details = ": " + *invocation.StatusDetails
@@ -169,9 +266,15 @@ func WaitForCommandCompletion(commandId, instanceId string, timeout ...time.Dura
 		}
 
 		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("command %s on instance %s did not complete within %s", commandId, instanceId, wait)
+			if lastStatus == types.CommandInvocationStatusPending || lastStatus == types.CommandInvocationStatusDelayed {
+				return nil, &CommandUndeliveredError{
+					CommandId: commandId, InstanceId: instanceId,
+					Status: lastStatus, Details: lastDetails, Waited: wait,
+				}
+			}
+			return nil, fmt.Errorf("command %s on instance %s did not complete within %s (last status %s, details %q)", commandId, instanceId, wait, lastStatus, lastDetails)
 		}
-		time.Sleep(5*time.Second + time.Duration(rand.Int63n(int64(time.Second))))
+		time.Sleep(pollBackoff())
 	}
 }
 
@@ -211,12 +314,49 @@ func putParameter(name, value string, paramType types.ParameterType) error {
 }
 
 // GetCommandInvocationDetails retrieves detailed command output for debugging
+// pollBackoff is the shared inter-poll pause. The jitter keeps concurrent matrix jobs
+// from synchronising into a herd against the same rate limit.
+func pollBackoff() time.Duration {
+	return 5*time.Second + time.Duration(rand.Int63n(int64(time.Second)))
+}
+
+// listCommandInvocations re-reads an invocation, tolerating throttling. Every read of an
+// invocation has to do this: the SSM client uses the SDK default of 3 attempts with ~1.5s
+// of total backoff, which is not enough when the whole test matrix polls concurrently.
+// A non-throttling error is returned immediately.
+func listCommandInvocations(commandId, instanceId string, attempts int) (*ssm.ListCommandInvocationsOutput, error) {
+	var err error
+	for i := 1; i <= attempts; i++ {
+		var out *ssm.ListCommandInvocationsOutput
+		out, err = SsmClient.ListCommandInvocations(ctx, &ssm.ListCommandInvocationsInput{
+			CommandId:  aws.String(commandId),
+			InstanceId: aws.String(instanceId),
+			Details:    true,
+		})
+		if err == nil {
+			return out, nil
+		}
+		if !isThrottlingError(err) {
+			return nil, err
+		}
+		log.Printf("ListCommandInvocations throttled reading command %s (attempt %d/%d); retrying", commandId, i, attempts)
+		if i < attempts {
+			time.Sleep(pollBackoff())
+		}
+	}
+	return nil, err
+}
+
+// GetCommandInvocationResult re-reads a command invocation. SSM makes an invocation's
+// terminal Status visible before it populates CommandPlugins[].Output, so a caller that
+// needs the output has to re-read after WaitForCommandCompletion returns.
+func GetCommandInvocationResult(commandId, instanceId string) (*ssm.ListCommandInvocationsOutput, error) {
+	return listCommandInvocations(commandId, instanceId, throttleRetryAttempts)
+}
+
+// GetCommandInvocationDetails renders a command invocation for diagnostics.
 func GetCommandInvocationDetails(commandId, instanceId string) string {
-	result, err := SsmClient.ListCommandInvocations(ctx, &ssm.ListCommandInvocationsInput{
-		CommandId:  aws.String(commandId),
-		InstanceId: aws.String(instanceId),
-		Details:    true,
-	})
+	result, err := listCommandInvocations(commandId, instanceId, throttleRetryAttempts)
 	if err != nil {
 		return "Failed to retrieve command output: " + err.Error()
 	}

--- a/util/awsservice/ssm.go
+++ b/util/awsservice/ssm.go
@@ -4,14 +4,33 @@
 package awsservice
 
 import (
+	"errors"
 	"fmt"
+	"log"
 	"math/rand"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/smithy-go"
 )
+
+// isThrottlingError reports whether err is a rate-limit response rather than a
+// real failure. Throttling is retryable at the call site; the SDK's own retryer
+// gives up after 3 attempts, which is not enough when the full test matrix polls
+// the same API concurrently.
+func isThrottlingError(err error) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "ThrottlingException", "Throttling", "RequestLimitExceeded", "TooManyUpdates":
+		return true
+	}
+	return false
+}
 
 func CreateSSMDocument(name string, content string, documentType types.DocumentType) error {
 	_, err := SsmClient.CreateDocument(ctx, &ssm.CreateDocumentInput{
@@ -117,6 +136,19 @@ func WaitForCommandCompletion(commandId, instanceId string, timeout ...time.Dura
 			Details:    true, // This gets the CommandPlugins details
 		})
 		if err != nil {
+			// A throttled poll says nothing about the command itself, which is very
+			// likely still running. The SSM client uses the SDK default of 3 attempts
+			// with ~1.5s of total backoff, which is not enough when the whole test
+			// matrix polls this API concurrently. Keep polling until the deadline
+			// instead of failing the test on a transient rate limit.
+			if isThrottlingError(err) {
+				log.Printf("ListCommandInvocations throttled for command %s on instance %s; retrying", commandId, instanceId)
+				if time.Now().After(deadline) {
+					return nil, fmt.Errorf("command %s on instance %s: still throttled at deadline %s: %w", commandId, instanceId, wait, err)
+				}
+				time.Sleep(5*time.Second + time.Duration(rand.Int63n(int64(time.Second))))
+				continue
+			}
 			return nil, err
 		}
 

--- a/validator/validators/stress/stress_validator.go
+++ b/validator/validators/stress/stress_validator.go
@@ -6,6 +6,7 @@ package stress
 import (
 	"fmt"
 	"log"
+	"math"
 	"strings"
 	"time"
 
@@ -401,6 +402,13 @@ func (s *StressValidator) CheckData(startTime, endTime time.Time) error {
 	return multiErr
 }
 
+// isDiscreteCountMetric reports whether a metric's values are whole numbers, so that its
+// upper bound must be rounded up rather than compared as a fraction. Covers both the Linux
+// ("procstat_num_fds") and Windows ("procstat num_fds") spellings.
+func isDiscreteCountMetric(metricName string) bool {
+	return strings.HasSuffix(metricName, "num_fds")
+}
+
 func (s *StressValidator) ValidateStressMetric(metricName, metricNamespace string, metricDimensions []types.Dimension, metricSampleCount int, startTime, endTime time.Time) error {
 	var (
 		dataRate       = fmt.Sprint(s.vConfig.GetDataRate())
@@ -434,6 +442,15 @@ func (s *StressValidator) ValidateStressMetric(metricName, metricNamespace strin
 	// Validate if the corresponding metrics are within the acceptable range [acceptable value +- 30%]
 	metricValue := metrics.MetricDataResults[0].Values[0]
 	upperBoundValue := metricPluginBoundValue[dataRate][receiver][metricName] * (1 + metricErrorBound)
+	// File-descriptor counts are whole numbers, so a fractional ceiling is effectively
+	// floored and silently narrows the intended tolerance: a bound of 12 becomes 15.6,
+	// which rejects 16 while accepting 15 - a real tolerance of +25%, not the +30% the
+	// error bound specifies. Worse, no attainable value sits between 15.6 and 16, so a
+	// process holding 16 descriptors can never pass however many times it is retried.
+	// Round bounds for discrete-count metrics up to the next whole number.
+	if isDiscreteCountMetric(metricName) {
+		upperBoundValue = math.Ceil(upperBoundValue)
+	}
 	log.Printf("Metric %s within the namespace %s has value of %f and the upper bound is %f \n", metricName, metricNamespace, metricValue, upperBoundValue)
 
 	if metricValue < 0 || metricValue > upperBoundValue {


### PR DESCRIPTION
# Description of the issue

Two unrelated intermittent failures in `metric_value_benchmark` on EC2 Linux.

**1. Prometheus sub-test.** All five measured metrics fail at once, never a subset:

```
No values found prometheus_test_counter / _gauge / _summary / _summary_count / _summary_sum
--- FAIL: TestMetricValueBenchmarkSuite/TestAllInSuite
```

Not OS-specific — it lands on a different host each run, and any given OS both
passes and fails across attempts. The runner never overrode
`GetAgentRunDuration`, so it inherited the 30s default; at a 5s scrape interval
and 10s stat period that yields about one datapoint per metric, and validation
then issued a single un-retried CloudWatch query immediately after the agent
stopped. Any delay in CloudWatch surfacing the extracted metrics emptied the
result set.

Two things also made it undiagnosable: the error from `MetricValueFetcher.Fetch`
was discarded and `TestResult.Reason` never set, so a throttling or credential
failure looked identical to "no datapoints"; and the scrape target ran as
`python3 -m http.server 8101 --directory /tmp &> /dev/null &`, which discards
startup errors and exits 0 regardless. `--directory` also needs Python 3.7+,
unavailable on this matrix's EL8 hosts.

**2. Go toolchain changes mid-run.** On the ITAR al2023 host, the build fails on
the standard library:

```
compile: version "go1.26.7-X:nodwarf5" does not match go tool version "go1.25.12 X:nodwarf5"
FAIL github.com/aws/amazon-cloudwatch-agent-test/test/sanity [build failed]
```

There is one Go install (`/usr/bin/go`, `GOROOT=/usr/lib/golang`) and it was
self-consistent when the tests started — the golang packages are upgraded while
the build is running, preceded by a root-issued `shutdown -r +1`. This fails
every ITAR test directory, since `go test ./test/sanity` runs unconditionally
before the matrix test.

# Description of changes

**Prometheus**
- Override `GetAgentRunDuration` to 2 minutes, giving ~12 datapoints per metric
  instead of one. Primary fix; matches `jmx_kafka`.
- Wrap validation in `metric.RetryValidation` at a 30s interval rather than the
  shared 60s, which was sized for the EKS suite's ~195 dimension-set pairs.
- Replace the Python server with `common.StartPrometheusFakeServer`. `net.Listen`
  fails synchronously and binds before returning, so port conflicts are real
  errors and `--directory` is gone. Net code reduction.
- Populate `TestResult.Reason` on every failure path, including the `Fetch` error.
- On exhausted retries, log whether the `prometheus_test` EMF log group exists,
  the scrape target status, sockets on 8101, and the agent log via `journalctl`
  (the config sets `"logfile": ""`, so there is no log file).

**Go toolchain**
- Version-lock `golang`, `golang-bin` and `golang-src` at setup, so the toolchain
  cannot change for the job's lifetime. The version itself does not matter, only
  that it stays fixed.
- Echo the toolchain in use and, on a driver/compiler mismatch, `distro-sync` the
  three packages. This covers an instance that boots already inconsistent.
- Log the golang install timestamps, `dnf releasever`, and any dnf/yum/patch
  systemd timers.

All RPM-specific commands degrade to a warning, since this provisioner is shared
with Ubuntu, Debian and SLES.

# License

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.

# Tests

`gofmt` and `go vet` clean, package compiles, `go test ./test/metric/` passes.

Dispatched `./test/metric_value_benchmark` across all EC2 Linux OS/arch
combinations: **38 of 38 jobs passed**, including every host previously observed
failing.

Focused test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/33619196395/job/100212803053
Full run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/33650778392
