### PR TITLE
fix cloudwatchlogs flaky tests

### DIFF
--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -615,6 +615,25 @@ var partitionTests = map[string]partition{
 	},
 }
 
+// filterByTestDir returns a copy of configMap keeping only testConfigs whose testDir
+// contains substr. Every test type key is preserved (with a possibly empty slice) so that
+// main still writes a valid — if empty — matrix file for each, avoiding missing-file
+// failures downstream. TEMPORARY(cloudwatchlogs-flaky): scopes CI to a single suite while
+// iterating; remove with its call site in main().
+func filterByTestDir(configMap map[string][]testConfig, substr string) map[string][]testConfig {
+	filtered := make(map[string][]testConfig, len(configMap))
+	for testType, testConfigs := range configMap {
+		kept := make([]testConfig, 0, len(testConfigs))
+		for _, tc := range testConfigs {
+			if strings.Contains(tc.testDir, substr) {
+				kept = append(kept, tc)
+			}
+		}
+		filtered[testType] = kept
+	}
+	return filtered
+}
+
 func main() {
 	useE2E := flag.Bool("e2e", false, "Use e2e test matrix generation")
 	flag.Parse()
@@ -623,6 +642,12 @@ func main() {
 	if *useE2E {
 		configMap = testTypeToTestConfigE2E
 	}
+
+	// TEMPORARY(cloudwatchlogs-flaky): scope every generated matrix to the
+	// cloudwatchlogs suite so CI runs only those tests while the flaky-test fix
+	// is validated. Delete this line (and filterByTestDir below) to restore the
+	// full matrix before merging.
+	configMap = filterByTestDir(configMap, "cloudwatchlogs")
 
 	for testType, testConfigs := range configMap {
 		for _, partition := range partitionTests {

--- a/generator/test_case_generator.go
+++ b/generator/test_case_generator.go
@@ -615,25 +615,6 @@ var partitionTests = map[string]partition{
 	},
 }
 
-// filterByTestDir returns a copy of configMap keeping only testConfigs whose testDir
-// contains substr. Every test type key is preserved (with a possibly empty slice) so that
-// main still writes a valid — if empty — matrix file for each, avoiding missing-file
-// failures downstream. TEMPORARY(cloudwatchlogs-flaky): scopes CI to a single suite while
-// iterating; remove with its call site in main().
-func filterByTestDir(configMap map[string][]testConfig, substr string) map[string][]testConfig {
-	filtered := make(map[string][]testConfig, len(configMap))
-	for testType, testConfigs := range configMap {
-		kept := make([]testConfig, 0, len(testConfigs))
-		for _, tc := range testConfigs {
-			if strings.Contains(tc.testDir, substr) {
-				kept = append(kept, tc)
-			}
-		}
-		filtered[testType] = kept
-	}
-	return filtered
-}
-
 func main() {
 	useE2E := flag.Bool("e2e", false, "Use e2e test matrix generation")
 	flag.Parse()
@@ -642,12 +623,6 @@ func main() {
 	if *useE2E {
 		configMap = testTypeToTestConfigE2E
 	}
-
-	// TEMPORARY(cloudwatchlogs-flaky): scope every generated matrix to the
-	// cloudwatchlogs suite so CI runs only those tests while the flaky-test fix
-	// is validated. Delete this line (and filterByTestDir below) to restore the
-	// full matrix before merging.
-	configMap = filterByTestDir(configMap, "cloudwatchlogs")
 
 	for testType, testConfigs := range configMap {
 		for _, partition := range partitionTests {

--- a/test/cloudwatchlogs/publish_logs_test.go
+++ b/test/cloudwatchlogs/publish_logs_test.go
@@ -29,6 +29,8 @@ const (
 	logLineId2                    = "bar"
 	logFilePath                   = "/tmp/cwagent_log_test.log" // TODO: not sure how well this will work on Windows
 	sleepForFlush                 = 20 * time.Second            // default flush interval is 5 seconds
+	logGroupExistsAttempts        = 6
+	logGroupExistsInterval        = 15 * time.Second
 	configPathAutoRemoval         = "resources/config_auto_removal.json"
 	standardLogGroupClass         = "STANDARD"
 	infrequentAccessLogGroupClass = "INFREQUENT_ACCESS"
@@ -287,7 +289,7 @@ func TestLogGroupClass(t *testing.T) {
 			}
 			t.Logf("Agent logs %s", string(agentLog))
 
-			assert.True(t, awsservice.IsLogGroupExists(logGroupName, param.logGroupClass))
+			assert.True(t, awsservice.IsLogGroupExistsWithRetry(logGroupName, logGroupExistsAttempts, logGroupExistsInterval, param.logGroupClass))
 		})
 	}
 }

--- a/test/cloudwatchlogs/publish_logs_test.go
+++ b/test/cloudwatchlogs/publish_logs_test.go
@@ -24,11 +24,13 @@ import (
 )
 
 const (
-	configOutputPath              = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
-	logLineId1                    = "foo"
-	logLineId2                    = "bar"
-	logFilePath                   = "/tmp/cwagent_log_test.log" // TODO: not sure how well this will work on Windows
-	sleepForFlush                 = 20 * time.Second            // default flush interval is 5 seconds
+	configOutputPath = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
+	logLineId1       = "foo"
+	logLineId2       = "bar"
+	logFilePath      = "/tmp/cwagent_log_test.log" // TODO: not sure how well this will work on Windows
+	sleepForFlush    = 20 * time.Second            // default flush interval is 5 seconds
+	logValidationAttempts         = 6
+	logValidationInterval         = 15 * time.Second
 	configPathAutoRemoval         = "resources/config_auto_removal.json"
 	standardLogGroupClass         = "STANDARD"
 	infrequentAccessLogGroupClass = "INFREQUENT_ACCESS"
@@ -130,12 +132,15 @@ func TestWriteLogsToCloudWatch(t *testing.T) {
 			common.StopAgent()
 			end := time.Now()
 
-			// check CWL to ensure we got the expected number of logs in the log stream
-			err = awsservice.ValidateLogs(
+			// Retry to absorb CloudWatch Logs propagation lag: events can take a few
+			// seconds to become queryable after the agent flushes.
+			err = awsservice.ValidateLogsWithRetry(
 				instanceId,
 				instanceId,
 				&start,
 				&end,
+				logValidationAttempts,
+				logValidationInterval,
 				awsservice.AssertLogsCount(param.numExpectedLogs),
 				awsservice.AssertNoDuplicateLogs(),
 			)

--- a/util/awsservice/cloudwatchlogs.go
+++ b/util/awsservice/cloudwatchlogs.go
@@ -70,6 +70,30 @@ func ValidateLogs(logGroup, logStream string, since, until *time.Time, validator
 	return nil
 }
 
+// ValidateLogsWithRetry is ValidateLogs with bounded re-validation. GetLogsSince does not
+// retry a stream that exists but whose events CloudWatch has not surfaced yet, so a single
+// query right after the agent stops is racy; should re-query.
+func ValidateLogsWithRetry(logGroup, logStream string, since, until *time.Time, attempts int, interval time.Duration, validators ...LogEventsValidator) error {
+	if attempts < 1 {
+		attempts = 1
+	}
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		err = ValidateLogs(logGroup, logStream, since, until, validators...)
+		if err == nil {
+			if attempt > 1 {
+				log.Printf("Log validation for %s/%s passed on attempt %d/%d", logGroup, logStream, attempt, attempts)
+			}
+			return nil
+		}
+		if attempt < attempts {
+			log.Printf("Log validation for %s/%s failed on attempt %d/%d: %v; retrying in %s", logGroup, logStream, attempt, attempts, err, interval)
+			time.Sleep(interval)
+		}
+	}
+	return fmt.Errorf("log validation for %s/%s failed after %d attempts over %s: %w", logGroup, logStream, attempts, time.Duration(attempts-1)*interval, err)
+}
+
 // GetLogsSince makes GetLogEvents API calls, paginates through the results for the given time frame, and returns
 // the raw log strings
 func GetLogsSince(logGroup, logStream string, since, until *time.Time) ([]types.OutputLogEvent, error) {

--- a/util/awsservice/cloudwatchlogs.go
+++ b/util/awsservice/cloudwatchlogs.go
@@ -152,6 +152,18 @@ func IsLogGroupExists(logGroupName string, logGroupClassArg ...types.LogGroupCla
 	return len(describeLogGroupOutput.LogGroups) > 0
 }
 
+func IsLogGroupExistsWithRetry(logGroupName string, attempts int, interval time.Duration, logGroupClassArg ...types.LogGroupClass) bool {
+	for i := 0; i < attempts; i++ {
+		if IsLogGroupExists(logGroupName, logGroupClassArg...) {
+			return true
+		}
+		if i < attempts-1 {
+			time.Sleep(interval)
+		}
+	}
+	return false
+}
+
 // GetLogQueryStats for the log group between start/end (in epoch seconds) for the
 // query string.
 func GetLogQueryStats(logGroupName string, startTime, endTime int64, queryString string) (*types.QueryStatistics, error) {


### PR DESCRIPTION
### Description of the issue
Two CloudWatch Logs tests are intermittently flaky because each validates once, right after the agent acts, with no retry for CloudWatch's propagation lag. `TestWriteLogsToCloudWatch` fails its exact count assertion when `GetLogsSince` (which only retries on ResourceNotFoundException) queries a stream whose events haven't surfaced yet. `TestLogGroupClass` fails `IsLogGroupExists(...)` because DescribeLogGroups is eventually consistent and can return empty right after the group is created.

### Description of changes
- Add `awsservice.ValidateLogsWithRetry`, a bounded re-validation wrapper around `ValidateLogs` that absorbs CloudWatch propagation delay without faking a pass
- Add `IsLogGroupExistsWithRetry` (polls `IsLogGroupExists`, bounded by `attempts`/`interval`) and use it in `TestLogGroupClass` with 6 attempts at 15s.

#### License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### Tests generator [cloudwatchlogs-only matrix](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/33672339644/job/100458006891)
>[!Note]
> AL2023 failure is an environment issue and will be fixed on a different PR