### PR TITLE
test(cloudwatchlogs): retry IsLogGroupExists to de-flake TestLogGroupClass

### DIFF
--- a/test/cloudwatchlogs/publish_logs_test.go
+++ b/test/cloudwatchlogs/publish_logs_test.go
@@ -29,6 +29,8 @@ const (
 	logLineId2                    = "bar"
 	logFilePath                   = "/tmp/cwagent_log_test.log" // TODO: not sure how well this will work on Windows
 	sleepForFlush                 = 20 * time.Second            // default flush interval is 5 seconds
+	logGroupExistsAttempts        = 6
+	logGroupExistsInterval        = 15 * time.Second
 	configPathAutoRemoval         = "resources/config_auto_removal.json"
 	standardLogGroupClass         = "STANDARD"
 	infrequentAccessLogGroupClass = "INFREQUENT_ACCESS"
@@ -287,7 +289,7 @@ func TestLogGroupClass(t *testing.T) {
 			}
 			t.Logf("Agent logs %s", string(agentLog))
 
-			assert.True(t, awsservice.IsLogGroupExists(logGroupName, param.logGroupClass))
+			assert.True(t, awsservice.IsLogGroupExistsWithRetry(logGroupName, logGroupExistsAttempts, logGroupExistsInterval, param.logGroupClass))
 		})
 	}
 }

--- a/util/awsservice/cloudwatchlogs.go
+++ b/util/awsservice/cloudwatchlogs.go
@@ -152,6 +152,18 @@ func IsLogGroupExists(logGroupName string, logGroupClassArg ...types.LogGroupCla
 	return len(describeLogGroupOutput.LogGroups) > 0
 }
 
+func IsLogGroupExistsWithRetry(logGroupName string, attempts int, interval time.Duration, logGroupClassArg ...types.LogGroupClass) bool {
+	for i := 0; i < attempts; i++ {
+		if IsLogGroupExists(logGroupName, logGroupClassArg...) {
+			return true
+		}
+		if i < attempts-1 {
+			time.Sleep(interval)
+		}
+	}
+	return false
+}
+
 // GetLogQueryStats for the log group between start/end (in epoch seconds) for the
 // query string.
 func GetLogQueryStats(logGroupName string, startTime, endTime int64, queryString string) (*types.QueryStatistics, error) {


### PR DESCRIPTION
# Description of the issue
`TestLogGroupClass` intermittently fails at `assert.True(IsLogGroupExists(...))` even when the agent log confirms the group was created. `DescribeLogGroups` is eventually consistent, so a class-filtered lookup immediately after creation can return empty, and the check runs once with no retry.

# Description of changes
Add `IsLogGroupExistsWithRetry` (polls `IsLogGroupExists`, bounded by `attempts`/`interval`) and use it in `TestLogGroupClass` with 6 attempts at 15s.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
`go build ./util/awsservice/...` and `go vet ./test/cloudwatchlogs/...` pass; gofmt clean.
