### PR TITLE
Add EKS Addon install path to OTelCI test

### DIFF
--- a/test/e2e/containerinsights/containerinsights_test.go
+++ b/test/e2e/containerinsights/containerinsights_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/aws/amazon-cloudwatch-agent-test/environment"
+	"github.com/aws/amazon-cloudwatch-agent-test/environment/eksinstallationtype"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/e2e"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/e2e/utils"
 	"github.com/aws/amazon-cloudwatch-agent-test/test/otel_collect/otlpvalidation"
@@ -153,6 +154,21 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	// EKS add-on installs the agent via Terraform before the per-run test.run.id
+	// exists, and its image patching only covers the node CR. The Helm path delivers
+	// the stamped node config and the build image through chart values, so mirror
+	// that here by patching the add-on-managed CRs directly.
+	if env.EKSInstallationType == eksinstallationtype.EKS_ADDON {
+		if err := applyNodeConfig(env); err != nil {
+			fmt.Printf("Failed to apply node config: %v\n", err)
+			os.Exit(1)
+		}
+		if err := patchClusterScraperImage(env); err != nil {
+			fmt.Printf("Failed to patch cluster-scraper image: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
 	// Clear pre-rendered otelConfig on the node CR so agent translates json config
 	if err := clearOtelConfig(env, nodeCRName); err != nil {
 		fmt.Printf("Failed to clear node otelConfig: %v\n", err)
@@ -191,6 +207,72 @@ func resolveClusterName(env *environment.MetaData) string {
 		return env.EKSClusterName
 	}
 	return os.Getenv("CLUSTER_NAME")
+}
+
+// applyNodeConfig patches the node cloudwatch-agent CR with the (test.run.id-stamped)
+// node config. On the EKS add-on path the add-on is installed by Terraform before the
+// run ID exists, so we patch the CR directly to mirror the Helm chart's agent.config
+// delivery. The add-on config file uses the configuration_values shape (agent.config),
+// which we unwrap down to the raw agent JSON that spec.config expects.
+func applyNodeConfig(env *environment.MetaData) error {
+	data, err := os.ReadFile(env.AgentConfig)
+	if err != nil {
+		return fmt.Errorf("reading node config %s: %w", env.AgentConfig, err)
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parsing node config: %w", err)
+	}
+	agentJSON := cfg
+	if agent, ok := cfg["agent"].(map[string]interface{}); ok {
+		if inner, ok := agent["config"].(map[string]interface{}); ok {
+			agentJSON = inner
+		}
+	}
+	agentConfigJSON, err := json.Marshal(agentJSON)
+	if err != nil {
+		return fmt.Errorf("marshaling node agent config: %w", err)
+	}
+	patch, err := json.Marshal(map[string]interface{}{
+		"spec": map[string]interface{}{"config": string(agentConfigJSON)},
+	})
+	if err != nil {
+		return fmt.Errorf("marshaling node CR patch: %w", err)
+	}
+
+	k8ctl := utils.NewK8CtlManager(env)
+	if err := k8ctl.UpdateKubeConfig(resolveClusterName(env)); err != nil {
+		return err
+	}
+	return k8ctl.PatchResource(
+		"amazoncloudwatchagent",
+		nodeCRName,
+		agentNamespace,
+		utils.PatchTypeMerge,
+		string(patch),
+	)
+}
+
+// patchClusterScraperImage sets the cluster-scraper CR image to the build under test.
+// The Helm chart wires this through agent.image values; the add-on image patching only
+// covers the node CR, so we patch the cluster-scraper here for parity.
+func patchClusterScraperImage(env *environment.MetaData) error {
+	image := fmt.Sprintf("%s/%s:%s",
+		env.CloudwatchAgentRepositoryURL,
+		env.CloudwatchAgentRepository,
+		env.CloudwatchAgentTag)
+
+	k8ctl := utils.NewK8CtlManager(env)
+	if err := k8ctl.UpdateKubeConfig(resolveClusterName(env)); err != nil {
+		return err
+	}
+	return k8ctl.PatchResource(
+		"amazoncloudwatchagent",
+		clusterScraperCRName,
+		agentNamespace,
+		utils.PatchTypeMerge,
+		fmt.Sprintf(`{"spec":{"image":"%s"}}`, image),
+	)
 }
 
 // applyClusterConfig patches the cluster-scraper CR with the role=cluster config
@@ -408,7 +490,7 @@ func testNodeLogs(t *testing.T) {
 			streams := awsservice.GetLogStreamNames(logGroup)
 			require.NotEmpty(t, streams, "no log streams in %s", logGroup)
 
-			// Validate the events in our time window actually carry this run's test.run.id 
+			// Validate the events in our time window actually carry this run's test.run.id
 			err := awsservice.ValidateLogs(logGroup, streams[0], &since, &until,
 				awsservice.AssertPerLog(awsservice.AssertLogContainsSubstring(testRunID)))
 			require.NoError(t, err, "validating logs in %s/%s carry %s", logGroup, streams[0], testRunID)

--- a/test/e2e/containerinsights/containerinsights_test.go
+++ b/test/e2e/containerinsights/containerinsights_test.go
@@ -209,6 +209,30 @@ func resolveClusterName(env *environment.MetaData) string {
 	return os.Getenv("CLUSTER_NAME")
 }
 
+// patchResourceWithRetry wraps K8CtlManager.PatchResource with a bounded retry so the
+// add-on path tolerates add-on-activation timing: the target CRs may not exist yet when
+// this first runs, and a single-shot patch would fail with "not found" and abort the suite.
+func patchResourceWithRetry(k8ctl *utils.K8CtlManager, resourceType, resourceName, namespace string, patchType utils.PatchType, patchData string) error {
+	const (
+		patchRetryTimeout  = 2 * time.Minute
+		patchRetryInterval = 5 * time.Second
+	)
+	deadline := time.Now().Add(patchRetryTimeout)
+	for attempt := 1; ; attempt++ {
+		err := k8ctl.PatchResource(resourceType, resourceName, namespace, patchType, patchData)
+		if err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("patching %s/%s failed after %s (%d attempts): %w",
+				resourceType, resourceName, patchRetryTimeout, attempt, err)
+		}
+		fmt.Printf("Patch %s/%s attempt %d failed, retrying in %s: %v\n",
+			resourceType, resourceName, attempt, patchRetryInterval, err)
+		time.Sleep(patchRetryInterval)
+	}
+}
+
 // applyNodeConfig patches the node cloudwatch-agent CR with the (test.run.id-stamped)
 // node config. On the EKS add-on path the add-on is installed by Terraform before the
 // run ID exists, so we patch the CR directly to mirror the Helm chart's agent.config
@@ -244,7 +268,8 @@ func applyNodeConfig(env *environment.MetaData) error {
 	if err := k8ctl.UpdateKubeConfig(resolveClusterName(env)); err != nil {
 		return err
 	}
-	return k8ctl.PatchResource(
+	return patchResourceWithRetry(
+		k8ctl,
 		"amazoncloudwatchagent",
 		nodeCRName,
 		agentNamespace,
@@ -262,16 +287,24 @@ func patchClusterScraperImage(env *environment.MetaData) error {
 		env.CloudwatchAgentRepository,
 		env.CloudwatchAgentTag)
 
+	patch, err := json.Marshal(map[string]interface{}{
+		"spec": map[string]interface{}{"image": image},
+	})
+	if err != nil {
+		return fmt.Errorf("marshaling cluster-scraper image patch: %w", err)
+	}
+
 	k8ctl := utils.NewK8CtlManager(env)
 	if err := k8ctl.UpdateKubeConfig(resolveClusterName(env)); err != nil {
 		return err
 	}
-	return k8ctl.PatchResource(
+	return patchResourceWithRetry(
+		k8ctl,
 		"amazoncloudwatchagent",
 		clusterScraperCRName,
 		agentNamespace,
 		utils.PatchTypeMerge,
-		fmt.Sprintf(`{"spec":{"image":"%s"}}`, image),
+		string(patch),
 	)
 }
 

--- a/test/e2e/containerinsights/resources/cwagent_configs_eks_addon/ci_node.json
+++ b/test/e2e/containerinsights/resources/cwagent_configs_eks_addon/ci_node.json
@@ -1,4 +1,7 @@
 {
+  "otelContainerInsights": {
+    "enabled": true
+  },
   "agent": {
     "config": {
       "opentelemetry": {

--- a/test/e2e/containerinsights/resources/keda_karpenter.yaml
+++ b/test/e2e/containerinsights/resources/keda_karpenter.yaml
@@ -53,7 +53,7 @@ spec:
             - |
               command -v python3 >/dev/null 2>&1 || dnf install -y python3 >/dev/null 2>&1
               exec python3 -c '
-              import http.server, socketserver
+              import http.server, socketserver, socket
               body = open("/etc/metrics/metrics", "rb").read()
               class H(http.server.BaseHTTPRequestHandler):
                   def do_GET(self):
@@ -64,7 +64,12 @@ spec:
                       self.wfile.write(body)
                   def log_message(self, *a):
                       pass
-              socketserver.TCPServer(("", 80), H).serve_forever()
+              class Server(socketserver.TCPServer):
+                  address_family = socket.AF_INET6
+                  def server_bind(self):
+                      self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+                      super().server_bind()
+              Server(("::", 80), H).serve_forever()
               '
           ports:
             - name: metrics
@@ -114,7 +119,7 @@ spec:
             - |
               command -v python3 >/dev/null 2>&1 || dnf install -y python3 >/dev/null 2>&1
               exec python3 -c '
-              import http.server, socketserver
+              import http.server, socketserver, socket
               body = open("/etc/metrics/metrics", "rb").read()
               class H(http.server.BaseHTTPRequestHandler):
                   def do_GET(self):
@@ -125,7 +130,12 @@ spec:
                       self.wfile.write(body)
                   def log_message(self, *a):
                       pass
-              socketserver.TCPServer(("", 80), H).serve_forever()
+              class Server(socketserver.TCPServer):
+                  address_family = socket.AF_INET6
+                  def server_bind(self):
+                      self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+                      super().server_bind()
+              Server(("::", 80), H).serve_forever()
               '
           ports:
             - name: http-metrics

--- a/test/e2e/containerinsights/resources/keda_karpenter.yaml
+++ b/test/e2e/containerinsights/resources/keda_karpenter.yaml
@@ -69,7 +69,11 @@ spec:
                   def server_bind(self):
                       self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
                       super().server_bind()
-              Server(("::", 80), H).serve_forever()
+              try:
+                  httpd = Server(("::", 80), H)
+              except OSError:
+                  httpd = socketserver.TCPServer(("", 80), H)
+              httpd.serve_forever()
               '
           ports:
             - name: metrics
@@ -135,7 +139,11 @@ spec:
                   def server_bind(self):
                       self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
                       super().server_bind()
-              Server(("::", 80), H).serve_forever()
+              try:
+                  httpd = Server(("::", 80), H)
+              except OSError:
+                  httpd = socketserver.TCPServer(("", 80), H)
+              httpd.serve_forever()
               '
           ports:
             - name: http-metrics


### PR DESCRIPTION
### Description of the issue
The OTel Container Insights EKS e2e test only covered the Helm install path, not the (now released) EKS add-on path. These test also needed testing with IPv6 which is included in this test.

### Description of changes
Add EKS Addon support to the Container Insights e2e test:
- `ci_node.json`: enable `otelContainerInsights` so the add-on creates the cluster-scraper CR.
- `containerinsights_test.go` (add-on-gated): patch the node CR config with the `test.run.id`-stamped config and set the cluster-scraper image to the build under test.

### License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### Tests
- Full OTELContainerInsights Add-on and IPv6 e2e runs: [OTELContainerInsightsTests](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/34507361916)

>[!Note]
> This PR should merge after we merge this [OCI Impementation](https://github.com/aws/amazon-cloudwatch-agent/pull/2271) agent main